### PR TITLE
Features/aeso

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,9 +42,11 @@ The RenewBench-Crawler repository is structured as follows:
 │   │   ├── loader.py             # Load and validate configs
 │   │   └── schema.py             # Pydantic config models and registry
 │   ├── energy/                 # Energy data crawlers
+│   │   ├── aeso/                 # AESO (Canada, Alberta)
 │   │   ├── eia/                  # EIA (US)
 │   │   ├── entsoe/               # ENTSO-e (EU)
 │   │   ├── epias/                # EPIAS (Turkey)
+│   │   ├── ieso/                 # IESO (Canada, Ontario)
 │   │   └── taipower/             # Taipower (Taiwan)
 │   └── weather/                # Weather data crawlers
 │       ├── era5/                 # ERA5 (Global)

--- a/configs/energy/aeso.yaml
+++ b/configs/energy/aeso.yaml
@@ -1,0 +1,4 @@
+paths:
+  dst_dir_raw: /lsdf/raw/energy/aeso/
+access:
+  api_key: "YOUR-SECRET-KEY---DON'T-COMMIT!!!"

--- a/docs/data_sources.md
+++ b/docs/data_sources.md
@@ -8,19 +8,20 @@ RenewBench-Crawler package.
 
 ### Overview
 
-| Region                   | Source   | Status             | Resolution               | Access            | Resources                                                                                                                                                                                                                                                                                                 |
-|--------------------------|----------|--------------------|--------------------------|-------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| **Europe**               | ENTSO-e  | downloader &check; | hourly/15 min; per plant | API token         | [TP](https://transparency.entsoe.eu/), [API guide](https://transparencyplatform.zendesk.com/hc/en-us/sections/12783116987028-Restful-API-integration-guide),<br> [API how-to](https://transparencyplatform.zendesk.com/hc/en-us/articles/12845911031188-How-to-get-security-token)                        |
-| **Turkey**               | EPIAS    | downloader &check; | hourly; per plant        | Login credentials | [TP](https://seffaflik.epias.com.tr/home), [Docs](https://seffaflik.epias.com.tr/electricity-service/technical/en/index.html),<br> [Registration form](https://kayit.epias.com.tr/epias-transparency-platform-registration-form)                                                                          |
-| **USA**                  | EIA      | downloader &check; | hourly; per company      | API token         | [API browser](https://www.eia.gov/opendata/browser/), [API docs](https://www.eia.gov/opendata/documentation.php),<br> [API registration form](https://www.eia.gov/opendata/register.php)                                                                                                                  |
-| **Taiwan**               | Taipower | downloader &check; | 10 min; per plant        | public            | [Website](https://www.taipower.com.tw/d006/loadGraph/loadGraph/genshx_e.html), [JSON](https://www.taipower.com.tw/d006/loadGraph/loadGraph/data/genary_eng.json),<br> [Example parser](https://github.com/electricitymaps/electricitymaps-contrib/blob/master/electricitymap/contrib/parsers/TAIPOWER.py) |
-| **Canada<br> (Alberta)** | IESO     | planned            |                          |                   |                                                                                                                                                                                                                                                                                                           |
-| **Canada<br> (Ontario)** | AESO     | planned            |                          |                   |                                                                                                                                                                                                                                                                                                           |
-| **Chile**                | CEN      | planned            |                          |                   |                                                                                                                                                                                                                                                                                                           |
-| **Brazil**               | ONS      | planned            |                          |                   |                                                                                                                                                                                                                                                                                                           |
-| **Uruguay**              | ADME     | planned            |                          |                   |                                                                                                                                                                                                                                                                                                           |
-| **Australia**            | AEMO     | planned            |                          |                   |                                                                                                                                                                                                                                                                                                           |
-| **New<br>Zealand**       | EAT      | planned            |                          |                   |                                                                                                                                                                                                                                                                                                           |
+| Region                   | Source   | Status             | Resolution               | Access            | Resources                                                                                                                                                                                                                                                                                                              |
+|--------------------------|----------|--------------------|--------------------------|-------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **Europe**               | ENTSO-e  | downloader &check; | hourly/15 min; per plant | API token         | [TP](https://transparency.entsoe.eu/), [API guide](https://transparencyplatform.zendesk.com/hc/en-us/sections/12783116987028-Restful-API-integration-guide),<br> [API how-to](https://transparencyplatform.zendesk.com/hc/en-us/articles/12845911031188-How-to-get-security-token)                                     |
+| **Turkey**               | EPIAS    | downloader &check; | hourly; per plant        | Login credentials | [TP](https://seffaflik.epias.com.tr/home), [Docs](https://seffaflik.epias.com.tr/electricity-service/technical/en/index.html),<br> [Registration form](https://kayit.epias.com.tr/epias-transparency-platform-registration-form)                                                                                       |
+| **USA**                  | EIA      | downloader &check; | hourly; per company      | API token         | [API browser](https://www.eia.gov/opendata/browser/), [API docs](https://www.eia.gov/opendata/documentation.php),<br> [API registration form](https://www.eia.gov/opendata/register.php)                                                                                                                               |
+| **Canada<br> (Alberta)** | AESO     | downloader &check; | hourly/5 min; per plant  | `box` API token   | [Website](https://www.aeso.ca/market/market-and-system-reporting/data-requests/historical-generation-data/), [Data hosting](https://aeso.app.box.com/s/qofgn9axnnw6uq3ip1goiq2ngb11txe5/folder/196731538687), <br> [API how-to](https://developer.box.com/guides/authentication/tokens/developer-tokens) (s. details!) |
+| **Canada<br> (Ontario)** | IESO     | downloader &check; | hourly; per plant        | public            | [Website](https://www.ieso.ca/power-data/data-directory)                                                                                                                                                                                                                                                               |
+| **Chile**                | CEN      | planned            |                          |                   |                                                                                                                                                                                                                                                                                                                        |
+| **Brazil**               | ONS      | planned            |                          |                   |                                                                                                                                                                                                                                                                                                                        |
+| **Uruguay**              | ADME     | planned            |                          |                   |                                                                                                                                                                                                                                                                                                                        |
+| **Australia**            | AEMO     | planned            |                          |                   |                                                                                                                                                                                                                                                                                                                        |
+| **New<br>Zealand**       | EAT      | planned            |                          |                   |                                                                                                                                                                                                                                                                                                                        |
+| **Japan**                | REI      | planned            | hourly; per region       |                   |                                                                                                                                                                                                                                                                                                                        |
+| **Taiwan**               | Taipower | downloader &check; | 10 min; per plant        | public            | [Website](https://www.taipower.com.tw/d006/loadGraph/loadGraph/genshx_e.html), [JSON](https://www.taipower.com.tw/d006/loadGraph/loadGraph/data/genary_eng.json),<br> [Example parser](https://github.com/electricitymaps/electricitymaps-contrib/blob/master/electricitymap/contrib/parsers/TAIPOWER.py)              |
 
 ### Data Source Details
 
@@ -33,12 +34,29 @@ RenewBench-Crawler package.
 - Requirements: personal API token ([how to get a token](https://transparencyplatform.zendesk.com/hc/en-us/articles/12845911031188-How-to-get-security-token))
 
 **Download & data structure**
-- Resolution: hourly / 15 min (stored as `Temporal_Resolution`), per plant and bidding zone
-- Raw output files: 1 CSV per day and bidding zone
-- Raw columns:
+- Spatial resolution: per generation unit (plant) in each bidding zone
+- Temporal resolution: hourly / 15‑min (stored as `Temporal_Resolution`)
+- Available data timespan: depends on bidding zone; typically mid‑2000s / 2010s to now
+- Files saved as **raw**: 1 `.csv` per day and bidding zone
+- Columns saved as **raw**:
 
-  `timestamp`, `Unit_Name`, `Unit_Code`, `PSR_Type`, `Capacity`, `Generation_MW`,
-  `Consumption_MW`, `Measurement_Unit`, `Temporal_Resolution`
+  `timestamp` – timestamp start in UTC-aware (`+00:00`)
+
+  `Unit_Name` – name of the generating unit
+
+  `Unit_Code` – unique identifier (mRID) of the generating unit
+
+  `PSR_Type` – PSR code of fuel category
+
+  `Capacity` – nominal capacity of the generating unit
+
+  `Generation_MW` – actual generation in MW
+
+  `Consumption_MW` – consumption in MW (if the unit is consuming, else `NaN`)
+
+  `Measurement_Unit` – physical unit of the reported quantities (usually `MAW`)
+
+  `Temporal_Resolution` – string describing the time step (e.g. `PT15M`, `PT60M`)
 
 </details>
 
@@ -51,14 +69,23 @@ RenewBench-Crawler package.
 - Requirements: personal username/password ([registration form](https://kayit.epias.com.tr/epias-transparency-platform-registration-form))
 
 **Download & data structure**
-- Resolution: hourly, per plant
-- Raw output files: 1 CSV per day
-- Raw columns (simplified):
+- Spatial resolution: per plant
+- Temporal resolution: hourly
+- Available data timespan: 2013-05 to now
+- Files saved as **raw**: 1 `.csv` per day
+- Columns saved as **raw**:
 
-  `date`, `hour`, `total`, `powerPlantName`,
+  `date` – timestamp start in UTC-aware (`+03:00`)
+
+  `hour` – hour
+
+  `total` – total generation of the power plant (MWh)
+
+  `powerPlantName` – name of the power plant
+
   `naturalGas`, `dammedHydro`, `lignite`, `river`, `importCoal`, `wind`, `sun`,
   `fueloil`, `geothermal`, `asphaltiteCoal`, `blackCoal`, `biomass`, `naphta`, `lng`,
-  `importExport`, `wasteheat`.
+  `importExport`, `wasteheat` - generation from different sources
 
 </details>
 
@@ -71,12 +98,108 @@ RenewBench-Crawler package.
 - Requirements: personal API token ([registration form](https://www.eia.gov/opendata/register.php))
 
 **Download & data structure**
-- Resolution: hourly, per company
-- Raw output files: 1 CSV per day
-- Raw columns:
+- Spatial resolution: per respondent (company)
+- Temporal resolution: hourly
+- Available data timespan: 2019-01 to now
+- Files saved as **raw**: 1 `.csv` per day
+- Columns saved as **raw**:
 
-  `period`, `respondent`, `respondent-name`, `fueltype`, `type-name`, `value`,
-  `value-units`
+  `period` - timestamp start in UTC
+
+  `respondent` - abbreviation for respondent (company) name
+
+  `respondent-name` - full respondent (company) name
+
+  `fueltype` - abbreviation for fuel categorization
+
+  `type-name` - full fuel name
+
+  `value` - net generation
+
+  `value-units` - unit of net generation
+
+</details>
+
+
+<details>
+<summary><b>AESO (Canada, Alberta)</b></summary>
+
+**Access**
+- Website: [AESO historical data](https://www.aeso.ca/market/market-and-system-reporting/data-requests/historical-generation-data/), [AESO
+  'box' data hosting/storage](https://aeso.app.box.com/s/qofgn9axnnw6uq3ip1goiq2ngb11txe5/folder/196731538687)
+- Requirements:
+  1. Create a free [box account](https://app.box.com/developers/console/).
+  2. In [the console](https://app.box.com/developers/console), create a new app with `App
+  Type` as `OAuth 2.0` (`App name` is irrelevant).
+  3. In the app's configuration
+     - Under `Application Scopes`: tick the box `Write all files and folders stored in
+     Box` and save.
+     - Under `Developer Token`: click the `Generate Developer Token` button or directly
+       copy the existing token. This is your API token!
+
+**Download & data structure**
+- Spatial resolution: per plant
+- Temporal resolution: hourly / 5 min
+- Available data timespan: 2015-01 to now / 2015-01 to 2023-02
+- Downloadable files: 1 `.zip` containing 1 `.csv` per month / 6-month periods
+- Files saved as **raw**: 1 `.csv` per month
+- Columns saved as **raw**:
+
+  `Date (MST)` - timestamp start in Mountain Standard Time
+
+  `Date (MPT)` - timestamp start in Mountain Prevailing Time (i.e. MST or MDT, as appropriate)
+
+  `Asset Short Name` - abbreviation for asset
+
+  `Asset Name` - asset name
+
+  `Asset Grouping` - the meter that behind-the-fence assets share, if appropriate.
+
+  `Volume` - volume reported via SCADA (similar to that reported on CSD page)
+
+  `Maximum Capability` - maximum capacity reported to the AESO
+
+  `System Capability` - capacity available to AESO via contracted volume, if any
+
+  `Fuel Type` - main fuel categorization
+
+  `Sub Fuel Type` - sub fuel categorization
+
+  `Planning Area` - AESO planning area the asset is located in
+
+  `Region` - AESO region the asset is located in
+
+</details>
+
+
+<details>
+<summary><b>IESO (Canada, Ontario)</b></summary>
+
+**Access**
+- Website: [IESO power data](https://www.ieso.ca/power-data/data-directory), [IESO supply overview](https://www.ieso.ca/Power-Data/Supply-Overview/Transmission-Connected-Generation)
+- Map: [Ontario's Electricity System](https://www.ieso.ca/localcontent/ontarioenergymap/index.html)
+- Requirements: public, no authentication needed
+
+**Download & data structure**
+- Spatial resolution: per plant
+- Temporal resolution: hourly
+- Available data timespan: 2010-01 to now
+- Downloadable files: 1 `.xlsx` per year (pre-April-2019), 1 `.csv` per month (post-April-2019)
+- Files saved as **raw**: 1 `.csv` per month
+- Columns saved as **raw**:
+
+  `Delivery Date` – date in local format (probably ET)
+
+  `Generator` – generator name
+
+  `Fuel Type` – fuel type (not given in `.xlsx` so `=NaN`; to be filled in during processing)
+
+  `Measurement` – type of measurement:
+  - `Output`: generation (MW)
+  - `Capability`: available capacity
+
+  `Hour 1`, `Hour 2`, …, `Hour 24` – ending hour intervals (i.e. `00:00 - 01:00` to `23:00 to
+  00:00`) and measurement type
 
 </details>
 
@@ -90,12 +213,31 @@ RenewBench-Crawler package.
 - Requirements: public, no authentication needed
 
 **Download & data structure**
-- Resolution: 10 min (live data)
-- Raw output files: 1 CSV per snapshot timestamp
-- Raw columns:
+- Spatial resolution: per plant
+- Temporal resolution: 10 min (live data)
+- Available data timespan: 2026-02 to now
+- Files saved as **raw**: 1 `.csv` per snapshot timestamp
+- Columns saved as **raw**:
 
-  `datetime`, `fueltype`, `fueltype_subcategory`, `name`, `capacity`, `output`,
-  `percentage`, `remark_xi`, `additional_3`
+  `datetime` – timestamp in UTC-aware fixed-offset ISO 8601 (`+08:00`)
+
+  `fueltype` – fuel type (e.g. `COAL`, `GAS`, `NUCLEAR`, `HYDRO`, `PV`)
+
+  `fueltype_subcategory` – fuel type sub‑category for renewables (i.e. purchases)
+
+  `name` – generating unit
+
+  `capacity` – installed nameplate capacity (nominal capacity of a plant or sum of capacities
+  of all plants in a unit)
+
+  `output` – net power generation (amount generated by a unit = total gross generation −
+  power consumption within the plant)
+
+  `percentage` – output relative to capacity (`output / capacity`) (%)
+
+  `remark_xi` – numbers referring to specific Taipower remarks wherever necessary
+
+  `additional_3` – additional remarks field
 
 </details>
 

--- a/docs/data_sources.md
+++ b/docs/data_sources.md
@@ -141,7 +141,7 @@ RenewBench-Crawler package.
 **Download & data structure**
 - Spatial resolution: per plant
 - Temporal resolution: hourly / 5 min
-- Available data timespan: 2015-01 to now / 2015-01 to 2023-02
+- Available data timespan hourly: 2015-01 to now; 5 min: 2015-01 to 2023-02
 - Downloadable files: 1 `.zip` containing 1 `.csv` per month / 6-month periods
 - Files saved as **raw**: 1 `.csv` per month
 - Columns saved as **raw**:

--- a/docs/data_sources.md
+++ b/docs/data_sources.md
@@ -35,8 +35,9 @@ RenewBench-Crawler package.
 
 **Download & data structure**
 - Spatial resolution: per generation unit (plant) in each bidding zone
-- Temporal resolution: hourly / 15‑min (stored as `Temporal_Resolution`)
-- Available data timespan: depends on bidding zone; typically mid‑2000s / 2010s to now
+- Temporal resolution: hourly / (sometimes) higher
+- Available data timespan: bidding zone dependant (typically mid‑2010s to now - see
+  [`ACTIVE_ZONES_METADATA` mapping](../rbc/energy/entsoe/mappings.py#L6))
 - Files saved as **raw**: 1 `.csv` per day and bidding zone
 - Columns saved as **raw**:
 
@@ -240,6 +241,24 @@ RenewBench-Crawler package.
   `additional_3` – additional remarks field
 
 </details>
+
+
+### Saving Structure
+
+The downloaded, raw energy data is saved into the following structure per data source
+`<source>`. Values in `()` are optional, i.e. only `entsoe` has a `<bidding_zone>`
+hierarchy level.
+
+```text
+raw/energy
+└── <source>
+    ├── status.pickle
+    ├── logs
+    │   └── <YYYY-MM-DD_HHMMSS>.log
+    └── <temporal_resolution (default: "1h")>
+        └── (<bidding_zone>)
+            └── <YYYY-MM(-DD)>.csv
+```
 
 ## Weather
 

--- a/docs/guide_adding_new_source.md
+++ b/docs/guide_adding_new_source.md
@@ -26,7 +26,7 @@ In general, your source will always need a config file and loading logic:
 
 > Example: [_entsoe.yaml_ file](../configs/energy/entsoe.yaml)
 
-2. **Config loader** ([rbc/config/schema.py](rbc/config/schema.py)):
+2. **Config loader** ([rbc/config/schema.py](../rbc/config/schema.py)):
 
     Amend the `rbc/config/schema.py` to
     - include a `class <Source>Config` with the attributes required by the
@@ -54,7 +54,7 @@ The following files will be required to set up the downloading logic for your cr
 
 > Example: [_entsoe_ folder](../rbc/energy/entsoe)
 
-2. **Script** ([scripts/\<type\>/\<source\>_...py](scripts)):
+2. **Script** ([scripts/\<type\>/\<source\>_...py](../scripts)):
 
     Create a script for each of your source's functionalities from step 3, i.e.
     - a `<type>/<source>_download.py` to run the `downloader.py`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ classifiers = [
     "Topic :: Scientific/Engineering",
 ]
 dependencies = [
+    "boxsdk",
     "cdsapi",
     "entsoe-apy",
     "eptr2",

--- a/rbc/config/schema.py
+++ b/rbc/config/schema.py
@@ -244,8 +244,8 @@ SCHEMA_REGISTRY: dict[str, Type[BaseModel]] = {
     "entsoe": EntsoeConfig,
     "epias": EpiasConfig,
     "ieso": IesoConfig,
-    "era5": Era5Config,
-    "icon_dream_global": IconDreamGlobalConfig,
-    "icon_dream_eu": IconDreamEuConfig,
     "barra2": Barra2Config,
+    "era5": Era5Config,
+    "icon_dream_eu": IconDreamEuConfig,
+    "icon_dream_global": IconDreamGlobalConfig,
 }

--- a/rbc/config/schema.py
+++ b/rbc/config/schema.py
@@ -114,6 +114,20 @@ class AccessValidation:
 # ----------------------------------
 # Per-source schemas - ENERGY
 # ----------------------------------
+class AesoConfig(PathValidation, AccessValidation, BaseModel):
+    """Configuration schema for the AESO energy data source.
+
+    Attributes:
+        source (Literal): Name of the data source.
+        paths (Paths): Paths pydantic model for paths.
+        access (AccessAPI): Access pydantic model for access settings.
+    """
+
+    source: Literal["aeso"] = "aeso"
+    paths: Paths
+    access: AccessAPI
+
+
 class EiaConfig(PathValidation, AccessValidation, BaseModel):
     """Configuration schema for the EIA energy data source.
 
@@ -213,6 +227,7 @@ class IconDreamEuConfig(BaseModel):
 # Schema registry
 # ----------------------------------
 SCHEMA_REGISTRY: dict[str, Type[BaseModel]] = {
+    "aeso": AesoConfig,
     "eia": EiaConfig,
     "entsoe": EntsoeConfig,
     "epias": EpiasConfig,

--- a/rbc/energy/aeso/__init__.py
+++ b/rbc/energy/aeso/__init__.py
@@ -1,0 +1,3 @@
+from rbc.energy.aeso.downloader import AesoDownloader
+
+__all__ = ["AesoDownloader"]

--- a/rbc/energy/aeso/downloader.py
+++ b/rbc/energy/aeso/downloader.py
@@ -18,7 +18,7 @@ from loguru import logger
 from rbc.energy.utils import (
     WORKERS,
     DataStructureError,
-    DownloadKey,
+    DownloadTask,
     EnergyDownloader,
     InvalidError,
     MissingDataError,
@@ -115,23 +115,19 @@ class AesoDownloader(EnergyDownloader):
     def download_data(self) -> None:
         """Parse data for all given years from AESO site and save to CSV."""
         all_months = self._get_month_list()
+        tasks = [
+            DownloadTask(date=d, temporal_resolution=t_res)
+            for t_res in self.temporal_resolutions
+            for d in all_months
+        ]
 
-        for t_res in self.temporal_resolutions:
-            checkpoint_path = self._build_checkpoint_path(
-                DownloadKey(temporal_resolution=t_res)
-            )
-            checkpoint = self._load_checkpoint(checkpoint_path)
+        logger.info(
+            f"Downloading tasks: {tasks[0].identifier} --- {tasks[-1].identifier}"
+        )
+        with ThreadPoolExecutor(max_workers=WORKERS) as executor:
+            executor.map(self._threading_wrapper, tasks)
 
-            tasks = [DownloadKey(date=d, temporal_resolution=t_res) for d in all_months]
-
-            logger.info(f"Downloading data for tasks:\n{tasks[0]} to {tasks[-1]}")
-            with ThreadPoolExecutor(max_workers=WORKERS) as executor:
-                executor.map(
-                    lambda t: self._threading_wrapper(t, checkpoint, checkpoint_path),
-                    tasks,
-                )
-
-    def _get_task_data(self, task: DownloadKey) -> pd.DataFrame:  # type: ignore[override]
+    def _get_task_data(self, task: DownloadTask) -> pd.DataFrame:  # type: ignore[override]
         """Get AESO generation data per plant for one specific month.
 
         AESO provides 5-min (2015 - 2023) and hourly (2015 - now) data on their site.
@@ -142,7 +138,7 @@ class AesoDownloader(EnergyDownloader):
         - "CSD Generation (hourly) - YYYY-MM.zip" from 2025-07 onward.
 
         Args:
-            task (DownloadKey): The metadata of a downloading task,
+            task (DownloadTask): The metadata of a downloading task,
                 here: date (YYYY-MM), temporal_resolution
 
         Returns:
@@ -157,24 +153,26 @@ class AesoDownloader(EnergyDownloader):
             DataStructureError: If downloaded data does not have the required columns or
                 unparsable dates.
         """
-        task.validate_required_fields("date", "temporal_resolution")
+        task.validate_required_fields("temporal_resolution")
 
         # find remote item that contains relevant data
         try:
             item = self._source_lookup[task.temporal_resolution][task.date]
         except KeyError:
-            raise MissingDataError("No AESO data available!")
+            raise MissingDataError(
+                "No AESO data that matches requested task! Skipping..."
+            )
 
         # load remote data into dataframe (using id and name because dict can't be cached!)
         df = self._load_zip(item_id=item["id"], item_name=item["name"])
 
         if df.empty:
-            raise MissingDataError("No generation data exists!")
+            raise MissingDataError("No energy generation data available! Skipping...")
 
         missing_cols = [c for c in EXPECTED_COLS if c not in df.columns]
         if missing_cols:
             raise DataStructureError(
-                f"AESO file structure change detected for task: {task}! "
+                f"AESO file structure change detected for '{task.identifier}'! "
                 f"Missing columns: {missing_cols}"
             )
 
@@ -184,14 +182,16 @@ class AesoDownloader(EnergyDownloader):
         )  # AESO uses MPT, not MST
         if date_col.isna().any():
             raise DataStructureError(
-                f"AESO file structure change detected for task: {task}! "
+                f"AESO file structure change detected for '{task.identifier}'! "
                 f"'Date (MPT)' contains unparsable values."
             )
 
         df = df.loc[date_col.dt.to_period("M") == pd.Period(task.date, freq="M")].copy()
 
         if df.empty:
-            raise MissingDataError("No generation data left after month filter!")
+            raise MissingDataError(
+                "No energy generation data after month filter! Skipping..."
+            )
 
         df = df.sort_values(
             by=["Date (MST)", "Date (MPT)", "Asset Name"], ignore_index=True
@@ -278,8 +278,8 @@ class AesoDownloader(EnergyDownloader):
 
                         else:
                             raise DataStructureError(
-                                f"AESO file structure change detected in file '{item.name}': "
-                                f"naming convention changed, date search returns {item_dates}"
+                                f"AESO file structure change detected in file '{item.name}'! "
+                                f"Naming convention changed, date search returns {item_dates}"
                             )
 
                 offset += len(items.entries)

--- a/rbc/energy/aeso/downloader.py
+++ b/rbc/energy/aeso/downloader.py
@@ -150,8 +150,8 @@ class AesoDownloader(EnergyDownloader):
         Raises:
             MissingDataError: If a month date was requested for which no data exists or if the
                 returned dataframe is empty.
-            DataStructureError: If downloaded data does not have the required columns or
-                unparsable dates.
+            DataStructureError: If the data structure changed and relevant columns are now
+                missing or data is unparsable (this will cause the entire run to be killed).
         """
         task.validate_required_fields("temporal_resolution")
 

--- a/rbc/energy/aeso/downloader.py
+++ b/rbc/energy/aeso/downloader.py
@@ -1,0 +1,289 @@
+"""AESO DATA DOWNLOADER.
+
+Access of AESO site and their zip (CSV) files using zipfile and pandas packages.
+"""
+
+import io
+import re
+import zipfile
+from concurrent.futures import ThreadPoolExecutor
+from functools import lru_cache
+from pathlib import Path
+
+import pandas as pd
+import requests
+from box_sdk_gen import BoxClient, BoxDeveloperTokenAuth, FileBaseTypeField
+from loguru import logger
+
+from rbc.energy.utils import WORKERS, DataStructureError, EnergyDownloader
+
+URL_BASE = "https://aeso.app.box.com/s/qofgn9axnnw6uq3ip1goiq2ngb11txe5"
+BOXAPI = f"shared_link={URL_BASE}"
+ROOT_ID = "196731538687"
+FOLDER_ID_DICT = {"1h": "196178549071", "5min": "196706124680"}
+
+EXPECTED_COLS = [
+    "Date (MST)",
+    "Date (MPT)",
+    "Asset Short Name",
+    "Asset Name",
+    "Asset Grouping",
+    "Volume",
+    "Maximum Capability",
+    "System Capability",
+    "Fuel Type",
+    "Sub Fuel Type",
+    "Planning Area",
+    "Region",
+]
+
+
+class AesoDownloader(EnergyDownloader):
+    """AESO data downloader.
+
+    Attributes:
+        temporal_resolutions (list[str]): The temporal resolutions to download.
+        client (BoxClient): AESO box cloud storage client.
+        _source_lookup (dict): Lookup dict of files that can be downloaded from AESO site.
+    """
+
+    def __init__(
+        self,
+        token: str,
+        output_path: Path,
+        years: list[int],
+        temporal_resolutions: list[str],
+        resume: bool = True,
+    ) -> None:
+        """Initializes the instance.
+
+        Args:
+            token (str): The personal box cloud storage API developer token.
+            output_path (Path): Path to the output directory.
+            years (list[int]): List of years to get data for.
+            temporal_resolutions (list[str]): The temporal resolutions to download.
+            resume (bool, optional): Whether to resume from a previous download (True)
+                or start from scratch (False). Defaults to True.
+
+        Raises:
+            ValueError: If provided temporal_resolutions are invalid (not 1h &/ 5min).
+            ConnectionError: If the AESO box endpoint isn't reachable.
+        """
+        super().__init__(output_path=output_path, years=years, resume=resume)
+
+        self.temporal_resolutions = temporal_resolutions
+        invalid_t_res = set(temporal_resolutions) - set(FOLDER_ID_DICT.keys())
+        if invalid_t_res:
+            raise ValueError(f"Invalid temporal resolution(s): {sorted(invalid_t_res)}")
+
+        logger.info(
+            f"AESO Downloader initialized for:"
+            f"\n- years:\t\t{years}"
+            f"\n- temporal resolutions:\t{temporal_resolutions}"
+        )
+
+        try:
+            requests.get(
+                f"https://api.box.com/2.0/folders/{ROOT_ID}/items",
+                headers={
+                    "Authorization": f"Bearer {token}",
+                    "boxapi": BOXAPI,
+                },
+                params={"limit": 1},
+                timeout=10,
+            ).raise_for_status()
+
+        except (requests.exceptions.HTTPError, requests.exceptions.Timeout) as e:
+            logger.error("Initialization AESO connectivity check failed!")
+            raise ConnectionError(f"AESO box cloud storage is unreachable: {e}")
+
+        # API setup
+        auth = BoxDeveloperTokenAuth(token=token)
+        self.client = BoxClient(auth=auth)
+
+        self._source_lookup = self._build_source_lookup()
+
+    def download_data(self) -> None:
+        """Parse data for all given years from AESO site and save to CSV."""
+        all_months = self._get_month_list()
+
+        for t_res in self.temporal_resolutions:
+            t_res_path = Path(self.output_path, t_res)
+            t_res_path.mkdir(parents=True, exist_ok=True)
+
+            checkpoint_path = Path(t_res_path, "status.pickle")
+            checkpoint = self._load_checkpoint(checkpoint_path)
+
+            logger.info(
+                f"Downloading data in '{t_res}' for: {all_months[0]} to {all_months[-1]}"
+            )
+            with ThreadPoolExecutor(max_workers=WORKERS) as executor:
+                executor.map(
+                    lambda t: self._threading_wrapper(t, checkpoint, checkpoint_path),
+                    [(t_res, d) for d in all_months],
+                )
+
+    def _get_task_data(self, task: tuple[str, str]) -> pd.DataFrame:  # type: ignore[override]
+        """Get AESO generation data per plant for one specific month.
+
+        AESO provides 5-min (2015 - 2023) and hourly (2015 - now) data on their site.
+        All data is stored in zip folders containing a single CSV file.
+        The 5-min files are labelled "CSD Generation (5-min) - YYYY-MM.zip".
+        The Hourly files are labelled
+        - "CSD Generation (hourly) - YYYY-01/07 to YYYY-06/12.zip" until 2025-06
+        - "CSD Generation (hourly) - YYYY-MM.zip" from 2025-07 onward.
+
+        Args:
+            task (tuple[str, str]): Tuple of (temporal res, month (YYYY-MM)) to get data for.
+
+        Returns:
+            pd.DataFrame: Dataframe for specific date with the columns
+            ["Date (MST)", "Date (MPT)", "Asset Short Name", "Asset Name", "Asset Grouping",
+             "Volume", "Maximum Capability", "System Capability", "Fuel Type", "Sub Fuel Type",
+             "Planning Area", "Region"]
+
+        Raises:
+            ValueError: If a month date was requested for which no data exists or if the
+                returned dataframe is empty.
+            DataStructureError: If downloaded data does not have the required columns or
+                unparsable dates.
+        """
+        t_res, date = task
+
+        # find remote item that contains relevant data
+        try:
+            item = self._source_lookup[t_res][date]
+        except KeyError:
+            raise ValueError("No AESO data available!")
+
+        # load remote data into dataframe
+        df = self._load_zip(
+            item_id=item["id"], item_name=item["name"]
+        )  # can't cache dict
+
+        if df.empty:
+            raise ValueError("No generation data exists!")
+
+        missing_cols = [c for c in EXPECTED_COLS if c not in df.columns]
+        if missing_cols:
+            raise DataStructureError(
+                f"AESO file structure change detected for task: {task}! "
+                f"Missing columns: {missing_cols}"
+            )
+
+        # slice relevant month excerpt from dataframe (some files cover multiple months!)
+        date_col = pd.to_datetime(
+            df["Date (MPT)"], errors="coerce"
+        )  # AESO uses MPT, not MST
+        if date_col.isna().any():
+            raise DataStructureError(
+                f"AESO file structure change detected for task: {task}! "
+                f"'Date (MPT)' contains unparsable values."
+            )
+
+        df = df.loc[date_col.dt.to_period("M") == pd.Period(date, freq="M")].copy()
+
+        if df.empty:
+            raise ValueError("No generation data left after month filter!")
+
+        df = df.sort_values(
+            by=["Date (MST)", "Date (MPT)", "Asset Name"], ignore_index=True
+        )
+        return df
+
+    @lru_cache(maxsize=8)
+    def _load_zip(self, item_id: str, item_name: str) -> pd.DataFrame:
+        """Downloads the CSV contained in the zip file into a df once.
+
+        Decorator lru_cache enables download and storage in cache of a file once, that can
+        be used over
+
+        Args:
+            item_id: Specific ID of item in URL to download.
+            item_name: Specific name of item in URL to download.
+
+        Returns:
+            pd.DataFrame: Dataframe for the desired source file.
+
+        Raises:
+            DataStructureError: If remote downloaded data does not have capacity values.
+        """
+        file_stream = self.client.downloads.download_file(item_id, boxapi=BOXAPI)
+        file_bytes = file_stream.read()
+
+        with zipfile.ZipFile(io.BytesIO(file_bytes)) as z:
+            file_names = z.namelist()
+            if len(file_names) != 1:
+                raise DataStructureError(
+                    f"AESO file structure change detected in file '{item_name}': "
+                    f"expected exactly one file in ZIP, found {file_names}"
+                )
+
+            csv_name = file_names[0]
+            if not csv_name.lower().endswith(".csv"):
+                raise DataStructureError(
+                    f"AESO file structure change detected in file '{item_name}': "
+                    f"expected CSV, found {csv_name}"
+                )
+
+            with z.open(csv_name) as f:
+                return pd.read_csv(f)
+
+    # --------------------------------------------
+    # Helper methods
+    # --------------------------------------------
+    def _build_source_lookup(self) -> dict[str, dict]:
+        """Build lookup table from AESO box site of all relevant files that can be downloaded.
+
+        Returns:
+            dict: Lookup dict {<tr>: YYYY-MM: {"id": <id>, "name": <name>}, ...}
+
+        Raises:
+            DataStructureError: If downloaded data does not have capacity values.
+        """
+        lookup: dict = {tr: {} for tr in self.temporal_resolutions}
+
+        for tr in self.temporal_resolutions:
+            limit = 1000  # max allowed by box
+            offset = 0
+
+            while True:
+                items = self.client.folders.get_folder_items(
+                    FOLDER_ID_DICT[tr], boxapi=BOXAPI, limit=limit, offset=offset
+                )
+
+                for item in items.entries:
+                    if item.type == FileBaseTypeField.FILE:
+                        item_dates = re.findall(r"\d{4}-\d{2}(?=[^0-9])", item.name)
+
+                        if len(item_dates) == 1:
+                            lookup[tr][item_dates[0]] = {
+                                "id": item.id,
+                                "name": item.name,
+                            }
+
+                        elif len(item_dates) == 2:
+                            date_range = pd.date_range(
+                                start=item_dates[0], end=item_dates[1], freq="MS"
+                            )
+                            for date in date_range.strftime("%Y-%m"):
+                                lookup[tr][date] = {"id": item.id, "name": item.name}
+
+                        else:
+                            raise DataStructureError(
+                                f"AESO file structure change detected in file '{item.name}': "
+                                f"naming convention changed, date search returns {item_dates}"
+                            )
+
+                offset += len(items.entries)
+
+                if offset >= items.total_count:
+                    break
+
+            if not lookup[tr]:
+                raise DataStructureError(
+                    f"AESO file structure change detected! "
+                    f"No data for temporal resolution: {tr}"
+                )
+
+        return lookup

--- a/rbc/energy/aeso/downloader.py
+++ b/rbc/energy/aeso/downloader.py
@@ -15,7 +15,7 @@ import requests
 from box_sdk_gen import BoxClient, BoxDeveloperTokenAuth, FileBaseTypeField
 from loguru import logger
 
-from rbc.energy.utils import WORKERS, DataStructureError, EnergyDownloader
+from rbc.energy.utils import WORKERS, DataStructureError, DownloadKey, EnergyDownloader
 
 URL_BASE = "https://aeso.app.box.com/s/qofgn9axnnw6uq3ip1goiq2ngb11txe5"
 BOXAPI = f"shared_link={URL_BASE}"
@@ -108,22 +108,21 @@ class AesoDownloader(EnergyDownloader):
         all_months = self._get_month_list()
 
         for t_res in self.temporal_resolutions:
-            t_res_path = Path(self.output_path, t_res)
-            t_res_path.mkdir(parents=True, exist_ok=True)
-
-            checkpoint_path = Path(t_res_path, "status.pickle")
+            checkpoint_path = self._build_checkpoint_path(
+                DownloadKey(temporal_resolution=t_res)
+            )
             checkpoint = self._load_checkpoint(checkpoint_path)
 
-            logger.info(
-                f"Downloading data in '{t_res}' for: {all_months[0]} to {all_months[-1]}"
-            )
+            tasks = [DownloadKey(date=d, temporal_resolution=t_res) for d in all_months]
+
+            logger.info(f"Downloading data for tasks:\n{tasks[0]} to {tasks[-1]}")
             with ThreadPoolExecutor(max_workers=WORKERS) as executor:
                 executor.map(
                     lambda t: self._threading_wrapper(t, checkpoint, checkpoint_path),
-                    [(t_res, d) for d in all_months],
+                    tasks,
                 )
 
-    def _get_task_data(self, task: tuple[str, str]) -> pd.DataFrame:  # type: ignore[override]
+    def _get_task_data(self, task: DownloadKey) -> pd.DataFrame:  # type: ignore[override]
         """Get AESO generation data per plant for one specific month.
 
         AESO provides 5-min (2015 - 2023) and hourly (2015 - now) data on their site.
@@ -134,7 +133,8 @@ class AesoDownloader(EnergyDownloader):
         - "CSD Generation (hourly) - YYYY-MM.zip" from 2025-07 onward.
 
         Args:
-            task (tuple[str, str]): Tuple of (temporal res, month (YYYY-MM)) to get data for.
+            task (DownloadKey): The metadata of a downloading task,
+                here: date (YYYY-MM), temporal_resolution
 
         Returns:
             pd.DataFrame: Dataframe for specific date with the columns
@@ -148,18 +148,16 @@ class AesoDownloader(EnergyDownloader):
             DataStructureError: If downloaded data does not have the required columns or
                 unparsable dates.
         """
-        t_res, date = task
+        task.validate_required_fields("date", "temporal_resolution")
 
         # find remote item that contains relevant data
         try:
-            item = self._source_lookup[t_res][date]
+            item = self._source_lookup[task.temporal_resolution][task.date]
         except KeyError:
             raise ValueError("No AESO data available!")
 
-        # load remote data into dataframe
-        df = self._load_zip(
-            item_id=item["id"], item_name=item["name"]
-        )  # can't cache dict
+        # load remote data into dataframe (using id and name because dict can't be cached!)
+        df = self._load_zip(item_id=item["id"], item_name=item["name"])
 
         if df.empty:
             raise ValueError("No generation data exists!")
@@ -181,7 +179,7 @@ class AesoDownloader(EnergyDownloader):
                 f"'Date (MPT)' contains unparsable values."
             )
 
-        df = df.loc[date_col.dt.to_period("M") == pd.Period(date, freq="M")].copy()
+        df = df.loc[date_col.dt.to_period("M") == pd.Period(task.date, freq="M")].copy()
 
         if df.empty:
             raise ValueError("No generation data left after month filter!")
@@ -236,20 +234,20 @@ class AesoDownloader(EnergyDownloader):
         """Build lookup table from AESO box site of all relevant files that can be downloaded.
 
         Returns:
-            dict: Lookup dict {<tr>: YYYY-MM: {"id": <id>, "name": <name>}, ...}
+            dict: Lookup dict {<t_res>: {YYYY-MM: {"id": <id>, "name": <name>}}, ...}
 
         Raises:
             DataStructureError: If downloaded data does not have capacity values.
         """
-        lookup: dict = {tr: {} for tr in self.temporal_resolutions}
+        lookup: dict = {t_res: {} for t_res in self.temporal_resolutions}
 
-        for tr in self.temporal_resolutions:
+        for t_res in self.temporal_resolutions:
             limit = 1000  # max allowed by box
             offset = 0
 
             while True:
                 items = self.client.folders.get_folder_items(
-                    FOLDER_ID_DICT[tr], boxapi=BOXAPI, limit=limit, offset=offset
+                    FOLDER_ID_DICT[t_res], boxapi=BOXAPI, limit=limit, offset=offset
                 )
 
                 for item in items.entries:
@@ -257,7 +255,7 @@ class AesoDownloader(EnergyDownloader):
                         item_dates = re.findall(r"\d{4}-\d{2}(?=[^0-9])", item.name)
 
                         if len(item_dates) == 1:
-                            lookup[tr][item_dates[0]] = {
+                            lookup[t_res][item_dates[0]] = {
                                 "id": item.id,
                                 "name": item.name,
                             }
@@ -267,7 +265,7 @@ class AesoDownloader(EnergyDownloader):
                                 start=item_dates[0], end=item_dates[1], freq="MS"
                             )
                             for date in date_range.strftime("%Y-%m"):
-                                lookup[tr][date] = {"id": item.id, "name": item.name}
+                                lookup[t_res][date] = {"id": item.id, "name": item.name}
 
                         else:
                             raise DataStructureError(
@@ -280,10 +278,10 @@ class AesoDownloader(EnergyDownloader):
                 if offset >= items.total_count:
                     break
 
-            if not lookup[tr]:
+            if not lookup[t_res]:
                 raise DataStructureError(
                     f"AESO file structure change detected! "
-                    f"No data for temporal resolution: {tr}"
+                    f"No data for temporal resolution: {t_res}"
                 )
 
         return lookup

--- a/rbc/energy/aeso/downloader.py
+++ b/rbc/energy/aeso/downloader.py
@@ -15,7 +15,14 @@ import requests
 from box_sdk_gen import BoxClient, BoxDeveloperTokenAuth, FileBaseTypeField
 from loguru import logger
 
-from rbc.energy.utils import WORKERS, DataStructureError, DownloadKey, EnergyDownloader
+from rbc.energy.utils import (
+    WORKERS,
+    DataStructureError,
+    DownloadKey,
+    EnergyDownloader,
+    InvalidError,
+    MissingDataError,
+)
 
 URL_BASE = "https://aeso.app.box.com/s/qofgn9axnnw6uq3ip1goiq2ngb11txe5"
 BOXAPI = f"shared_link={URL_BASE}"
@@ -66,7 +73,7 @@ class AesoDownloader(EnergyDownloader):
                 or start from scratch (False). Defaults to True.
 
         Raises:
-            ValueError: If provided temporal_resolutions are invalid (not 1h &/ 5min).
+            InvalidError: If provided temporal_resolutions are invalid (not 1h &/ 5min).
             ConnectionError: If the AESO box endpoint isn't reachable.
         """
         super().__init__(output_path=output_path, years=years, resume=resume)
@@ -74,7 +81,9 @@ class AesoDownloader(EnergyDownloader):
         self.temporal_resolutions = temporal_resolutions
         invalid_t_res = set(temporal_resolutions) - set(FOLDER_ID_DICT.keys())
         if invalid_t_res:
-            raise ValueError(f"Invalid temporal resolution(s): {sorted(invalid_t_res)}")
+            raise InvalidError(
+                f"Invalid temporal resolution(s): {sorted(invalid_t_res)}"
+            )
 
         logger.info(
             f"AESO Downloader initialized for:"
@@ -143,7 +152,7 @@ class AesoDownloader(EnergyDownloader):
              "Planning Area", "Region"]
 
         Raises:
-            ValueError: If a month date was requested for which no data exists or if the
+            MissingDataError: If a month date was requested for which no data exists or if the
                 returned dataframe is empty.
             DataStructureError: If downloaded data does not have the required columns or
                 unparsable dates.
@@ -154,13 +163,13 @@ class AesoDownloader(EnergyDownloader):
         try:
             item = self._source_lookup[task.temporal_resolution][task.date]
         except KeyError:
-            raise ValueError("No AESO data available!")
+            raise MissingDataError("No AESO data available!")
 
         # load remote data into dataframe (using id and name because dict can't be cached!)
         df = self._load_zip(item_id=item["id"], item_name=item["name"])
 
         if df.empty:
-            raise ValueError("No generation data exists!")
+            raise MissingDataError("No generation data exists!")
 
         missing_cols = [c for c in EXPECTED_COLS if c not in df.columns]
         if missing_cols:
@@ -182,7 +191,7 @@ class AesoDownloader(EnergyDownloader):
         df = df.loc[date_col.dt.to_period("M") == pd.Period(task.date, freq="M")].copy()
 
         if df.empty:
-            raise ValueError("No generation data left after month filter!")
+            raise MissingDataError("No generation data left after month filter!")
 
         df = df.sort_values(
             by=["Date (MST)", "Date (MPT)", "Asset Name"], ignore_index=True

--- a/rbc/energy/aeso/downloader.py
+++ b/rbc/energy/aeso/downloader.py
@@ -177,9 +177,7 @@ class AesoDownloader(EnergyDownloader):
             )
 
         # slice relevant month excerpt from dataframe (some files cover multiple months!)
-        date_col = pd.to_datetime(
-            df["Date (MPT)"], errors="coerce"
-        )  # AESO uses MPT, not MST
+        date_col = pd.to_datetime(df["Date (MPT)"], errors="coerce")  # AESO uses MPT!
         if date_col.isna().any():
             raise DataStructureError(
                 f"AESO file structure change detected for '{task.identifier}'! "

--- a/rbc/energy/eia/downloader.py
+++ b/rbc/energy/eia/downloader.py
@@ -15,8 +15,11 @@ from requests import exceptions
 from rbc.energy.utils import (
     MAX_RATE_LIMIT_RETRIES,
     WORKERS,
+    DataStructureError,
     DownloadKey,
     EnergyDownloader,
+    InvalidError,
+    MissingDataError,
     RateLimitError,
 )
 
@@ -47,10 +50,10 @@ class EiaDownloader(EnergyDownloader):
             output_path (Path): Path to the output directory.
             years (list[int]): List of years to get data for.
             resume (bool, optional): Whether to resume from a previous download (True)
-            or start from scratch (False). Defaults to True.
+                or start from scratch (False). Defaults to True.
 
         Raises:
-            ValueError: If token is invalid or basic API call fails.
+            InvalidError: If token is invalid or basic API call fails.
         """
         super().__init__(output_path=output_path, years=years, resume=resume)
         self.token = token
@@ -63,11 +66,11 @@ class EiaDownloader(EnergyDownloader):
             response = requests.get(URL_ROOT, params={"api_key": self.token})
             if response.status_code != 200:
                 logger.info(f"Failed: {response.json().get('error', {}).get('code')}")
-                raise ValueError(f"Provided API token {token} incorrect.")
+                raise InvalidError(f"Provided API token {token} incorrect.")
 
         except Exception as e:
             logger.info(f"Failed: {e}")
-            raise ValueError(f"Provided API token {token} incorrect.")
+            raise InvalidError(f"Provided API token {token} incorrect.")
 
     def download_data(self):
         """Parse data for all given years from EIA site and save to CSV."""
@@ -100,11 +103,12 @@ class EiaDownloader(EnergyDownloader):
             'value', 'value-units']
 
         Raises:
-            ConnectionError/Timeout: If API issue occurred with connection or timeout.
+            ConnectionError/Timeout: If API issue occurred with connection or timeout or if
+                not all available data was downloaded.
             HTTPError: If request response is not 200.
             RateLimitError: If API rate limit has been exceeded.
-            ValueError: If response parsing failed, if not all available data was
-            downloaded, or if the dataframe is empty.
+            DataStructureError: If response parsing failed due to a change in EIA structure.
+            MissingDataError: If the loaded dataframe is empty.
         """
         task.validate_required_fields("date")
 
@@ -162,7 +166,8 @@ class EiaDownloader(EnergyDownloader):
                 all_data.extend(dict_data)
 
             except (requests.exceptions.JSONDecodeError, KeyError, ValueError) as e:
-                raise ValueError(
+                raise DataStructureError(
+                    f"EIA API structure change detected for task: {task}."
                     f"Failed parsing of data from {URL} with parameters {params}: "
                     f"{type(e).__name__}!"
                 )
@@ -180,11 +185,13 @@ class EiaDownloader(EnergyDownloader):
 
         # Check all available data was downloaded
         if len(all_data) != total_available:
-            raise ValueError(f"Incomplete download: {len(all_data)}/{total_available}")
+            raise ConnectionError(
+                f"Incomplete download: {len(all_data)}/{total_available}"
+            )
 
         df_gen = pd.DataFrame(all_data)
         if df_gen.empty:
-            raise ValueError(f"No generation data available for {task}!")
+            raise MissingDataError(f"No generation data available for {task}!")
 
         df_gen = df_gen[df_gen["period"] != end]  # remove included hour from next day
         df_gen = df_gen.sort_values(["period", "respondent"], ignore_index=True)

--- a/rbc/energy/eia/downloader.py
+++ b/rbc/energy/eia/downloader.py
@@ -169,7 +169,7 @@ class EiaDownloader(EnergyDownloader):
 
             except (requests.exceptions.JSONDecodeError, KeyError, ValueError) as e:
                 raise DataStructureError(
-                    f"EIA structure change detected for '{task.identifier}'!"
+                    f"EIA structure change detected for '{task.identifier}'! "
                     f"Failed parsing of data from {URL} with parameters {params}: "
                     f"{type(e).__name__}!"
                 )

--- a/rbc/energy/eia/downloader.py
+++ b/rbc/energy/eia/downloader.py
@@ -16,7 +16,7 @@ from rbc.energy.utils import (
     MAX_RATE_LIMIT_RETRIES,
     WORKERS,
     DataStructureError,
-    DownloadKey,
+    DownloadTask,
     EnergyDownloader,
     InvalidError,
     MissingDataError,
@@ -57,8 +57,6 @@ class EiaDownloader(EnergyDownloader):
         """
         super().__init__(output_path=output_path, years=years, resume=resume)
         self.token = token
-        self.checkpoint_path = Path(self.output_path, "status.pickle")
-        self.checkpoint = self._load_checkpoint(self.checkpoint_path)
 
         logger.info(f"EIA Downloader initialized for:\n- years:\t\t{years}")
 
@@ -74,18 +72,15 @@ class EiaDownloader(EnergyDownloader):
 
     def download_data(self):
         """Parse data for all given years from EIA site and save to CSV."""
-        tasks = [DownloadKey(date=d) for d in self._get_date_list()]
+        tasks = [DownloadTask(date=d) for d in self._get_date_list()]
 
-        logger.info(f"Downloading data for tasks:\n{tasks[0]} to {tasks[-1]}")
+        logger.info(
+            f"Downloading tasks: {tasks[0].identifier} --- {tasks[-1].identifier}"
+        )
         with ThreadPoolExecutor(max_workers=WORKERS) as executor:
-            executor.map(
-                lambda t: self._threading_wrapper(
-                    t, self.checkpoint, self.checkpoint_path
-                ),
-                tasks,
-            )
+            executor.map(self._threading_wrapper, tasks)
 
-    def _get_task_data(self, task: DownloadKey) -> pd.DataFrame:  # type: ignore[override]
+    def _get_task_data(self, task: DownloadTask) -> pd.DataFrame:  # type: ignore[override]
         """Get EIA generation data per plant for one specific date.
 
         The parsing cap lies at 5000 rows per API call. The amount of hourly data
@@ -95,7 +90,7 @@ class EiaDownloader(EnergyDownloader):
         instead of per month/year.
 
         Args:
-            task (DownloadKey): The metadata of a downloading task, here: date (YYYY-MM-DD)
+            task (DownloadTask): The metadata of a downloading task, here: date (YYYY-MM-DD)
 
         Returns:
             pd.DataFrame: Dataframe for specific date with the columns
@@ -110,8 +105,6 @@ class EiaDownloader(EnergyDownloader):
             DataStructureError: If response parsing failed due to a change in EIA structure.
             MissingDataError: If the loaded dataframe is empty.
         """
-        task.validate_required_fields("date")
-
         dt = pd.Period(task.date, freq="D")
         start = dt.strftime("%Y-%m-%dT00")
         end = pd.Period((dt + pd.Timedelta(days=1)), freq="D").strftime("%Y-%m-%dT00")
@@ -167,7 +160,7 @@ class EiaDownloader(EnergyDownloader):
 
             except (requests.exceptions.JSONDecodeError, KeyError, ValueError) as e:
                 raise DataStructureError(
-                    f"EIA API structure change detected for task: {task}."
+                    f"EIA API structure change detected for '{task.identifier}'!"
                     f"Failed parsing of data from {URL} with parameters {params}: "
                     f"{type(e).__name__}!"
                 )
@@ -191,7 +184,7 @@ class EiaDownloader(EnergyDownloader):
 
         df_gen = pd.DataFrame(all_data)
         if df_gen.empty:
-            raise MissingDataError(f"No generation data available for {task}!")
+            raise MissingDataError("No energy generation data available! Skipping...")
 
         df_gen = df_gen[df_gen["period"] != end]  # remove included hour from next day
         df_gen = df_gen.sort_values(["period", "respondent"], ignore_index=True)

--- a/rbc/energy/eia/downloader.py
+++ b/rbc/energy/eia/downloader.py
@@ -15,6 +15,7 @@ from requests import exceptions
 from rbc.energy.utils import (
     MAX_RATE_LIMIT_RETRIES,
     WORKERS,
+    DownloadKey,
     EnergyDownloader,
     RateLimitError,
 )
@@ -70,18 +71,18 @@ class EiaDownloader(EnergyDownloader):
 
     def download_data(self):
         """Parse data for all given years from EIA site and save to CSV."""
-        all_dates = self._get_date_list()
+        tasks = [DownloadKey(date=d) for d in self._get_date_list()]
 
-        logger.info(f"Downloading data for: {all_dates[0]} to {all_dates[-1]}")
+        logger.info(f"Downloading data for tasks:\n{tasks[0]} to {tasks[-1]}")
         with ThreadPoolExecutor(max_workers=WORKERS) as executor:
             executor.map(
                 lambda t: self._threading_wrapper(
                     t, self.checkpoint, self.checkpoint_path
                 ),
-                all_dates,
+                tasks,
             )
 
-    def _get_task_data(self, task: str) -> pd.DataFrame:  # type: ignore[override]
+    def _get_task_data(self, task: DownloadKey) -> pd.DataFrame:  # type: ignore[override]
         """Get EIA generation data per plant for one specific date.
 
         The parsing cap lies at 5000 rows per API call. The amount of hourly data
@@ -91,7 +92,7 @@ class EiaDownloader(EnergyDownloader):
         instead of per month/year.
 
         Args:
-            task (str): Date to get data for.
+            task (DownloadKey): The metadata of a downloading task, here: date (YYYY-MM-DD)
 
         Returns:
             pd.DataFrame: Dataframe for specific date with the columns
@@ -105,7 +106,9 @@ class EiaDownloader(EnergyDownloader):
             ValueError: If response parsing failed, if not all available data was
             downloaded, or if the dataframe is empty.
         """
-        dt = pd.Period(task, freq="D")
+        task.validate_required_fields("date")
+
+        dt = pd.Period(task.date, freq="D")
         start = dt.strftime("%Y-%m-%dT00")
         end = pd.Period((dt + pd.Timedelta(days=1)), freq="D").strftime("%Y-%m-%dT00")
 

--- a/rbc/energy/eia/downloader.py
+++ b/rbc/energy/eia/downloader.py
@@ -26,14 +26,22 @@ from rbc.energy.utils import (
 URL_ROOT = "https://api.eia.gov/v2/"
 URL = "https://api.eia.gov/v2/electricity/rto/fuel-type-data/data/"
 
+EXPECTED_COLS = [
+    "period",
+    "respondent",
+    "respondent-name",
+    "fueltype",
+    "type-name",
+    "value",
+    "value-units",
+]
+
 
 class EiaDownloader(EnergyDownloader):
     """EIA data downloader.
 
     Attributes:
         token (str): The personal EIA API token.
-        checkpoint_path (Path): Path to the checkpoint file for resuming.
-        checkpoint (dict): Dict of 0 and 1 values for resuming.
     """
 
     def __init__(
@@ -102,7 +110,8 @@ class EiaDownloader(EnergyDownloader):
                 not all available data was downloaded.
             HTTPError: If request response is not 200.
             RateLimitError: If API rate limit has been exceeded.
-            DataStructureError: If response parsing failed due to a change in EIA structure.
+            DataStructureError: If the EIA structure changed causing response parsing fail or
+                relevant columns to be missed (this will cause the entire run to be killed).
             MissingDataError: If the loaded dataframe is empty.
         """
         dt = pd.Period(task.date, freq="D")
@@ -160,7 +169,7 @@ class EiaDownloader(EnergyDownloader):
 
             except (requests.exceptions.JSONDecodeError, KeyError, ValueError) as e:
                 raise DataStructureError(
-                    f"EIA API structure change detected for '{task.identifier}'!"
+                    f"EIA structure change detected for '{task.identifier}'!"
                     f"Failed parsing of data from {URL} with parameters {params}: "
                     f"{type(e).__name__}!"
                 )
@@ -185,6 +194,13 @@ class EiaDownloader(EnergyDownloader):
         df_gen = pd.DataFrame(all_data)
         if df_gen.empty:
             raise MissingDataError("No energy generation data available! Skipping...")
+
+        missing_cols = [c for c in EXPECTED_COLS if c not in df_gen.columns]
+        if missing_cols:
+            raise DataStructureError(
+                f"EIA structure change detected for '{task.identifier}'! "
+                f"Missing columns: {missing_cols}"
+            )
 
         df_gen = df_gen[df_gen["period"] != end]  # remove included hour from next day
         df_gen = df_gen.sort_values(["period", "respondent"], ignore_index=True)

--- a/rbc/energy/entsoe/downloader.py
+++ b/rbc/energy/entsoe/downloader.py
@@ -24,7 +24,7 @@ from rbc.energy.utils import (
     write_df_to_csv,
 )
 
-RELEVANT_RECORD_KEYS = {
+EXPECTED_COLS_MAPPING = {
     "timestamp": "timestamp",
     "time_series.mkt_psrtype.power_system_resources.name": "Unit_Name",
     "time_series.mkt_psrtype.power_system_resources.m_rid.value": "Unit_Code",
@@ -60,7 +60,7 @@ class EntsoeDownloader(EnergyDownloader):
             years (list[int]): List of years to get data for.
             bidding_zones (list[str]): List of bidding zones to get data for.
             resume (bool, optional): Whether to resume from a previous download (True)
-            or start from scratch (False). Defaults to True.
+                or start from scratch (False). Defaults to True.
 
         Raises:
             InvalidError: If bidding zone is unsupported or token is invalid.
@@ -113,11 +113,11 @@ class EntsoeDownloader(EnergyDownloader):
 
         Raises:
             ConnectionError: If Entso-E TP is unavailable or the API did not
-            return the requested data (this will cause a retry on the next resume).
+                return the requested data (this will cause a retry on the next resume).
             MissingDataError: If no data is available for the given task (this will cause
-            the task to be skipped in future).
-            DataStructureError: If data structure has changed and relevant columns
-            are missing (this will cause the entire run to be killed).
+                the task to be skipped in future).
+            DataStructureError: If the data structure changed and relevant columns are now
+                missing (this will cause the entire run to be killed).
         """
         task.validate_required_fields("bidding_zone")
         dt = pd.Period(task.date, freq="D")
@@ -146,8 +146,8 @@ class EntsoeDownloader(EnergyDownloader):
 
         try:
             # Columns names are made to match those on the Entso-E Transparency Platform
-            df = df.loc[:, list(RELEVANT_RECORD_KEYS.keys())].rename(
-                columns=RELEVANT_RECORD_KEYS
+            df = df.loc[:, list(EXPECTED_COLS_MAPPING.keys())].rename(
+                columns=EXPECTED_COLS_MAPPING
             )
         except KeyError as e:
             raise DataStructureError(
@@ -171,9 +171,6 @@ class EntsoeDownloader(EnergyDownloader):
         Args:
             task (DownloadTask): The metadata for the task that was downloaded.
             df (pd.DataFrame): Downloaded dataframe for the task.
-
-        Raises:
-            DataStructureError: If columns are missing temporal resolution values
         """
         df_full = df.dropna(subset=["Temporal_Resolution"])
         if len(df_full) != len(df):

--- a/rbc/energy/entsoe/downloader.py
+++ b/rbc/energy/entsoe/downloader.py
@@ -17,7 +17,7 @@ from loguru import logger
 from rbc.energy.utils import (
     WORKERS,
     DataStructureError,
-    DownloadKey,
+    DownloadTask,
     EnergyDownloader,
     InvalidError,
     MissingDataError,
@@ -87,27 +87,23 @@ class EntsoeDownloader(EnergyDownloader):
     def download_data(self) -> None:
         """Parse data for all given years and zones from ENTSO-E Platform and save to CSV."""
         all_dates = self._get_date_list()
+        tasks = [
+            DownloadTask(date=d, bidding_zone=bz)
+            for bz in self.bidding_zones
+            for d in all_dates
+        ]
 
-        for bz in self.bidding_zones:
-            checkpoint_path = self._build_checkpoint_path(
-                task=DownloadKey(bidding_zone=bz)
-            )
-            checkpoint = self._load_checkpoint(checkpoint_path)
+        logger.info(
+            f"Downloading tasks: {tasks[0].identifier} --- {tasks[-1].identifier}"
+        )
+        with ThreadPoolExecutor(max_workers=WORKERS) as executor:
+            executor.map(self._threading_wrapper, tasks)
 
-            tasks = [DownloadKey(date=d, bidding_zone=bz) for d in all_dates]
-
-            logger.info(f"Downloading data for tasks:\n{tasks[0]} to {tasks[-1]}")
-            with ThreadPoolExecutor(max_workers=WORKERS) as executor:
-                executor.map(
-                    lambda t: self._threading_wrapper(t, checkpoint, checkpoint_path),
-                    tasks,
-                )
-
-    def _get_task_data(self, task: DownloadKey) -> pd.DataFrame:  # type: ignore[override]
+    def _get_task_data(self, task: DownloadTask) -> pd.DataFrame:  # type: ignore[override]
         """Get Entso-e generation data per plant for one specific date and bidding zone.
 
         Args:
-            task (DownloadKey): The metadata of a downloading task,
+            task (DownloadTask): The metadata of a downloading task,
                 here: date (YYYY-MM-DD), bidding_zone
 
         Returns:
@@ -123,7 +119,7 @@ class EntsoeDownloader(EnergyDownloader):
             DataStructureError: If data structure has changed and relevant columns
             are missing (this will cause the entire run to be killed).
         """
-        task.validate_required_fields("date", "bidding_zone")
+        task.validate_required_fields("bidding_zone")
         dt = pd.Period(task.date, freq="D")
 
         try:
@@ -136,17 +132,13 @@ class EntsoeDownloader(EnergyDownloader):
             ).query_api()
 
         except ServiceUnavailableError:
-            raise ConnectionError(
-                "Entso-E Transparency Platform is currently unavailable!"
-            )
+            raise ConnectionError("Entso-E Transparency Platform is unavailable!")
 
-        if type(result) is not list:
-            raise ConnectionError(f"API call did not return requested data for {task}!")
+        if not isinstance(result, list):
+            raise ConnectionError("API call did not return requested data!")
 
         if not result:
-            raise MissingDataError(
-                f"No data available for {task}! Setting download status to 1."
-            )
+            raise MissingDataError("No energy generation data available! Skipping...")
 
         records = extract_records(result)  # turns into list of dicts
         records = add_timestamps(records)  # adds key 'timestamp' to each dict
@@ -159,7 +151,7 @@ class EntsoeDownloader(EnergyDownloader):
             )
         except KeyError as e:
             raise DataStructureError(
-                f"Entsoe-E structure change detected for {task}! "
+                f"Entsoe-E structure change detected for '{task.identifier}'! "
                 f"Relevant columns are missing: {e}"
             )
 
@@ -170,14 +162,14 @@ class EntsoeDownloader(EnergyDownloader):
         df = df.sort_values(by=["timestamp", "Unit_Name"], ascending=[True, True])
         return df
 
-    def _save_task_data(self, task: DownloadKey, df: pd.DataFrame) -> None:
+    def _save_task_data(self, task: DownloadTask, df: pd.DataFrame) -> None:
         """Save ENTSO-E downloaded task data to disk, splitting by temporal resolution.
 
         The API does not allow temporal resolution arguments, but ENTSO-E data has varying
         resolutions. The df is grouped by t_res and subsets are written to the correct folder.
 
         Args:
-            task (DownloadKey): The metadata for the task that was downloaded.
+            task (DownloadTask): The metadata for the task that was downloaded.
             df (pd.DataFrame): Downloaded dataframe for the task.
 
         Raises:

--- a/rbc/energy/entsoe/downloader.py
+++ b/rbc/energy/entsoe/downloader.py
@@ -11,9 +11,10 @@ import pandas as pd
 from entsoe.config import get_config, set_config
 from entsoe.Generation import ActualGenerationPerGenerationUnit
 from entsoe.query.decorators import ServiceUnavailableError
-from entsoe.utils import add_timestamps, extract_records, mappings
+from entsoe.utils import add_timestamps, extract_records
 from loguru import logger
 
+from rbc.energy.entsoe.mappings import ACTIVE_ZONES, ACTIVE_ZONES_METADATA
 from rbc.energy.utils import (
     WORKERS,
     DataStructureError,
@@ -49,7 +50,7 @@ class EntsoeDownloader(EnergyDownloader):
         token: str,
         output_path: Path,
         years: list[int],
-        bidding_zones: list[str] = mappings.keys(),
+        bidding_zones: list[str] = ACTIVE_ZONES,
         resume: bool = True,
     ) -> None:
         """Initializes the instance.
@@ -69,7 +70,7 @@ class EntsoeDownloader(EnergyDownloader):
         self.bidding_zones = list(bidding_zones)
 
         for bz in self.bidding_zones:
-            if bz not in list(mappings.keys()):
+            if bz not in ACTIVE_ZONES:
                 raise InvalidError(f"Bidding zone '{bz}' is not supported.")
 
         logger.info(
@@ -121,6 +122,12 @@ class EntsoeDownloader(EnergyDownloader):
         """
         task.validate_required_fields("bidding_zone")
         dt = pd.Period(task.date, freq="D")
+
+        bz_start = int(ACTIVE_ZONES_METADATA[str(task.bidding_zone)]["start"])
+        if dt.year < bz_start:
+            raise MissingDataError(
+                f"No data for year {dt.year} (it's before start {bz_start}). Skipping..."
+            )
 
         try:
             result = ActualGenerationPerGenerationUnit(

--- a/rbc/energy/entsoe/downloader.py
+++ b/rbc/energy/entsoe/downloader.py
@@ -3,6 +3,7 @@
 Remote API access of ENTSO-E Platform using the entsoe-apy package.
 """
 
+import re
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
@@ -16,7 +17,9 @@ from loguru import logger
 from rbc.energy.utils import (
     WORKERS,
     DataStructureError,
+    DownloadKey,
     EnergyDownloader,
+    write_df_to_csv,
 )
 
 RELEVANT_RECORD_KEYS = {
@@ -84,26 +87,26 @@ class EntsoeDownloader(EnergyDownloader):
         all_dates = self._get_date_list()
 
         for bz in self.bidding_zones:
-            bz_path = Path(self.output_path, bz)
-            bz_path.mkdir(parents=True, exist_ok=True)
-
-            checkpoint_path = Path(bz_path, "status.pickle")
+            checkpoint_path = self._build_checkpoint_path(
+                task=DownloadKey(bidding_zone=bz)
+            )
             checkpoint = self._load_checkpoint(checkpoint_path)
 
-            logger.info(
-                f"Downloading data in '{bz}' for: {all_dates[0]} to {all_dates[-1]}"
-            )
+            tasks = [DownloadKey(date=d, bidding_zone=bz) for d in all_dates]
+
+            logger.info(f"Downloading data for tasks:\n{tasks[0]} to {tasks[-1]}")
             with ThreadPoolExecutor(max_workers=WORKERS) as executor:
                 executor.map(
                     lambda t: self._threading_wrapper(t, checkpoint, checkpoint_path),
-                    [(bz, d) for d in all_dates],
+                    tasks,
                 )
 
-    def _get_task_data(self, task: tuple[str, str]) -> pd.DataFrame:  # type: ignore[override]
+    def _get_task_data(self, task: DownloadKey) -> pd.DataFrame:  # type: ignore[override]
         """Get Entso-e generation data per plant for one specific date and bidding zone.
 
         Args:
-            task (tuple): Tuple of (zone, date) to download data for.
+            task (DownloadKey): The metadata of a downloading task,
+                here: date (YYYY-MM-DD), bidding_zone
 
         Returns:
             pd.DataFrame: Dataframe for specific task with the columns
@@ -118,14 +121,14 @@ class EntsoeDownloader(EnergyDownloader):
             DataStructureError: If data structure has changed and relevant columns
             are missing (this will cause the entire run to be killed).
         """
-        zone, date = task
-        dt = pd.Period(date, freq="D")
+        task.validate_required_fields("date", "bidding_zone")
+        dt = pd.Period(task.date, freq="D")
 
         try:
             result = ActualGenerationPerGenerationUnit(
                 period_start=int(dt.strftime("%Y%m%d0000")),  # start of day
                 period_end=int(dt.strftime("%Y%m%d2359")),  # end of day
-                in_domain=zone,
+                in_domain=task.bidding_zone,
                 psr_type=None,
                 registered_resource=None,
             ).query_api()
@@ -164,3 +167,48 @@ class EntsoeDownloader(EnergyDownloader):
 
         df = df.sort_values(by=["timestamp", "Unit_Name"], ascending=[True, True])
         return df
+
+    def _save_task_data(self, task: DownloadKey, df: pd.DataFrame) -> None:
+        """Save ENTSO-E downloaded task data to disk, splitting by temporal resolution.
+
+        The API does not allow temporal resolution arguments, but ENTSO-E data has varying
+        resolutions. The df is grouped by t_res and subsets are written to the correct folder.
+
+        Args:
+            task (DownloadKey): The metadata for the task that was downloaded.
+            df (pd.DataFrame): Downloaded dataframe for the task.
+
+        Raises:
+            DataStructureError: If columns are missing temporal resolution values
+        """
+        df_full = df.dropna(subset=["Temporal_Resolution"])
+        if df.all().all() != df_full.all().all():
+            logger.warning(
+                "Some rows are missing temporal resolution values! Skipping."
+            )
+
+        for t_res, df_t_res in df.groupby("Temporal_Resolution", sort=True):
+            updated_task = task.update(
+                temporal_resolution=self._normalize_temporal_resolution(str(t_res))
+            )
+            file_path = self._build_task_path(updated_task)
+            write_df_to_csv(df=df_t_res, file_path=file_path)
+
+    @staticmethod
+    def _normalize_temporal_resolution(t_res: str) -> str:
+        """Convert ENTSO-E ISO-like temporal resolution string to name, i.e. PT60M -> 1h.
+
+        Args:
+            t_res (str): Temporal resolution string as defined in ENTSO-E (i.e. PT60M).
+
+        Returns:
+            Normalized temporal resolution name.
+
+        Raises:
+            DataStructureError: If the resolution format is unknown.
+        """
+        if match := re.search(r"^PT(\d+)M$", t_res):
+            minutes = int(match.group(1))
+            return "1h" if minutes == 60 else f"{minutes}min"
+
+        raise DataStructureError(f"Unknown ENTSO-E temporal resolution '{t_res}'")

--- a/rbc/energy/entsoe/downloader.py
+++ b/rbc/energy/entsoe/downloader.py
@@ -19,6 +19,8 @@ from rbc.energy.utils import (
     DataStructureError,
     DownloadKey,
     EnergyDownloader,
+    InvalidError,
+    MissingDataError,
     write_df_to_csv,
 )
 
@@ -61,14 +63,14 @@ class EntsoeDownloader(EnergyDownloader):
             or start from scratch (False). Defaults to True.
 
         Raises:
-            ValueError: If bidding zone is unsupported or token is invalid.
+            InvalidError: If bidding zone is unsupported or token is invalid.
         """
         super().__init__(output_path=output_path, years=years, resume=resume)
         self.bidding_zones = list(bidding_zones)
 
         for bz in self.bidding_zones:
             if bz not in list(mappings.keys()):
-                raise ValueError(f"Bidding zone '{bz}' is not supported.")
+                raise InvalidError(f"Bidding zone '{bz}' is not supported.")
 
         logger.info(
             f"Entsoe-E Downloader initialized for:"
@@ -78,7 +80,7 @@ class EntsoeDownloader(EnergyDownloader):
 
         set_config(security_token=token)
         if get_config().security_token is None:
-            raise ValueError(
+            raise InvalidError(
                 f"Entsoe-apy failed to successfully configure token '{token}'!"
             )
 
@@ -116,7 +118,7 @@ class EntsoeDownloader(EnergyDownloader):
         Raises:
             ConnectionError: If Entso-E TP is unavailable or the API did not
             return the requested data (this will cause a retry on the next resume).
-            ValueError: If no data is available for the given task (this will cause
+            MissingDataError: If no data is available for the given task (this will cause
             the task to be skipped in future).
             DataStructureError: If data structure has changed and relevant columns
             are missing (this will cause the entire run to be killed).
@@ -142,7 +144,7 @@ class EntsoeDownloader(EnergyDownloader):
             raise ConnectionError(f"API call did not return requested data for {task}!")
 
         if not result:
-            raise ValueError(
+            raise MissingDataError(
                 f"No data available for {task}! Setting download status to 1."
             )
 
@@ -182,12 +184,12 @@ class EntsoeDownloader(EnergyDownloader):
             DataStructureError: If columns are missing temporal resolution values
         """
         df_full = df.dropna(subset=["Temporal_Resolution"])
-        if df.all().all() != df_full.all().all():
+        if len(df_full) != len(df):
             logger.warning(
-                "Some rows are missing temporal resolution values! Skipping."
+                "Some rows are missing temporal resolution values! Removing those rows."
             )
 
-        for t_res, df_t_res in df.groupby("Temporal_Resolution", sort=True):
+        for t_res, df_t_res in df_full.groupby("Temporal_Resolution", sort=True):
             updated_task = task.update(
                 temporal_resolution=self._normalize_temporal_resolution(str(t_res))
             )

--- a/rbc/energy/entsoe/mappings.py
+++ b/rbc/energy/entsoe/mappings.py
@@ -1,0 +1,82 @@
+"""ENTSOE-E MAPPINGS.
+
+Mappings of relevant ENTSO-E bidding zones (EIC codes) that return generation data per unit.
+"""
+
+ACTIVE_ZONES_METADATA: dict[str, dict[str, int | str]] = {
+    "10Y1001A1001A016": {
+        "name": "NIE / SEM(SONI)",
+        "alias": "Northern Ireland / SEM(SONI)",
+        "start": 2015,
+        "end": 2025,
+    },
+    "10Y1001A1001A39I": {"name": "EE", "alias": "Estonia", "start": 2015},
+    "10Y1001A1001A796": {"name": "DK", "alias": "Denmark", "start": 2015},
+    "10Y1001A1001A990": {"name": "MD", "alias": "Moldova", "start": 2020},
+    "10Y1001A1001B012": {"name": "GE", "alias": "Georgia", "start": 2021},
+    "10Y1001C--00100H": {"name": "XK", "alias": "Kosovo", "start": 2021},
+    "10YAL-KESH-----5": {"name": "AL", "alias": "Albania", "start": 2024},
+    "10YAT-APG------L": {"name": "AT", "alias": "Austria", "start": 2015},
+    "10YBA-JPCC-----D": {
+        "name": "BA",
+        "alias": "Bosnia and Herzegovina",
+        "start": 2017,
+    },
+    "10YBE----------2": {"name": "BE", "alias": "Belgium", "start": 2015},
+    "10YCA-BULGARIA-R": {"name": "BG", "alias": "Bulgaria", "start": 2015},
+    "10YCH-SWISSGRIDZ": {"name": "CH", "alias": "Switzerland", "start": 2015},
+    "10YCS-CG-TSO---S": {"name": "ME", "alias": "Montenegro", "start": 2015},
+    "10YCS-SERBIATSOV": {"name": "RS", "alias": "Serbia", "start": 2022, "end": 2025},
+    "10YCZ-CEPS-----N": {"name": "CZ", "alias": "Czech Republic", "start": 2015},
+    "10YDE-ENBW-----N": {
+        "name": "DE(TransnetBW)",
+        "alias": "Germany (TransnetBW)",
+        "start": 2015,
+    },
+    "10YDE-EON------1": {
+        "name": "DE(TenneT GER)",
+        "alias": "Germany (TenneT)",
+        "start": 2015,
+    },
+    "10YDE-RWENET---I": {
+        "name": "DE(Amprion)",
+        "alias": "Germany (Amprion)",
+        "start": 2015,
+    },
+    "10YDE-VE-------2": {
+        "name": "DE(50Hertz) / DE(50HzT)",
+        "alias": "Germany (50Hertz)",
+        "start": 2015,
+    },
+    "10YES-REE------0": {"name": "ES", "alias": "Spain", "start": 2014},
+    "10YFI-1--------U": {"name": "FI", "alias": "Finland", "start": 2015},
+    "10YFR-RTE------C": {"name": "FR", "alias": "France", "start": 2014},
+    "10YGB----------A": {
+        "name": "GB / National Grid",
+        "alias": "Great Britain / National Grid",
+        "start": 2015,
+        "end": 2021,
+    },
+    "10YGR-HTSO-----Y": {"name": "GR", "alias": "Greece", "start": 2015},
+    "10YHU-MAVIR----U": {"name": "HU", "alias": "Hungary", "start": 2015},
+    "10YIE-1001A00010": {
+        "name": "IE / SEM(EirGrid)",
+        "alias": "Ireland / SEM(EirGrid)",
+        "start": 2015,
+    },
+    "10YIT-GRTN-----B": {"name": "IT", "alias": "Italy", "start": 2015},
+    "10YLT-1001A0008Q": {"name": "LT", "alias": "Lithuania", "start": 2015},
+    "10YLV-1001A00074": {"name": "LV", "alias": "Latvia", "start": 2015},
+    "10YMK-MEPSO----8": {"name": "MK", "alias": "North Macedonia", "start": 2018},
+    "10YNL----------L": {"name": "NL", "alias": "Netherlands", "start": 2015},
+    "10YNO-0--------C": {"name": "NO", "alias": "Norway", "start": 2020},
+    "10YPL-AREA-----S": {"name": "PL", "alias": "Poland", "start": 2015},
+    "10YPT-REN------W": {"name": "PT", "alias": "Portugal", "start": 2014},
+    "10YRO-TEL------P": {"name": "RO", "alias": "Romania", "start": 2015},
+    "10YSE-1--------K": {"name": "SE", "alias": "Sweden", "start": 2014},
+    "10YSI-ELES-----O": {"name": "SI", "alias": "Slovenia", "start": 2015},
+    "10YSK-SEPS-----K": {"name": "SK", "alias": "Slovakia", "start": 2015},
+}
+
+ACTIVE_ZONES = list(ACTIVE_ZONES_METADATA.keys())
+MIN_YEAR = min([int(v["start"]) for v in ACTIVE_ZONES_METADATA.values()])

--- a/rbc/energy/epias/downloader.py
+++ b/rbc/energy/epias/downloader.py
@@ -14,19 +14,41 @@ from loguru import logger
 
 from rbc.energy.utils import (
     WORKERS,
+    DataStructureError,
     DownloadTask,
     EnergyDownloader,
     InvalidError,
     MissingDataError,
 )
 
+EXPECTED_COLS = [
+    "date",
+    "hour",
+    "total",
+    "powerPlantName",
+    "naturalGas",
+    "dammedHydro",
+    "lignite",
+    "river",
+    "importCoal",
+    "wind",
+    "sun",
+    "fueloil",
+    "geothermal",
+    "asphaltiteCoal",
+    "blackCoal",
+    "biomass",
+    "naphta",
+    "lng",
+    "importExport",
+    "wasteheat",
+]
+
 
 class EpiasDownloader(EnergyDownloader):
     """EPIAS data downloader.
 
     Attributes:
-        checkpoint_path (Path): Path to the checkpoint file for resuming.
-        checkpoint (dict): Dict of 0 and 1 values for resuming.
         eptr (EPTR2): EPTR2 object for EPIAS data access.
     """
 
@@ -81,6 +103,8 @@ class EpiasDownloader(EnergyDownloader):
 
         Raises:
             MissingDataError: If no power plant or generation data is available.
+            DataStructureError: If the data structure changed and relevant columns are now
+                missing (this will cause the entire run to be killed).
         """
         # get power-plants   # ['id', 'name', 'eic', 'shortName']
         start = task.date
@@ -101,5 +125,12 @@ class EpiasDownloader(EnergyDownloader):
         df_gen = pd.concat(gen_data)
         if df_gen.empty:
             raise MissingDataError("No energy generation data available! Skipping...")
+
+        missing_cols = [c for c in EXPECTED_COLS if c not in df_gen.columns]
+        if missing_cols:
+            raise DataStructureError(
+                f"EPIAS structure change detected for '{task.identifier}'! "
+                f"Missing columns: {missing_cols}"
+            )
 
         return df_gen

--- a/rbc/energy/epias/downloader.py
+++ b/rbc/energy/epias/downloader.py
@@ -14,7 +14,7 @@ from loguru import logger
 
 from rbc.energy.utils import (
     WORKERS,
-    DownloadKey,
+    DownloadTask,
     EnergyDownloader,
     InvalidError,
     MissingDataError,
@@ -52,8 +52,6 @@ class EpiasDownloader(EnergyDownloader):
             InvalidError: If login credentials are incorrect.
         """
         super().__init__(output_path=output_path, years=years, resume=resume)
-        self.checkpoint_path = Path(self.output_path, "status.pickle")
-        self.checkpoint = self._load_checkpoint(self.checkpoint_path)
 
         logger.info(f"EPIAS Downloader initialized for:\n- years:\t\t{years}")
 
@@ -64,22 +62,19 @@ class EpiasDownloader(EnergyDownloader):
 
     def download_data(self):
         """Parse data for all given years from EPIAS Platform and save to CSV."""
-        tasks = [DownloadKey(date=d) for d in self._get_date_list()]
+        tasks = [DownloadTask(date=d) for d in self._get_date_list()]
 
-        logger.info(f"Downloading data for tasks:\n{tasks[0]} to {tasks[-1]}")
+        logger.info(
+            f"Downloading tasks: {tasks[0].identifier} --- {tasks[-1].identifier}"
+        )
         with ThreadPoolExecutor(max_workers=WORKERS) as executor:
-            executor.map(
-                lambda t: self._threading_wrapper(
-                    t, self.checkpoint, self.checkpoint_path
-                ),
-                tasks,
-            )
+            executor.map(self._threading_wrapper, tasks)
 
-    def _get_task_data(self, task: DownloadKey) -> pd.DataFrame:  # type: ignore[override]
+    def _get_task_data(self, task: DownloadTask) -> pd.DataFrame:  # type: ignore[override]
         """Get EPIAS generation data per plant for one specific date.
 
         Args:
-            task (DownloadKey): The metadata of a downloading task, here: date (YYYY-MM-DD)
+            task (DownloadTask): The metadata of a downloading task, here: date (YYYY-MM-DD)
 
         Returns:
             pd.DataFrame: Dataframe for specific date.
@@ -87,14 +82,12 @@ class EpiasDownloader(EnergyDownloader):
         Raises:
             MissingDataError: If no power plant or generation data is available.
         """
-        task.validate_required_fields("date")
-
         # get power-plants   # ['id', 'name', 'eic', 'shortName']
         start = task.date
         end = (pd.Timestamp(start) + pd.Timedelta(days=1)).strftime("%Y-%m-%d")
         df_pp = self.eptr.call("pp-list-for-date-range", start_date=start, end_date=end)
         if df_pp.empty:
-            raise MissingDataError(f"No power plant data available for {task}!")
+            raise MissingDataError("No power plant data available! Skipping...")
 
         # get generation data in batches
         num_batches = math.ceil(len(df_pp) / 1000)  # max allowed batch size = 1000
@@ -107,6 +100,6 @@ class EpiasDownloader(EnergyDownloader):
 
         df_gen = pd.concat(gen_data)
         if df_gen.empty:
-            raise MissingDataError(f"No generation data available for {task}!")
+            raise MissingDataError("No energy generation data available! Skipping...")
 
         return df_gen

--- a/rbc/energy/epias/downloader.py
+++ b/rbc/energy/epias/downloader.py
@@ -12,7 +12,13 @@ import pandas as pd
 from eptr2 import EPTR2
 from loguru import logger
 
-from rbc.energy.utils import WORKERS, DownloadKey, EnergyDownloader
+from rbc.energy.utils import (
+    WORKERS,
+    DownloadKey,
+    EnergyDownloader,
+    InvalidError,
+    MissingDataError,
+)
 
 
 class EpiasDownloader(EnergyDownloader):
@@ -40,10 +46,10 @@ class EpiasDownloader(EnergyDownloader):
             output_path (Path): Path to the output directory.
             years (list[int]): List of years to get data for.
             resume (bool, optional): Whether to resume from a previous download (True)
-            or start from scratch (False). Defaults to True.
+                or start from scratch (False). Defaults to True.
 
         Raises:
-            ValueError: If login credentials are incorrect.
+            InvalidError: If login credentials are incorrect.
         """
         super().__init__(output_path=output_path, years=years, resume=resume)
         self.checkpoint_path = Path(self.output_path, "status.pickle")
@@ -54,7 +60,7 @@ class EpiasDownloader(EnergyDownloader):
         try:
             self.eptr = EPTR2(username=username, password=password)
         except Exception:
-            raise ValueError("Provided username and password are incorrect.")
+            raise InvalidError("Provided username and password are incorrect.")
 
     def download_data(self):
         """Parse data for all given years from EPIAS Platform and save to CSV."""
@@ -79,7 +85,7 @@ class EpiasDownloader(EnergyDownloader):
             pd.DataFrame: Dataframe for specific date.
 
         Raises:
-            ValueError: If no power plant or generation data is available.
+            MissingDataError: If no power plant or generation data is available.
         """
         task.validate_required_fields("date")
 
@@ -88,7 +94,7 @@ class EpiasDownloader(EnergyDownloader):
         end = (pd.Timestamp(start) + pd.Timedelta(days=1)).strftime("%Y-%m-%d")
         df_pp = self.eptr.call("pp-list-for-date-range", start_date=start, end_date=end)
         if df_pp.empty:
-            raise ValueError(f"No power plant data available for {task}!")
+            raise MissingDataError(f"No power plant data available for {task}!")
 
         # get generation data in batches
         num_batches = math.ceil(len(df_pp) / 1000)  # max allowed batch size = 1000
@@ -101,6 +107,6 @@ class EpiasDownloader(EnergyDownloader):
 
         df_gen = pd.concat(gen_data)
         if df_gen.empty:
-            raise ValueError(f"No generation data available for {task}!")
+            raise MissingDataError(f"No generation data available for {task}!")
 
         return df_gen

--- a/rbc/energy/epias/downloader.py
+++ b/rbc/energy/epias/downloader.py
@@ -12,7 +12,7 @@ import pandas as pd
 from eptr2 import EPTR2
 from loguru import logger
 
-from rbc.energy.utils import WORKERS, EnergyDownloader
+from rbc.energy.utils import WORKERS, DownloadKey, EnergyDownloader
 
 
 class EpiasDownloader(EnergyDownloader):
@@ -58,22 +58,22 @@ class EpiasDownloader(EnergyDownloader):
 
     def download_data(self):
         """Parse data for all given years from EPIAS Platform and save to CSV."""
-        all_dates = self._get_date_list()
+        tasks = [DownloadKey(date=d) for d in self._get_date_list()]
 
-        logger.info(f"Downloading data for: {all_dates[0]} to {all_dates[-1]}")
+        logger.info(f"Downloading data for tasks:\n{tasks[0]} to {tasks[-1]}")
         with ThreadPoolExecutor(max_workers=WORKERS) as executor:
             executor.map(
                 lambda t: self._threading_wrapper(
                     t, self.checkpoint, self.checkpoint_path
                 ),
-                all_dates,
+                tasks,
             )
 
-    def _get_task_data(self, task: str) -> pd.DataFrame:  # type: ignore[override]
+    def _get_task_data(self, task: DownloadKey) -> pd.DataFrame:  # type: ignore[override]
         """Get EPIAS generation data per plant for one specific date.
 
         Args:
-            task (str): Date to get data for.
+            task (DownloadKey): The metadata of a downloading task, here: date (YYYY-MM-DD)
 
         Returns:
             pd.DataFrame: Dataframe for specific date.
@@ -81,8 +81,10 @@ class EpiasDownloader(EnergyDownloader):
         Raises:
             ValueError: If no power plant or generation data is available.
         """
+        task.validate_required_fields("date")
+
         # get power-plants   # ['id', 'name', 'eic', 'shortName']
-        start = task
+        start = task.date
         end = (pd.Timestamp(start) + pd.Timedelta(days=1)).strftime("%Y-%m-%d")
         df_pp = self.eptr.call("pp-list-for-date-range", start_date=start, end_date=end)
         if df_pp.empty:
@@ -93,7 +95,8 @@ class EpiasDownloader(EnergyDownloader):
         batches = np.array_split(df_pp["id"].values, num_batches)
 
         gen_data = [
-            self.eptr.call("rt-gen-bulk", date=task, pp_ids=b.tolist()) for b in batches
+            self.eptr.call("rt-gen-bulk", date=task.date, pp_ids=b.tolist())
+            for b in batches
         ]
 
         df_gen = pd.concat(gen_data)

--- a/rbc/energy/ieso/downloader.py
+++ b/rbc/energy/ieso/downloader.py
@@ -15,7 +15,7 @@ from loguru import logger
 from rbc.energy.utils import (
     WORKERS,
     DataStructureError,
-    DownloadKey,
+    DownloadTask,
     EnergyDownloader,
     MissingDataError,
     load_df_from_file,
@@ -55,8 +55,6 @@ class IesoDownloader(EnergyDownloader):
             ConnectionError: If the base URLs aren't reachable.
         """
         super().__init__(output_path=output_path, years=years, resume=resume)
-        self.checkpoint_path = Path(self.output_path, "status.pickle")
-        self.checkpoint = self._load_checkpoint(self.checkpoint_path)
         self._download_lock = threading.Lock()
 
         logger.info(f"IESO Downloader initialized for:\n- years:\t\t{years}")
@@ -71,18 +69,15 @@ class IesoDownloader(EnergyDownloader):
 
     def download_data(self) -> None:
         """Parse data for all given years from IESO site and save to CSV."""
-        tasks = [DownloadKey(date=d) for d in self._get_month_list()]
+        tasks = [DownloadTask(date=d) for d in self._get_month_list()]
 
-        logger.info(f"Downloading data for tasks:\n{tasks[0]} to {tasks[-1]}")
+        logger.info(
+            f"Downloading tasks: {tasks[0].identifier} --- {tasks[-1].identifier}"
+        )
         with ThreadPoolExecutor(max_workers=WORKERS) as executor:
-            executor.map(
-                lambda t: self._threading_wrapper(
-                    t, self.checkpoint, self.checkpoint_path
-                ),
-                tasks,
-            )
+            executor.map(self._threading_wrapper, tasks)
 
-    def _get_task_data(self, task: DownloadKey) -> pd.DataFrame:  # type: ignore[override]
+    def _get_task_data(self, task: DownloadTask) -> pd.DataFrame:  # type: ignore[override]
         """Get IESO generation data per plant for one specific month.
 
         IESO's data storing structure and method was changed in April 2019 from
@@ -91,7 +86,7 @@ class IesoDownloader(EnergyDownloader):
         in the newer data and stored per month as well.
 
         Args:
-            task (DownloadKey): The metadata of a downloading task, here: date (YYYY-MM)
+            task (DownloadTask): The metadata of a downloading task, here: date (YYYY-MM)
 
         Returns:
             pd.DataFrame: Dataframe for specific date with the columns
@@ -103,14 +98,14 @@ class IesoDownloader(EnergyDownloader):
                 dataframe is empty.
             DataStructureError: If downloaded data does not have the required columns.
         """
-        task.validate_required_fields("date")
-
         dt = pd.Period(task.date, freq="M")
         year = dt.year
         month = dt.month
 
         if year < 2010:
-            raise MissingDataError(f"No data for year {year}, as it's before 2010")
+            raise MissingDataError(
+                f"No data for year {year} (it's before 2010). Skipping..."
+            )
 
         if year < 2019 or (year == 2019 and month <= 4):
             df = self._get_from_old_source(year, month)
@@ -118,11 +113,13 @@ class IesoDownloader(EnergyDownloader):
             df = self._get_from_new_source(year, month)
 
         if df.empty:
-            raise MissingDataError(f"No generation data available for {year}-{month}")
+            raise MissingDataError(
+                f"No energy generation data available for {year}-{month}. Skipping..."
+            )
 
         if not all(col in df.columns for col in EXPECTED_COLS):
             raise DataStructureError(
-                f"IESO file structure change detected for task: '{task}'! "
+                f"IESO file structure change detected for '{task.identifier}'! "
                 f"Missing columns: {[c for c in EXPECTED_COLS if c not in df.columns]}"
             )
 
@@ -150,7 +147,7 @@ class IesoDownloader(EnergyDownloader):
             df = df[df["Measurement"] != "Forecast"]
         except KeyError:
             raise DataStructureError(
-                f"IESO file structure change detected in new csv: '{url}'! "
+                f"IESO file structure change detected in new csv '{url}'! "
                 f"'Measurement' column is missing!"
             )
         return df
@@ -181,7 +178,7 @@ class IesoDownloader(EnergyDownloader):
             )
         except AttributeError as e:
             raise DataStructureError(
-                f"IESO file structure change detected in old excel: '{url}'! "
+                f"IESO file structure change detected in old excel '{url}'! "
                 f"'Delivery Date' is no longer datetimelike: {e}"
             )
 
@@ -221,7 +218,7 @@ class IesoDownloader(EnergyDownloader):
 
         if df_cap is None:
             raise DataStructureError(
-                f"IESO file structure change detected in old excel: '{url}'! "
+                f"IESO file structure change detected in old excel '{url}'! "
                 f"No valid capacity sheets found!"
             )
 

--- a/rbc/energy/ieso/downloader.py
+++ b/rbc/energy/ieso/downloader.py
@@ -17,6 +17,7 @@ from rbc.energy.utils import (
     DataStructureError,
     DownloadKey,
     EnergyDownloader,
+    MissingDataError,
     load_df_from_file,
 )
 
@@ -48,7 +49,7 @@ class IesoDownloader(EnergyDownloader):
             output_path (Path): Path to the output directory.
             years (list[int]): List of years to get data for.
             resume (bool, optional): Whether to resume from a previous download (True)
-            or start from scratch (False). Defaults to True.
+                or start from scratch (False). Defaults to True.
 
         Raises:
             ConnectionError: If the base URLs aren't reachable.
@@ -98,8 +99,8 @@ class IesoDownloader(EnergyDownloader):
             'Hour 1', 'Hour 2', 'Hour 3', ..., 'Hour 23', 'Hour 24']
 
         Raises:
-            ValueError: If an earlier year was provided than data exists for or if the
-            dataframe is empty.
+            MissingDataError: If an earlier year was provided than data exists for or if the
+                dataframe is empty.
             DataStructureError: If downloaded data does not have the required columns.
         """
         task.validate_required_fields("date")
@@ -109,7 +110,7 @@ class IesoDownloader(EnergyDownloader):
         month = dt.month
 
         if year < 2010:
-            raise ValueError(f"No data for year {year}, as it's before 2010")
+            raise MissingDataError(f"No data for year {year}, as it's before 2010")
 
         if year < 2019 or (year == 2019 and month <= 4):
             df = self._get_from_old_source(year, month)
@@ -117,7 +118,7 @@ class IesoDownloader(EnergyDownloader):
             df = self._get_from_new_source(year, month)
 
         if df.empty:
-            raise ValueError(f"No generation data available for {year}-{month}")
+            raise MissingDataError(f"No generation data available for {year}-{month}")
 
         if not all(col in df.columns for col in EXPECTED_COLS):
             raise DataStructureError(

--- a/rbc/energy/ieso/downloader.py
+++ b/rbc/energy/ieso/downloader.py
@@ -32,8 +32,6 @@ class IesoDownloader(EnergyDownloader):
     """IESO data downloader.
 
     Attributes:
-        checkpoint_path (Path): Path to the checkpoint file for resuming.
-        checkpoint (dict): Dict of 0 and 1 values for resuming.
         _download_lock (threading.Lock): Lock for downloading yearly data once.
     """
 
@@ -96,7 +94,8 @@ class IesoDownloader(EnergyDownloader):
         Raises:
             MissingDataError: If an earlier year was provided than data exists for or if the
                 dataframe is empty.
-            DataStructureError: If downloaded data does not have the required columns.
+            DataStructureError: If the data structure changed and relevant columns are now
+                missing (this will cause the entire run to be killed).
         """
         dt = pd.Period(task.date, freq="M")
         year = dt.year
@@ -117,10 +116,11 @@ class IesoDownloader(EnergyDownloader):
                 f"No energy generation data available for {year}-{month}. Skipping..."
             )
 
-        if not all(col in df.columns for col in EXPECTED_COLS):
+        missing_cols = [c for c in EXPECTED_COLS if c not in df.columns]
+        if missing_cols:
             raise DataStructureError(
                 f"IESO file structure change detected for '{task.identifier}'! "
-                f"Missing columns: {[c for c in EXPECTED_COLS if c not in df.columns]}"
+                f"Missing columns: {missing_cols}"
             )
 
         return df

--- a/rbc/energy/ieso/downloader.py
+++ b/rbc/energy/ieso/downloader.py
@@ -15,6 +15,7 @@ from loguru import logger
 from rbc.energy.utils import (
     WORKERS,
     DataStructureError,
+    DownloadKey,
     EnergyDownloader,
     load_df_from_file,
 )
@@ -69,18 +70,18 @@ class IesoDownloader(EnergyDownloader):
 
     def download_data(self) -> None:
         """Parse data for all given years from IESO site and save to CSV."""
-        all_months = self._get_month_list()
+        tasks = [DownloadKey(date=d) for d in self._get_month_list()]
 
-        logger.info(f"Downloading data for: {all_months[0]} to {all_months[-1]}")
+        logger.info(f"Downloading data for tasks:\n{tasks[0]} to {tasks[-1]}")
         with ThreadPoolExecutor(max_workers=WORKERS) as executor:
             executor.map(
                 lambda t: self._threading_wrapper(
                     t, self.checkpoint, self.checkpoint_path
                 ),
-                all_months,
+                tasks,
             )
 
-    def _get_task_data(self, task: str) -> pd.DataFrame:  # type: ignore[override]
+    def _get_task_data(self, task: DownloadKey) -> pd.DataFrame:  # type: ignore[override]
         """Get IESO generation data per plant for one specific month.
 
         IESO's data storing structure and method was changed in April 2019 from
@@ -89,7 +90,7 @@ class IesoDownloader(EnergyDownloader):
         in the newer data and stored per month as well.
 
         Args:
-            task (str): Month to get data for.
+            task (DownloadKey): The metadata of a downloading task, here: date (YYYY-MM)
 
         Returns:
             pd.DataFrame: Dataframe for specific date with the columns
@@ -101,8 +102,11 @@ class IesoDownloader(EnergyDownloader):
             dataframe is empty.
             DataStructureError: If downloaded data does not have the required columns.
         """
-        year = int(task[:4])
-        month = int(task[5:7])
+        task.validate_required_fields("date")
+
+        dt = pd.Period(task.date, freq="M")
+        year = dt.year
+        month = dt.month
 
         if year < 2010:
             raise ValueError(f"No data for year {year}, as it's before 2010")
@@ -227,6 +231,9 @@ class IesoDownloader(EnergyDownloader):
         df = df.sort_values(by=["Delivery Date", "Generator", "Measurement"])
         return df
 
+    # --------------------------------------------
+    # Helper methods
+    # --------------------------------------------
     @staticmethod
     def standardize_old_data(df: pd.DataFrame, measurement_type: str) -> pd.DataFrame:
         """Standardize old (pre-2019) dataframes to match the newer CSV format.

--- a/rbc/energy/utils.py
+++ b/rbc/energy/utils.py
@@ -101,11 +101,11 @@ class DownloadTask:
                 f"Invalid temporal resolution: '{self.temporal_resolution}'"
             )
 
-    # Validate that the date is actually a valid calendar date
-    try:
-        pd.to_datetime(self.date)
-    except (ValueError, TypeError):
-        raise ValueError(f"Invalid calendar date: '{self.date}'")
+        # check that date is actually a valid calendar date
+        try:
+            pd.to_datetime(self.date)
+        except (ValueError, TypeError):
+            raise ValueError(f"Invalid calendar date: '{self.date}'")
 
     @property
     def identifier(self) -> str:

--- a/rbc/energy/utils.py
+++ b/rbc/energy/utils.py
@@ -93,19 +93,19 @@ class DownloadTask:
         Raises:
             ValueError: If provided date or temporal resolution are in the wrong format.
         """
+        # check that date matches pattern and is a valid calendar date
         if not self._DATE_PATTERN.match(self.date):
             raise ValueError(f"Invalid date / date format: '{self.date}'")
-
-        if not self._TRES_PATTERN.match(self.temporal_resolution):
-            raise ValueError(
-                f"Invalid temporal resolution: '{self.temporal_resolution}'"
-            )
-
-        # check that date is actually a valid calendar date
         try:
             pd.to_datetime(self.date)
         except (ValueError, TypeError):
             raise ValueError(f"Invalid calendar date: '{self.date}'")
+
+        # check that temporal resolution matches pattern
+        if not self._TRES_PATTERN.match(self.temporal_resolution):
+            raise ValueError(
+                f"Invalid temporal resolution: '{self.temporal_resolution}'"
+            )
 
     @property
     def identifier(self) -> str:

--- a/rbc/energy/utils.py
+++ b/rbc/energy/utils.py
@@ -445,8 +445,8 @@ def write_df_to_csv(df: pd.DataFrame, file_path: Path, index: bool = False) -> N
     Args:
         df (pd.DataFrame): Pandas dataframe to be stored in csv file.
         file_path (Path): Path to the csv file.
-        index (bool, optional): Whether to include the df index in the
-            csv (True) or not (False). Defaults to False.
+        index (bool, optional): Whether to include the df index in the csv (True) or not
+            (False). Defaults to False.
     """
     if file_path.suffix != ".csv":
         file_path = file_path.with_suffix(".csv")
@@ -469,7 +469,7 @@ def load_df_from_file(file_path: Path | str, **args) -> pd.DataFrame:
 
     Raises:
         InvalidError: If the file doesn't have one of the expected suffixes, if the file
-        doesn't exist, if invalid arguments (args) were provided for loading with pandas.
+            doesn't exist, if invalid arguments (args) were provided for loading with pandas.
         RETRY_ERRORS: If the file is a URL that is inaccessible for some reason.
     """
     try:

--- a/rbc/energy/utils.py
+++ b/rbc/energy/utils.py
@@ -113,6 +113,11 @@ class EnergyDownloader(ABC):
     def _download_task_data(self, task: str | tuple[str, str]) -> int:
         """Parse data for a specific task and dump to CSV.
 
+        Child classes must raise / propagate errors the following errors to be handled here:
+        - DataStructureError / RateLimitError / InvalidError: to immediately kill a run.
+        - ValueError: when data is missing for a specific task.
+        - self.RETRY_ERRORS: when accessing generally fails.
+
         Args:
             task (str | tuple): Date or (zone, date) to download data for.
 
@@ -128,16 +133,22 @@ class EnergyDownloader(ABC):
                 write_df_to_csv(df=df_gen, file_path=file_path)
                 return 1
 
-            # errors that warrant immediate run kill
-            except (DataStructureError, RateLimitError, InvalidError) as e:
+            except (DataStructureError, RateLimitError, InvalidError) as e:  # kill run
                 logger.critical(f"FATAL! Stopping run due to error: {e}")
                 os._exit(1)
 
-            except ValueError as e:
+            except ValueError as e:  # handle missing data for task
                 logger.error(f"Missing data for {task}: {e}")
+
+                date = task[-1] if isinstance(task, tuple) else task
+                year = pd.Timestamp(date).year
+
+                if year == pd.Timestamp.now().year:
+                    return 0  # current year task -> might become available later!
+
                 return 1  # skip task
 
-            except self.RETRY_ERRORS as e:
+            except self.RETRY_ERRORS as e:  # handle access failures
                 code = self._get_status_code(e)
 
                 if code:

--- a/rbc/energy/utils.py
+++ b/rbc/energy/utils.py
@@ -100,6 +100,7 @@ class DownloadTask:
             raise ValueError(
                 f"Invalid temporal resolution: '{self.temporal_resolution}'"
             )
+
     # Validate that the date is actually a valid calendar date
     try:
         pd.to_datetime(self.date)

--- a/rbc/energy/utils.py
+++ b/rbc/energy/utils.py
@@ -66,11 +66,8 @@ class InvalidError(Exception):
 
 
 @dataclass(frozen=True)
-class DownloadKey:
-    """Dataclass for defining downloading metadata for a task or checkpoint grouping.
-
-    A key with a `date` represents one concrete download task.
-    A key without a `date` can be used to define a checkpoint/output grouping.
+class DownloadTask:
+    """Dataclass for defining downloading metadata for a task.
 
     This defines a task's relevant attributes, which in turn is used to build a consistent
     path structure:
@@ -82,7 +79,7 @@ class DownloadKey:
         bidding_zone (str | None): Optional bidding zone of data. Defaults to None.
     """
 
-    date: str | None = None
+    date: str
     temporal_resolution: str = "1h"
     bidding_zone: str | None = None
 
@@ -91,12 +88,12 @@ class DownloadKey:
     _TRES_PATTERN = re.compile(r"^\d+(?:h|min|d)$")
 
     def __post_init__(self) -> None:
-        """Validates the date format if a date is provided.
+        """Validates the date and temporal resolution formats.
 
         Raises:
             ValueError: If provided date or temporal resolution are in the wrong format.
         """
-        if self.date is not None and not self._DATE_PATTERN.match(self.date):
+        if not self._DATE_PATTERN.match(self.date):
             raise ValueError(f"Invalid date / date format: '{self.date}'")
 
         if not self._TRES_PATTERN.match(self.temporal_resolution):
@@ -104,14 +101,30 @@ class DownloadKey:
                 f"Invalid temporal resolution: '{self.temporal_resolution}'"
             )
 
-    def update(self, **changes) -> "DownloadKey":
+    @property
+    def identifier(self) -> str:
+        """A task's unique string representation for checkpointing and logging.
+
+        Returns:
+            str: Unique string 'date=YYYY-MM(-DD)|temporal_resolution=1h(|bidding_zone=<bz>)'
+        """
+        parts = [
+            f"date={self.date}",
+            f"temporal_resolution={self.temporal_resolution}",
+        ]
+        if self.bidding_zone:
+            parts.append(f"bidding_zone={self.bidding_zone}")
+
+        return "|".join(parts)
+
+    def update(self, **changes) -> "DownloadTask":
         """Update a key with provided changes.
 
         Args:
             changes: Dictionary of changes to make to the DownloadKey instance.
 
         Returns:
-            DownloadKey: Updated download task instance.
+            DownloadTask: Updated download task instance.
         """
         return replace(self, **changes)
 
@@ -136,12 +149,14 @@ class EnergyDownloader(ABC):
     """Abstract base class for parallelized daily energy downloader classes.
 
     Attributes:
+        RETRY_ERRORS (tuple): Tuple of exceptions that may be raised when retrying calls.
         output_path (Path): Path to the output directory.
         years (list[int]): List of years to get data for.
         resume (bool, optional): Whether to resume from a previous download (True) or
-        start from scratch (False). Defaults to True.
+            start from scratch (False). Defaults to True.
         _lock (threading.Lock): Threading lock to ensure thread-safe checkpoint updates.
-        RETRY_ERRORS (tuple): Tuple of exceptions that may be raised when retrying calls.
+        checkpoint_path (Path): Path to the checkpoint file for resuming.
+        checkpoint (dict): Dict of 0 and 1 values for resuming.
     """
 
     RETRY_ERRORS = RETRY_ERRORS
@@ -153,40 +168,40 @@ class EnergyDownloader(ABC):
             output_path (Path): Path to the output directory.
             years (list[int]): List of years to get data for.
             resume (bool, optional): Whether to resume from a previous download (True)
-            or start from scratch (False). Defaults to True.
+                or start from scratch (False). Defaults to True.
         """
         self.output_path = output_path
         self.years = years
         self.resume = resume
         self._lock = threading.Lock()
 
-    def _threading_wrapper(
-        self, task: DownloadKey, checkpoint: dict[str, int], checkpoint_path: Path
-    ) -> None:
+        self.checkpoint_path = Path(self.output_path, "status.pickle")
+        self.checkpoint = self._load_checkpoint()
+
+    def _threading_wrapper(self, task: DownloadTask) -> None:
         """Thread-safe wrapper for one download task (download and checkpoint reading/saving).
 
         Args:
-            task (DownloadKey): The metadata for a task to download data for.
-            checkpoint (dict): Dict of 0 and 1 values for resuming.
-            checkpoint_path (Path): Path to the checkpoint file for resuming.
+            task (DownloadTask): The metadata for a task to download data for.
         """
-        ckpt_key = self._turn_task_into_checkpoint_key(task)
         with self._lock:
-            if checkpoint.get(ckpt_key) == 1:
-                logger.info(f"{task}: Data already downloaded. Skipping.")
+            if self.checkpoint.get(task.identifier) == 1:
+                logger.info(
+                    f"Task '{task.identifier}': Data already downloaded. Skipping."
+                )
                 return
 
         try:
             status = self._download_task_data(task=task)
         except Exception as e:
-            logger.error(f"Unexpected error in thread for {task}: {e}")
+            logger.error(f"Unexpected error in thread for {task.identifier}: {e}")
             status = 0
 
         with self._lock:
-            checkpoint[ckpt_key] = status
-            self._save_checkpoint(checkpoint, checkpoint_path)
+            self.checkpoint[task.identifier] = status
+            self._save_checkpoint()
 
-    def _download_task_data(self, task: DownloadKey) -> int:
+    def _download_task_data(self, task: DownloadTask) -> int:
         """Parse data for a specific task and dump to CSV.
 
         Child classes must raise / propagate errors the following errors to be handled here:
@@ -195,7 +210,7 @@ class EnergyDownloader(ABC):
         - self.RETRY_ERRORS: when accessing generally fails.
 
         Args:
-            task (DownloadKey): The metadata for a task to download data for.
+            task (DownloadTask): The metadata for a task to download data for.
 
         Returns:
             int: Status of the download (1 if successful, 0 if unsuccessful).
@@ -211,7 +226,7 @@ class EnergyDownloader(ABC):
                 os._exit(1)
 
             except MissingDataError as e:  # handle missing data for task
-                logger.error(f"Missing data for {task}: {e}")
+                logger.error(f"Missing data for task '{task.identifier}': {e}")
 
                 task.validate_required_fields("date")
                 if pd.Timestamp(task.date).year == pd.Timestamp.now().year:
@@ -226,106 +241,68 @@ class EnergyDownloader(ABC):
                     # 1. permanent missing data
                     if code == 404:
                         logger.warning(
-                            f"Data for task {task} not found (404). Skipping."
+                            f"Data for task '{task.identifier}' not found (404). Skipping."
                         )
                         return 1
                     # 2. permanent client errors (400-499, except rate limits 429)
                     if 400 <= code < 500 and code != 429:
-                        logger.error(f"Permanent error {code} for {task}. Skipping.")
+                        logger.error(
+                            f"Permanent error {code} for task '{task.identifier}'. Skipping."
+                        )
                         return 1
 
                 # 3. everything else (500s, Timeouts, 429s) -> Retry
                 if attempt < MAX_RETRIES:
                     time.sleep(RETRY_DELAY)
                 else:
-                    logger.critical(f"Failed {task} after {MAX_RETRIES} attempts: {e}")
+                    logger.critical(
+                        f"Failed task '{task.identifier}' after {MAX_RETRIES} attempts: {e}"
+                    )
                     return 0
 
         return 1  # pragma: no cover
 
     @abstractmethod
-    def _get_task_data(self, task: DownloadKey) -> pd.DataFrame:
+    def _get_task_data(self, task: DownloadTask) -> pd.DataFrame:
         """Method to get the task's data (child classes MUST implement/overwrite this!).
 
         Args:
-            task (DownloadKey): The metadata for a task to download data for.
+            task (DownloadTask): The metadata for a task to download data for.
 
         Returns:
             DataFrame: The task's downloaded data (child classes MUST implement this!).
         """
 
-    def _save_task_data(self, task: DownloadKey, df: pd.DataFrame) -> None:
+    def _save_task_data(self, task: DownloadTask, df: pd.DataFrame) -> None:
         """Save downloaded task data to disk.
 
         Functionality is separated here to allow child classes to overwrite (i.e. Entso-e).
 
         Args:
-            task (DownloadKey): The metadata for the task that was downloaded.
+            task (DownloadTask): The metadata for the task that was downloaded.
             df (pd.DataFrame): Downloaded dataframe for the task.
         """
         file_path = self._build_task_path(task)
         write_df_to_csv(df=df, file_path=file_path)
 
     # ------------------------------------------------------------------
-    # Path definition and checkpoint helpers (using DownloadKey)
+    # Path definition and checkpoint helpers (using DownloadTask)
     # ------------------------------------------------------------------
-    @staticmethod
-    def _turn_task_into_checkpoint_key(task: DownloadKey) -> str:
-        """Convert a task to a string key for checkpointing.
-
-        Args:
-            task (DownloadKey): The metadata for a task to download data for.
-
-        Returns:
-            str: String to use as key in checkpointing dict.
-        """
-        parts = [
-            f"date={task.date}" if task.date else None,
-            f"temporal_res={task.temporal_resolution}"
-            if task.temporal_resolution
-            else None,
-            f"bidding_zone={task.bidding_zone}" if task.bidding_zone else None,
-        ]
-        return "|".join(p for p in parts if p is not None)
-
-    def _build_checkpoint_path(self, task: DownloadKey) -> Path:
-        """Return checkpoint path for a task grouping.
-
-        By default, checkpoints are stored per temporal resolution and optional zone.
-        The structure for the path is:
-        <output_path>/<temporal_resolution>/<optional...>/<optional bz>/status.pickle
-
-        Args:
-            task (DownloadKey): The metadata for a task grouping without a 'date'.
-
-        Returns:
-            Path: Path to the checkpoint file.
-        """
-        parts: list[str | Path] = [self.output_path, task.temporal_resolution]
-
-        if task.bidding_zone:
-            parts.append(task.bidding_zone)
-
-        return Path(*parts, "status.pickle")
-
-    def _load_checkpoint(self, checkpoint_path: Path) -> dict[str, int]:
+    def _load_checkpoint(self) -> dict[str, int]:
         """Load checkpoint from checkpoint path depending on resume logic.
-
-        Args:
-            checkpoint_path (Path): Path to checkpoint file.
 
         Returns:
             dict: Loaded checkpoint.
         """
-        if self.resume and checkpoint_path.is_file():
-            logger.info(f"Loading checkpoint from '{checkpoint_path}'")
+        if self.resume and self.checkpoint_path.is_file():
+            logger.info(f"Loading checkpoint from '{self.checkpoint_path}'")
 
             try:
-                with open(checkpoint_path, "rb") as f:
+                with open(self.checkpoint_path, "rb") as f:
                     return pickle.load(f)
             except (EOFError, pickle.UnpicklingError):
                 logger.warning(
-                    f"Checkpoint '{checkpoint_path}' is corrupted. Starting fresh."
+                    f"Checkpoint '{self.checkpoint_path}' is corrupted. Starting fresh."
                 )
                 return {}
         else:
@@ -334,33 +311,26 @@ class EnergyDownloader(ABC):
             )
             return {}
 
-    @staticmethod
-    def _save_checkpoint(checkpoint: dict[str, int], checkpoint_path: Path) -> None:
-        """Save checkpoint safely (ensure abrupt terminations don't corrupt the file).
-
-        Args:
-            checkpoint (dict): Checkpoint to be saved.
-            checkpoint_path (Path): Path to checkpoint file.
-        """
-        checkpoint_path.parent.mkdir(parents=True, exist_ok=True)
-        temp_path = checkpoint_path.with_suffix(".tmp")
+    def _save_checkpoint(self) -> None:
+        """Save checkpoint safely (ensure abrupt terminations don't corrupt the file)."""
+        self.checkpoint_path.parent.mkdir(parents=True, exist_ok=True)
+        temp_path = self.checkpoint_path.with_suffix(".tmp")
         with open(temp_path, "wb") as f:
-            pickle.dump(checkpoint, f)
-        os.replace(temp_path, checkpoint_path)
+            pickle.dump(self.checkpoint, f)
+        os.replace(temp_path, self.checkpoint_path)
 
-    def _build_task_path(self, task: DownloadKey) -> Path:
+    def _build_task_path(self, task: DownloadTask) -> Path:
         """Build the CSV file path to which the downloaded task data will be saved.
 
         Designed structure:
         <output_path>/<temporal_resolution>/<optional ...>/<optional bz>/<date>.csv
 
         Args:
-            task (DownloadKey): The metadata for a task to download data for.
+            task (DownloadTask): The metadata for a task to download data for.
 
         Returns:
             Path: Path to the csv file.
         """
-        task.validate_required_fields("date")
         parts: list[str | Path] = [self.output_path, task.temporal_resolution]
 
         if task.bidding_zone:

--- a/rbc/energy/utils.py
+++ b/rbc/energy/utils.py
@@ -226,7 +226,7 @@ class EnergyDownloader(ABC):
                 os._exit(1)
 
             except MissingDataError as e:  # handle missing data for task
-                logger.error(f"Missing data for task '{task.identifier}': {e}")
+                logger.error(f"Missing data for '{task.identifier}': {e}")
 
                 task.validate_required_fields("date")
                 if pd.Timestamp(task.date).year == pd.Timestamp.now().year:
@@ -241,13 +241,13 @@ class EnergyDownloader(ABC):
                     # 1. permanent missing data
                     if code == 404:
                         logger.warning(
-                            f"Data for task '{task.identifier}' not found (404). Skipping."
+                            f"Data for '{task.identifier}' not found (404). Skipping."
                         )
                         return 1
                     # 2. permanent client errors (400-499, except rate limits 429)
                     if 400 <= code < 500 and code != 429:
                         logger.error(
-                            f"Permanent error {code} for task '{task.identifier}'. Skipping."
+                            f"Permanent error {code} for '{task.identifier}'. Skipping."
                         )
                         return 1
 
@@ -256,7 +256,7 @@ class EnergyDownloader(ABC):
                     time.sleep(RETRY_DELAY)
                 else:
                     logger.critical(
-                        f"Failed task '{task.identifier}' after {MAX_RETRIES} attempts: {e}"
+                        f"Failed '{task.identifier}' after {MAX_RETRIES} attempts: {e}"
                     )
                     return 0
 

--- a/rbc/energy/utils.py
+++ b/rbc/energy/utils.py
@@ -100,6 +100,11 @@ class DownloadTask:
             raise ValueError(
                 f"Invalid temporal resolution: '{self.temporal_resolution}'"
             )
+    # Validate that the date is actually a valid calendar date
+    try:
+        pd.to_datetime(self.date)
+    except (ValueError, TypeError):
+        raise ValueError(f"Invalid calendar date: '{self.date}'")
 
     @property
     def identifier(self) -> str:

--- a/rbc/energy/utils.py
+++ b/rbc/energy/utils.py
@@ -341,39 +341,6 @@ class EnergyDownloader(ABC):
     # --------------------------------------------
     # General helper methods
     # --------------------------------------------
-    # @staticmethod
-    # def _check_connection(requests_func: Callable[[], requests.Response]) -> None:
-    #     """Generic wrapper to check the API/URL connection status using requests.
-    #
-    #     Args:
-    #         requests_func (Callable): Function to check the requests call response.
-    #
-    #     Raises:
-    #         HTTPError: If access to remote site failed.
-    #         ConnectionError: If remote site is unreachable.
-    #     """
-    #     try:
-    #         response = requests_func()
-    #         response.raise_for_status()
-    #
-    #     except requests.exceptions.HTTPError:  # catch 4xx/5xx status codes
-    #         if response.content:
-    #             reason = response.json().get("error", {}).get("code", "Unknown Error")
-    #             error_msg = f"status {response.status_code} ({reason})"
-    #         elif response.reason:
-    #             error_msg = f"status {response.status_code} ({response.reason})"
-    #         else:
-    #             error_msg = f"status {response.status_code} (Empty Response)"
-    #
-    #         logger.error(f"API/URL request failed with {error_msg}")
-    #         raise requests.exceptions.HTTPError(
-    #             f"API/URL access failed with {error_msg}"
-    #         )
-    #
-    #     except requests.exceptions.RequestException as e:  # catch connection/timeout/..
-    #         logger.error("Initialization connectivity check failed!")
-    #         raise ConnectionError(f"API/URL unreachable: {e}") from e
-
     @staticmethod
     def _get_status_code(e: Exception) -> int | None:
         """Extracts HTTP status code from various library exceptions.

--- a/rbc/energy/utils.py
+++ b/rbc/energy/utils.py
@@ -41,6 +41,12 @@ RETRY_ERRORS = (
 )
 
 
+class MissingDataError(Exception):
+    """Raised when a data source is missing data that a task is trying to download."""
+
+    pass
+
+
 class DataStructureError(Exception):
     """Raised when a data source changes its structure significantly."""
 
@@ -88,13 +94,13 @@ class DownloadKey:
         """Validates the date format if a date is provided.
 
         Raises:
-            AttributeError: If provided date or temporal resolution are in the wrong format.
+            ValueError: If provided date or temporal resolution are in the wrong format.
         """
         if self.date is not None and not self._DATE_PATTERN.match(self.date):
-            raise AttributeError(f"Invalid date / date format: '{self.date}'")
+            raise ValueError(f"Invalid date / date format: '{self.date}'")
 
         if not self._TRES_PATTERN.match(self.temporal_resolution):
-            raise AttributeError(
+            raise ValueError(
                 f"Invalid temporal resolution: '{self.temporal_resolution}'"
             )
 
@@ -116,12 +122,12 @@ class DownloadKey:
               fields (str): List of fields to check.
 
         Raises:
-              AttributeError: If any of the required fields are None.
+              ValueError: If any of the required fields are None.
         """
         for field in fields:
             value = getattr(self, field)
             if value is None or (isinstance(value, str) and not value.strip()):
-                raise AttributeError(
+                raise ValueError(
                     f"Required attribute '{field}' missing for task: {self}"
                 )
 
@@ -185,7 +191,7 @@ class EnergyDownloader(ABC):
 
         Child classes must raise / propagate errors the following errors to be handled here:
         - DataStructureError / RateLimitError / InvalidError: to immediately kill a run.
-        - ValueError: when data is missing for a specific task.
+        - MissingDataError: when data is missing for a specific task.
         - self.RETRY_ERRORS: when accessing generally fails.
 
         Args:
@@ -204,7 +210,7 @@ class EnergyDownloader(ABC):
                 logger.critical(f"FATAL! Stopping run due to error: {e}")
                 os._exit(1)
 
-            except ValueError as e:  # handle missing data for task
+            except MissingDataError as e:  # handle missing data for task
                 logger.error(f"Missing data for {task}: {e}")
 
                 task.validate_required_fields("date")
@@ -353,9 +359,6 @@ class EnergyDownloader(ABC):
 
         Returns:
             Path: Path to the csv file.
-
-        Raises:
-            ValueError: If date is missing.
         """
         task.validate_required_fields("date")
         parts: list[str | Path] = [self.output_path, task.temporal_resolution]
@@ -368,6 +371,39 @@ class EnergyDownloader(ABC):
     # --------------------------------------------
     # General helper methods
     # --------------------------------------------
+    # @staticmethod
+    # def _check_connection(requests_func: Callable[[], requests.Response]) -> None:
+    #     """Generic wrapper to check the API/URL connection status using requests.
+    #
+    #     Args:
+    #         requests_func (Callable): Function to check the requests call response.
+    #
+    #     Raises:
+    #         HTTPError: If access to remote site failed.
+    #         ConnectionError: If remote site is unreachable.
+    #     """
+    #     try:
+    #         response = requests_func()
+    #         response.raise_for_status()
+    #
+    #     except requests.exceptions.HTTPError:  # catch 4xx/5xx status codes
+    #         if response.content:
+    #             reason = response.json().get("error", {}).get("code", "Unknown Error")
+    #             error_msg = f"status {response.status_code} ({reason})"
+    #         elif response.reason:
+    #             error_msg = f"status {response.status_code} ({response.reason})"
+    #         else:
+    #             error_msg = f"status {response.status_code} (Empty Response)"
+    #
+    #         logger.error(f"API/URL request failed with {error_msg}")
+    #         raise requests.exceptions.HTTPError(
+    #             f"API/URL access failed with {error_msg}"
+    #         )
+    #
+    #     except requests.exceptions.RequestException as e:  # catch connection/timeout/..
+    #         logger.error("Initialization connectivity check failed!")
+    #         raise ConnectionError(f"API/URL unreachable: {e}") from e
+
     @staticmethod
     def _get_status_code(e: Exception) -> int | None:
         """Extracts HTTP status code from various library exceptions.
@@ -412,7 +448,7 @@ class EnergyDownloader(ABC):
             )
 
         if not all_dates:
-            raise ValueError(f"Provided years '{self.years}' lie in the future!")
+            raise InvalidError(f"Provided years '{self.years}' lie in the future!")
 
         return all_dates
 

--- a/rbc/energy/utils.py
+++ b/rbc/energy/utils.py
@@ -5,10 +5,12 @@ Shared helper functions for data downloaders
 
 import os
 import pickle
+import re
 import threading
 import time
 import urllib
 from abc import ABC, abstractmethod
+from dataclasses import dataclass, replace
 from pathlib import Path
 
 import pandas as pd
@@ -57,6 +59,73 @@ class InvalidError(Exception):
     pass
 
 
+@dataclass(frozen=True)
+class DownloadKey:
+    """Dataclass for defining downloading metadata for a task or checkpoint grouping.
+
+    A key with a `date` represents one concrete download task.
+    A key without a `date` can be used to define a checkpoint/output grouping.
+
+    This defines a task's relevant attributes, which in turn is used to build a consistent
+    path structure:
+    raw/energy/<source>/<resolution>/<optional ...>/<optional bidding_zone>/<date>.csv
+
+    Attributes:
+        date (str | None): Date in the format YYYY-MM(-DD) to download data for.
+        temporal_resolution (str): Temporal resolution of data. Defaults to "1h".
+        bidding_zone (str | None): Optional bidding zone of data. Defaults to None.
+    """
+
+    date: str | None = None
+    temporal_resolution: str = "1h"
+    bidding_zone: str | None = None
+
+    # patterns for matching
+    _DATE_PATTERN = re.compile(r"^\d{4}(-(0[1-9]|1[0-2])(-(0[1-9]|[12]\d|3[01]))?)?$")
+    _TRES_PATTERN = re.compile(r"^\d+(?:h|min|d)$")
+
+    def __post_init__(self) -> None:
+        """Validates the date format if a date is provided.
+
+        Raises:
+            AttributeError: If provided date or temporal resolution are in the wrong format.
+        """
+        if self.date is not None and not self._DATE_PATTERN.match(self.date):
+            raise AttributeError(f"Invalid date / date format: '{self.date}'")
+
+        if not self._TRES_PATTERN.match(self.temporal_resolution):
+            raise AttributeError(
+                f"Invalid temporal resolution: '{self.temporal_resolution}'"
+            )
+
+    def update(self, **changes) -> "DownloadKey":
+        """Update a key with provided changes.
+
+        Args:
+            changes: Dictionary of changes to make to the DownloadKey instance.
+
+        Returns:
+            DownloadKey: Updated download task instance.
+        """
+        return replace(self, **changes)
+
+    def validate_required_fields(self, *fields: str) -> None:
+        """Check that specific fields are not None.
+
+        Args:
+              fields (str): List of fields to check.
+
+        Raises:
+              AttributeError: If any of the required fields are None.
+        """
+        for field in fields:
+            value = getattr(self, field)
+            if value is None or (isinstance(value, str) and not value.strip()):
+                raise AttributeError(
+                    f"Required attribute '{field}' missing for task: {self}"
+                )
+
+
 class EnergyDownloader(ABC):
     """Abstract base class for parallelized daily energy downloader classes.
 
@@ -86,17 +155,18 @@ class EnergyDownloader(ABC):
         self._lock = threading.Lock()
 
     def _threading_wrapper(
-        self, task: str | tuple[str, str], checkpoint: dict, checkpoint_path: Path
+        self, task: DownloadKey, checkpoint: dict[str, int], checkpoint_path: Path
     ) -> None:
-        """Threading wrapper for data download and checkpoint reading/saving.
+        """Thread-safe wrapper for one download task (download and checkpoint reading/saving).
 
         Args:
-            task (str | tuple): Date or (zone, date) to download data for.
+            task (DownloadKey): The metadata for a task to download data for.
             checkpoint (dict): Dict of 0 and 1 values for resuming.
             checkpoint_path (Path): Path to the checkpoint file for resuming.
         """
+        ckpt_key = self._turn_task_into_checkpoint_key(task)
         with self._lock:
-            if checkpoint.get(task) == 1:
+            if checkpoint.get(ckpt_key) == 1:
                 logger.info(f"{task}: Data already downloaded. Skipping.")
                 return
 
@@ -107,10 +177,10 @@ class EnergyDownloader(ABC):
             status = 0
 
         with self._lock:
-            checkpoint[task] = status
+            checkpoint[ckpt_key] = status
             self._save_checkpoint(checkpoint, checkpoint_path)
 
-    def _download_task_data(self, task: str | tuple[str, str]) -> int:
+    def _download_task_data(self, task: DownloadKey) -> int:
         """Parse data for a specific task and dump to CSV.
 
         Child classes must raise / propagate errors the following errors to be handled here:
@@ -119,18 +189,15 @@ class EnergyDownloader(ABC):
         - self.RETRY_ERRORS: when accessing generally fails.
 
         Args:
-            task (str | tuple): Date or (zone, date) to download data for.
+            task (DownloadKey): The metadata for a task to download data for.
 
         Returns:
             int: Status of the download (1 if successful, 0 if unsuccessful).
         """
-        file_path = self._get_csv_path(task)
-        file_path.parent.mkdir(parents=True, exist_ok=True)
-
         for attempt in range(1, MAX_RETRIES + 1):
             try:
                 df_gen = self._get_task_data(task=task)
-                write_df_to_csv(df=df_gen, file_path=file_path)
+                self._save_task_data(task=task, df=df_gen)
                 return 1
 
             except (DataStructureError, RateLimitError, InvalidError) as e:  # kill run
@@ -140,10 +207,8 @@ class EnergyDownloader(ABC):
             except ValueError as e:  # handle missing data for task
                 logger.error(f"Missing data for {task}: {e}")
 
-                date = task[-1] if isinstance(task, tuple) else task
-                year = pd.Timestamp(date).year
-
-                if year == pd.Timestamp.now().year:
+                task.validate_required_fields("date")
+                if pd.Timestamp(task.date).year == pd.Timestamp.now().year:
                     return 0  # current year task -> might become available later!
 
                 return 1  # skip task
@@ -173,54 +238,71 @@ class EnergyDownloader(ABC):
         return 1  # pragma: no cover
 
     @abstractmethod
-    def _get_task_data(self, task: str | tuple[str, str]) -> pd.DataFrame:
+    def _get_task_data(self, task: DownloadKey) -> pd.DataFrame:
         """Method to get the task's data (child classes MUST implement/overwrite this!).
 
         Args:
-            task (str | tuple): Date or (zone, date) to download data for.
+            task (DownloadKey): The metadata for a task to download data for.
+
+        Returns:
+            DataFrame: The task's downloaded data (child classes MUST implement this!).
         """
 
-    # --------------------------------------------
-    # Helper methods
-    # --------------------------------------------
+    def _save_task_data(self, task: DownloadKey, df: pd.DataFrame) -> None:
+        """Save downloaded task data to disk.
+
+        Functionality is separated here to allow child classes to overwrite (i.e. Entso-e).
+
+        Args:
+            task (DownloadKey): The metadata for the task that was downloaded.
+            df (pd.DataFrame): Downloaded dataframe for the task.
+        """
+        file_path = self._build_task_path(task)
+        write_df_to_csv(df=df, file_path=file_path)
+
+    # ------------------------------------------------------------------
+    # Path definition and checkpoint helpers (using DownloadKey)
+    # ------------------------------------------------------------------
     @staticmethod
-    def _get_status_code(e: Exception) -> int | None:
-        """Extracts HTTP status code from various library exceptions.
+    def _turn_task_into_checkpoint_key(task: DownloadKey) -> str:
+        """Convert a task to a string key for checkpointing.
 
         Args:
-            e (Exception): Exception raised when an error occurs.
+            task (DownloadKey): The metadata for a task to download data for.
 
         Returns:
-            int | None: HTTP status code if it was a HTTPError, otherwise None.
+            str: String to use as key in checkpointing dict.
         """
-        if hasattr(e, "response") and hasattr(e.response, "status_code"):  # requests
-            return e.response.status_code
-        if hasattr(e, "code"):  # urllib
-            return e.code
-        return None
+        parts = [
+            f"date={task.date}" if task.date else None,
+            f"temporal_res={task.temporal_resolution}"
+            if task.temporal_resolution
+            else None,
+            f"bidding_zone={task.bidding_zone}" if task.bidding_zone else None,
+        ]
+        return "|".join(p for p in parts if p is not None)
 
-    def _get_csv_path(self, task: str | tuple[str, str]) -> Path:
-        """Get csv file path to which resume logic will be saved.
+    def _build_checkpoint_path(self, task: DownloadKey) -> Path:
+        """Return checkpoint path for a task grouping.
+
+        By default, checkpoints are stored per temporal resolution and optional zone.
+        The structure for the path is:
+        <output_path>/<temporal_resolution>/<optional...>/<optional bz>/status.pickle
 
         Args:
-            task (str | tuple): Date or (zone, date) to download data for.
+            task (DownloadKey): The metadata for a task grouping without a 'date'.
 
         Returns:
-            Path: Path to the csv file.
-
-        Raises:
-            ValueError: If task is not a string or tuple.
+            Path: Path to the checkpoint file.
         """
-        if isinstance(task, str):  # Case for EIA / EPIAS
-            return Path(self.output_path, f"{task}.csv")
+        parts: list[str | Path] = [self.output_path, task.temporal_resolution]
 
-        if isinstance(task, tuple) and len(task) == 2:  # Case for Entsoe (zone, date)
-            zone, date = task
-            return Path(self.output_path, zone, f"{date}.csv")
+        if task.bidding_zone:
+            parts.append(task.bidding_zone)
 
-        raise ValueError(f"CSV path can't be defined. Unsupported task format: {task}")
+        return Path(*parts, "status.pickle")
 
-    def _load_checkpoint(self, checkpoint_path: Path) -> dict:
+    def _load_checkpoint(self, checkpoint_path: Path) -> dict[str, int]:
         """Load checkpoint from checkpoint path depending on resume logic.
 
         Args:
@@ -247,17 +329,60 @@ class EnergyDownloader(ABC):
             return {}
 
     @staticmethod
-    def _save_checkpoint(checkpoint: dict, checkpoint_path: Path) -> None:
+    def _save_checkpoint(checkpoint: dict[str, int], checkpoint_path: Path) -> None:
         """Save checkpoint safely (ensure abrupt terminations don't corrupt the file).
 
         Args:
             checkpoint (dict): Checkpoint to be saved.
             checkpoint_path (Path): Path to checkpoint file.
         """
+        checkpoint_path.parent.mkdir(parents=True, exist_ok=True)
         temp_path = checkpoint_path.with_suffix(".tmp")
         with open(temp_path, "wb") as f:
             pickle.dump(checkpoint, f)
         os.replace(temp_path, checkpoint_path)
+
+    def _build_task_path(self, task: DownloadKey) -> Path:
+        """Build the CSV file path to which the downloaded task data will be saved.
+
+        Designed structure:
+        <output_path>/<temporal_resolution>/<optional ...>/<optional bz>/<date>.csv
+
+        Args:
+            task (DownloadKey): The metadata for a task to download data for.
+
+        Returns:
+            Path: Path to the csv file.
+
+        Raises:
+            ValueError: If date is missing.
+        """
+        task.validate_required_fields("date")
+        parts: list[str | Path] = [self.output_path, task.temporal_resolution]
+
+        if task.bidding_zone:
+            parts.append(task.bidding_zone)
+
+        return Path(*parts, f"{task.date}.csv")
+
+    # --------------------------------------------
+    # General helper methods
+    # --------------------------------------------
+    @staticmethod
+    def _get_status_code(e: Exception) -> int | None:
+        """Extracts HTTP status code from various library exceptions.
+
+        Args:
+            e (Exception): Exception raised when an error occurs.
+
+        Returns:
+            int | None: HTTP status code if it was a HTTPError, otherwise None.
+        """
+        if hasattr(e, "response") and hasattr(e.response, "status_code"):  # requests
+            return e.response.status_code
+        if hasattr(e, "code"):  # urllib
+            return e.code
+        return None
 
     def _get_date_list(self) -> list[str]:
         """Get a list of all valid dates in the provided year(s).

--- a/scripts/energy/aeso_download.py
+++ b/scripts/energy/aeso_download.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python
+"""AESO DATA DOWNLOAD SCRIPT.
+
+Download data from AESO box cloud storage site for Alberta, Canada.
+"""
+
+from argparse import ArgumentParser, Namespace
+
+from loguru import logger
+
+from rbc.config.loader import load_config, parse_key_value_pairs
+from rbc.energy.aeso import AesoDownloader
+from rbc.utils import setup_logging
+
+SOURCE = "aeso"
+
+
+def parse_arguments() -> Namespace:
+    """Parse command line arguments.
+
+    Returns:
+        argparse.Namespace: Namespace parsed command line arguments.
+    """
+    parser = ArgumentParser(prog="AESO data download")
+    parser.add_argument(
+        "-y",
+        "--years",
+        nargs="+",
+        type=int,
+        default=list(range(2015, 2026)),  # 2015-2026 for 1h, 2015-2023 for 5min
+        help=f"Years to download. Example: -y 2020 2021. "
+        f"Default: {list(range(2015, 2026))}",
+    )
+    parser.add_argument(
+        "-tr",
+        "--temporal_resolutions",
+        nargs="+",
+        type=str,
+        default=["1h", "5min"],  # these are the available resolutions
+        help=f"Years to download. Example: -y 2020 2021. Default: {['1h', '5min']}",
+    )
+    parser.add_argument(
+        "--no-resume",
+        dest="resume",
+        action="store_false",
+        help="Do not resume download from a previous checkpoint.",
+    )
+    parser.set_defaults(resume=True)
+    parser.add_argument(
+        "-o",
+        "--cfg_options",
+        action="append",
+        help="Override YAML config values (supports nested keys). "
+        "Example: -o paths.dst_dir_raw=/your/path/ -o access.api_key=YOUR-SECRET-KEY",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    """Coordinating AESO data download."""
+    args = parse_arguments()
+    overrides = parse_key_value_pairs(args.cfg_options) if args.cfg_options else None
+
+    cfg = load_config(source=SOURCE, overrides=overrides)
+    setup_logging(output_dir=cfg.paths.dst_dir_raw)
+    logger.info(f"Flags for the '{SOURCE}' download:\n{args}")
+    logger.info(f"Config for the '{SOURCE}' download:\n{cfg}")
+
+    downloader = AesoDownloader(
+        token=cfg.access.api_key,
+        output_path=cfg.paths.dst_dir_raw,
+        years=args.years,
+        temporal_resolutions=args.temporal_resolutions,
+        resume=args.resume,
+    )
+    downloader.download_data()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/energy/aeso_download.py
+++ b/scripts/energy/aeso_download.py
@@ -5,6 +5,7 @@ Download data from AESO box cloud storage site for Alberta, Canada.
 """
 
 from argparse import ArgumentParser, Namespace
+from datetime import datetime
 
 from loguru import logger
 
@@ -27,9 +28,9 @@ def parse_arguments() -> Namespace:
         "--years",
         nargs="+",
         type=int,
-        default=list(range(2015, 2026)),  # 2015-2026 for 1h, 2015-2023 for 5min
+        default=list(range(2015, datetime.now().year + 1)),  # 5min: 2015-2023
         help=f"Years to download. Example: -y 2020 2021. "
-        f"Default: {list(range(2015, 2026))}",
+        f"Default: {list(range(2015, datetime.now().year + 1))}",
     )
     parser.add_argument(
         "-tr",

--- a/scripts/energy/aeso_download.py
+++ b/scripts/energy/aeso_download.py
@@ -38,7 +38,7 @@ def parse_arguments() -> Namespace:
         nargs="+",
         type=str,
         default=["1h", "5min"],  # these are the available resolutions
-        help=f"Years to download. Example: -y 2020 2021. Default: {['1h', '5min']}",
+        help=f"Temporal resolutions to download. Example: --temporal_resolutions 1h 5min. Default: {['1h', '5min']}",
     )
     parser.add_argument(
         "--no-resume",

--- a/scripts/energy/eia_download.py
+++ b/scripts/energy/eia_download.py
@@ -4,8 +4,8 @@
 Download data from EIA website for the USA.
 """
 
-import argparse
-from argparse import ArgumentParser
+from argparse import ArgumentParser, Namespace
+from datetime import datetime
 
 from loguru import logger
 
@@ -16,7 +16,7 @@ from rbc.utils import setup_logging
 SOURCE = "eia"
 
 
-def parse_arguments() -> argparse.Namespace:
+def parse_arguments() -> Namespace:
     """Parse command line arguments.
 
     Returns:
@@ -28,9 +28,9 @@ def parse_arguments() -> argparse.Namespace:
         "--years",
         nargs="+",
         type=int,
-        default=list(range(2019, 2026)),  # these are the available years for hourly gen
+        default=list(range(2019, datetime.now().year + 1)),  # available years
         help=f"Years to download. Example: -y 2020 2021. "
-        f"Default: {list(range(2019, 2026))}",
+        f"Default: {list(range(2019, datetime.now().year + 1))}",
     )
     parser.add_argument(
         "--no-resume",

--- a/scripts/energy/entsoe_download.py
+++ b/scripts/energy/entsoe_download.py
@@ -7,11 +7,11 @@ Download data from ENTSO-E Transparency Platform for European bidding zones.
 from argparse import ArgumentParser, Namespace
 from datetime import datetime
 
-from entsoe.utils import mappings
 from loguru import logger
 
 from rbc.config.loader import load_config, parse_key_value_pairs
 from rbc.energy.entsoe import EntsoeDownloader
+from rbc.energy.entsoe.mappings import ACTIVE_ZONES, MIN_YEAR
 from rbc.utils import setup_logging
 
 SOURCE = "entsoe"
@@ -29,21 +29,22 @@ def parse_arguments() -> Namespace:
         "--years",
         nargs="+",
         type=int,
-        default=list(range(2005, datetime.now().year + 1)),
+        default=list(range(MIN_YEAR, datetime.now().year + 1)),
         help=f"Years to download. Example: -y 2020 2021. "
-        f"Default: {list(range(2005, datetime.now().year + 1))}",
+        f"Default: {list(range(MIN_YEAR, datetime.now().year + 1))}",
     )
     parser.add_argument(
         "-bz",
         "--bidding_zones",
         nargs="+",
         type=str,
-        choices=list(mappings.keys()),
-        default=list(mappings.keys()),
+        choices=ACTIVE_ZONES,
+        default=ACTIVE_ZONES,
         metavar="BIDDING_ZONES",
-        help="Bidding zones to download. "
+        help="Bidding zone EIC codes to download. "
         "Example: -b '10YES-REE------0' '10YFR-RTE------C'. "
-        "Default: All (see entsoe.utils.mappings)",
+        "Default: All zones that had/have generation data per unit "
+        "(see rbc.energy.entsoe.mappings.py)",
     )
     parser.add_argument(
         "--no-resume",

--- a/scripts/energy/entsoe_download.py
+++ b/scripts/energy/entsoe_download.py
@@ -4,8 +4,8 @@
 Download data from ENTSO-E Transparency Platform for European bidding zones.
 """
 
-import argparse
-from argparse import ArgumentParser
+from argparse import ArgumentParser, Namespace
+from datetime import datetime
 
 from entsoe.utils import mappings
 from loguru import logger
@@ -17,7 +17,7 @@ from rbc.utils import setup_logging
 SOURCE = "entsoe"
 
 
-def parse_arguments() -> argparse.Namespace:
+def parse_arguments() -> Namespace:
     """Parse command line arguments.
 
     Returns:
@@ -29,9 +29,9 @@ def parse_arguments() -> argparse.Namespace:
         "--years",
         nargs="+",
         type=int,
-        default=list(range(2010, 2026)),
+        default=list(range(2005, datetime.now().year + 1)),
         help=f"Years to download. Example: -y 2020 2021. "
-        f"Default: {list(range(2010, 2026))}",
+        f"Default: {list(range(2005, datetime.now().year + 1))}",
     )
     parser.add_argument(
         "-bz",

--- a/scripts/energy/entsoe_get_zones.py
+++ b/scripts/energy/entsoe_get_zones.py
@@ -348,7 +348,7 @@ def parse_arguments() -> Namespace:
         "--only-print-mapping",
         action="store_true",
         help="Don't get the data, only print the ACTIVE_ZONES_MAPPING dict from existing "
-        "JSON results to copy-past into 'rbc/energy/entsoe.mapping.py'.",
+        "JSON results to copy-paste into 'rbc/energy/entsoe.mapping.py'.",
     )
     return parser.parse_args()
 

--- a/scripts/energy/entsoe_get_zones.py
+++ b/scripts/energy/entsoe_get_zones.py
@@ -1,0 +1,384 @@
+"""Probe ENTSO-E bidding zones for likely data availability.
+
+This script performs a lightweight scan across ENTSO-E bidding zones by querying
+only a small set of sample dates rather than every day of every year.
+
+Features:
+- incremental saving after every checked zone
+- resume support
+- Loguru logging to console and file
+
+Usage:
+    python scripts/entsoe_get_zones.py --token YOUR_TOKEN --output-dir outputs/entsoe_probe
+    python scripts/entsoe_get_zones.py --token YOUR_TOKEN --output-dir outputs/entsoe_probe --resume
+"""
+
+from __future__ import annotations
+
+import json
+from argparse import ArgumentParser, Namespace
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+from entsoe.config import set_config
+from entsoe.Generation import ActualGenerationPerGenerationUnit
+from entsoe.query.decorators import ServiceUnavailableError
+from entsoe.utils import mappings
+from loguru import logger
+
+from rbc.utils import setup_logging
+
+
+class EntsoeBZCollector:
+    """Collect active bidding zone data.
+
+    Attributes:
+        dates (list[str]): List of dates to check.
+        dates_per_year (int): Number of dates per year.
+        results_by_zone (dict[str, Any]): Dictionary of result statistics per bidding zone.
+        results_path (Path): Path of results JSON file.
+        resume (bool): Whether to resume from previous data collection or not.
+        years (list[str]): List of years to check.
+    """
+
+    def __init__(
+        self,
+        token: str,
+        output_dir: Path,
+        years: list,
+        dates_per_year: int,
+        resume: bool,
+    ) -> None:
+        """Initialize EntsoeBZCollector.
+
+        Args:
+            token (str): ENTSO-E bidding token.
+            output_dir (Path): Output directory.
+            years (list[str]): Years to collect.
+            dates_per_year (int): Number of dates per year.
+            resume (bool): Whether to resume from previous data collection or not.
+        """
+        self.results_path = Path(output_dir, "active_zones.json")
+        self.resume = resume
+        self.years = years
+        self.dates_per_year = dates_per_year
+        self.dates = self.build_sample_dates()
+
+        if token is not None:
+            set_config(security_token=token)
+
+        logger.info(f"Saving to file: {self.results_path}")
+        logger.info(f"Years: {self.years}")
+        logger.info(f"Dates per year: {self.dates_per_year}")
+        logger.info(
+            f"Checking {len(mappings)} zones: {len(self.years)} years × "
+            f"{self.dates_per_year} dates/year = {len(self.dates)} total checks"
+        )
+        logger.info(f"Resume mode: {self.resume}")
+
+        if self.resume:
+            self.results_by_zone = self._load_results()
+            logger.info(f"Loaded {len(self.results_by_zone)} previously checked zones.")
+        else:
+            self.results_by_zone = {}
+            logger.info("Starting from scratch.")
+
+    def build_sample_dates(self) -> list[str]:
+        """Build a list of sample dates (MM-DD) to probe.
+
+        Returns:
+            list[str]: List of all sample dates (YYYY-MM-DD).
+
+        Raises:
+            ValueError: If dates_per_year is invalid.
+        """
+        if self.dates_per_year == 1:
+            mm_dd = ["12-15"]  # ensures inclusion even if recording started at year end
+        elif self.dates_per_year == 2:
+            mm_dd = ["03-15", "09-15"]
+        elif self.dates_per_year == 3:
+            mm_dd = ["01-15", "06-15", "12-15"]
+        else:
+            raise ValueError("dates_per_year must be one of: 1, 2, 3")
+
+        return [f"{y}-{d}" for y in self.years for d in mm_dd]
+
+    # ------------------------------------------------------------------
+    # Main entrypoint for running / getting the mapping dict
+    # ------------------------------------------------------------------
+    def run(self):
+        """Run the collection of bidding zones."""
+        zones = list(mappings.keys())
+
+        for i, zone in enumerate(zones, start=1):
+            if self.resume and zone in self.results_by_zone:
+                logger.info(f"[{i:>3}/{len(zones)}] Skipping {zone} - already checked.")
+                continue
+
+            logger.info(
+                f"[{i:>3}/{len(zones)}] Checking {zone} ({mappings[zone]['name']})"
+            )
+            result = self._check_zone(zone=zone)
+            self.results_by_zone[zone] = result
+            self._save_results()
+
+            logger.info(
+                f"Completed checking {zone}:\t has_data={result['has_any_data']} | "
+                f"hits={result['n_hits']} | first_year={result['first_year']} | "
+                f"last_year={result['last_year']} | errors={result['errors']}"
+            )
+
+        self._print_summary()
+
+    def _check_zone(self, zone: str) -> dict[str, Any]:
+        """Check data availability for one zone.
+
+        Args:
+            zone (str): Zone to check.
+
+        Returns:
+            dict[str, Any]: Dictionary containing current bidding zone statistics.
+        """
+        hit_dates: list[str] = []
+        miss_dates: list[str] = []
+        error_counts: dict[str, int] = {}
+
+        for date in self.dates:
+            has_data, status = self._query_data(zone=zone, date=date)
+
+            if has_data:
+                hit_dates.append(date)
+            elif has_data is False:
+                miss_dates.append(date)
+            else:
+                error_counts[status] = error_counts.get(status, 0) + 1
+
+        return {
+            "zone": zone,
+            "zone_name": mappings.get(zone, {}),
+            "has_any_data": bool(hit_dates),
+            "hit_dates": hit_dates,
+            "n_hits": len(hit_dates),
+            "n_misses": len(miss_dates),
+            "errors": error_counts,
+            **self._get_hit_stats(hit_dates),
+        }
+
+    @staticmethod
+    def _query_data(zone: str, date: str) -> tuple[bool | None, str]:
+        """Check whether a single zone/date query returns 'generation per unit' data.
+
+        Args:
+            zone (str): Zone to check.
+            date (str): Date to check.
+
+        Returns:
+            tuple(bool | None, str): If error, None & status reason. If successful,
+                bool for whether data was present.
+        """
+        dt = pd.Period(date, freq="D")
+
+        try:
+            result = ActualGenerationPerGenerationUnit(
+                period_start=int(dt.strftime("%Y%m%d0000")),
+                period_end=int(dt.strftime("%Y%m%d2359")),
+                in_domain=zone,
+                psr_type=None,
+                registered_resource=None,
+            ).query_api()
+
+        except ServiceUnavailableError:
+            return None, "service_unavailable"
+        except Exception as e:
+            return None, type(e).__name__
+
+        if not isinstance(result, list):
+            return None, "unexpected_response_type"
+
+        if not result:
+            return False, "no_data"
+
+        return True, "has_data"
+
+    @staticmethod
+    def _get_hit_stats(hit_dates: list[str]) -> dict[str, int | str | None]:
+        """Get hit-specific statistics for the current bidding zone.
+
+        Args:
+            hit_dates (list[str]): List of dates where data was found.
+
+        Returns:
+            dict[str, int | str | None]: Dictionary summarising the hit statistics.
+        """
+        if not hit_dates:
+            return {
+                "first_hit": None,
+                "last_hit": None,
+                "first_year": None,
+                "last_year": None,
+            }
+
+        years = sorted({int(d[:4]) for d in hit_dates})
+        return {
+            "first_hit": min(hit_dates),
+            "last_hit": max(hit_dates),
+            "first_year": years[0],
+            "last_year": years[-1],
+        }
+
+    # ------------------------------------------------------------------
+    # Main entrypoint for printing the created mapping dict
+    # ------------------------------------------------------------------
+    def print_active_zone_metadata_dict(self) -> None:
+        """Print ACTIVE_ZONE_METADATA dict to paste into rbc/energy/entsoe/mapping.py."""
+        if not self.results_by_zone:
+            self.results_by_zone = self._load_results()
+
+        if not self.results_by_zone:
+            logger.warning(
+                "No JSON from which to extract the ACTIVE_ZONES_MAPPING dict!"
+            )
+            return
+
+        print("ACTIVE_ZONES_MAPPING = {")
+        for zone, meta in list(self.results_by_zone.items()):
+            if not meta.get("has_any_data"):
+                continue
+
+            name = " / ".join(meta["zone_name"].keys())
+            items = [f'"name": "{name}"', f'"start": {meta["first_year"]}']
+
+            if meta.get("last_year", datetime.now().year) != datetime.now().year:
+                items.append(f'"end": {meta["last_year"]}')
+
+            print(f'    "{zone}": {{{", ".join(items)}}},')
+        print("}")
+
+    # ------------------------------------------------------------------
+    # i/o helpers
+    # ------------------------------------------------------------------
+    def _load_results(self) -> dict[str, dict]:
+        """Load existing results from disk if present.
+
+        Returns:
+            dict[str, dict]: Dictionary containing loaded bidding zone statistics.
+        """
+        if not self.results_path.is_file():
+            return {}
+
+        try:
+            return json.loads(self.results_path.read_text())
+        except json.JSONDecodeError:
+            logger.warning(f"Existing results file '{self.results_path}' is invalid.")
+            return {}
+
+    def _save_results(self) -> None:
+        """Save results dict to disk."""
+        self.results_path.parent.mkdir(parents=True, exist_ok=True)
+        tmp_path = self.results_path.with_suffix(".tmp")
+        tmp_path.write_text(json.dumps(self.results_by_zone, indent=2, sort_keys=True))
+        tmp_path.replace(self.results_path)
+
+    def _print_summary(self) -> None:
+        """Log a readable total summary."""
+        results = list(self.results_by_zone.values())
+        active = [r for r in results if r["has_any_data"]]
+        inactive = [r for r in results if not r["has_any_data"]]
+
+        logger.info("=== ENTSO-E ZONE PROBE SUMMARY ===")
+        logger.info(f"Zones checked: {len(results)}")
+        logger.info(f"Zones with sampled data: {len(active)}")
+        logger.info(f"Zones with no sampled data: {len(inactive)}")
+
+        logger.info("--- Zones with sampled data ---")
+        for r in sorted(active, key=lambda x: (x["first_year"] or 9999, x["zone"])):
+            logger.info(
+                f"{r['zone']} | {r['zone_name']} | "
+                f"hits={r['n_hits']} | first_year={r['first_year']} | last_year={r['last_year']}"
+            )
+
+        logger.info("--- Zones with no sampled data ---")
+        for r in sorted(inactive, key=lambda x: x["zone"]):
+            err = r["errors"]
+            err_txt = (
+                ", ".join(f"{k}:{v}" for k, v in sorted(err.items())) if err else "none"
+            )
+            logger.info(f"{r['zone']} | {r['zone_name']} | errors={err_txt}")
+
+
+def parse_arguments() -> Namespace:
+    """Parse command line arguments.
+
+    Returns:
+        argparse.Namespace: Namespace parsed command line arguments.
+    """
+    parser = ArgumentParser(
+        description="Get ENTSO-E bidding zones that provide energy generation data per unit."
+    )
+    parser.add_argument("-t", "--token", help="ENTSO-E API token.")
+    parser.add_argument(
+        "-o",
+        "--output-dir",
+        type=Path,
+        required=True,
+        help="Directory for storing JSON results and logs.",
+    )
+    parser.add_argument(
+        "--years",
+        nargs="+",
+        type=int,
+        default=list(range(2014, datetime.now().year + 1)),  # 2014 is the earliest
+        help="Years to check. Default: 2014...current year",
+    )
+    parser.add_argument(
+        "--dates-per-year",
+        type=int,
+        choices=[1, 2, 3],
+        default=1,
+        help="Number of sample dates per year to test. Default: 1",
+    )
+    parser.add_argument(
+        "--resume",
+        action="store_true",
+        help="Resume from existing saved JSON if present.",
+    )
+    parser.add_argument(
+        "--only-print-mapping",
+        action="store_true",
+        help="Don't get the data, only print the ACTIVE_ZONES_MAPPING dict from existing "
+        "JSON results to copy-past into 'rbc/energy/entsoe.mapping.py'.",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    """Coordinate getting active Entso-E EIC bidding zones."""
+    args = parse_arguments()
+
+    if not args.only_print_mapping and not args.token:
+        raise ValueError("--token is required unless --only-print-mapping is used!")
+
+    setup_logging(output_dir=args.output_dir)
+
+    resume = args.resume or args.only_print_mapping
+    collector = EntsoeBZCollector(
+        token=args.token,
+        output_dir=args.output_dir,
+        years=args.years,
+        dates_per_year=args.dates_per_year,
+        resume=resume,
+    )
+
+    if args.only_print_mapping:
+        collector.print_active_zone_metadata_dict()
+        return
+
+    collector.run()
+    logger.info("Completed getting active Entso-E EIC bidding zones.")
+    collector.print_active_zone_metadata_dict()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/energy/epias_download.py
+++ b/scripts/energy/epias_download.py
@@ -4,8 +4,8 @@
 Download data from EPIAS Transparency Platform for Turkey.
 """
 
-import argparse
-from argparse import ArgumentParser
+from argparse import ArgumentParser, Namespace
+from datetime import datetime
 
 from loguru import logger
 
@@ -16,7 +16,7 @@ from rbc.utils import setup_logging
 SOURCE = "epias"
 
 
-def parse_arguments() -> argparse.Namespace:
+def parse_arguments() -> Namespace:
     """Parse command line arguments.
 
     Returns:
@@ -28,9 +28,9 @@ def parse_arguments() -> argparse.Namespace:
         "--years",
         nargs="+",
         type=int,
-        default=list(range(2010, 2026)),
+        default=list(range(2013, datetime.now().year + 1)),  # available years
         help=f"Years to download. Example: -y 2020 2021. "
-        f"Default: {list(range(2010, 2026))}",
+        f"Default: {list(range(2013, datetime.now().year + 1))}",
     )
     parser.add_argument(
         "--no-resume",

--- a/scripts/energy/ieso_download.py
+++ b/scripts/energy/ieso_download.py
@@ -5,6 +5,7 @@ Download data from IESO website for Ontario, Canada.
 """
 
 from argparse import ArgumentParser, Namespace
+from datetime import datetime
 
 from loguru import logger
 
@@ -27,9 +28,9 @@ def parse_arguments() -> Namespace:
         "--years",
         nargs="+",
         type=int,
-        default=list(range(2010, 2026)),  # these are the available years for hourly gen
+        default=list(range(2010, datetime.now().year + 1)),  # available years
         help=f"Years to download. Example: -y 2020 2021. "
-        f"Default: {list(range(2010, 2026))}",
+        f"Default: {list(range(2010, datetime.now().year + 1))}",
     )
     parser.add_argument(
         "--no-resume",

--- a/tests/config/conftest.py
+++ b/tests/config/conftest.py
@@ -16,6 +16,10 @@ def source_configs(tmp_path: Path) -> dict:
         dict: Dictionary of example source config dicts.
     """
     return {
+        "aeso": {
+            "paths": {"dst_dir_raw": str(Path(tmp_path, "aeso"))},
+            "access": {"api_key": "token"},
+        },
         "eia": {
             "paths": {"dst_dir_raw": str(Path(tmp_path, "eia"))},
             "access": {"api_key": "token"},

--- a/tests/config/conftest.py
+++ b/tests/config/conftest.py
@@ -33,18 +33,18 @@ def source_configs(tmp_path: Path) -> dict:
             "access": {"username": "name", "password": "pw"},
         },
         "ieso": {"paths": {"dst_dir_raw": str(Path(tmp_path, "ieso"))}},
+        "barra2": {
+            "paths": {"dst_dir_raw": str(Path(tmp_path, "barra2"))},
+        },
         "era5": {
             "paths": {"dst_dir_raw": str(Path(tmp_path, "era5"))},
             "access": {"api_key": "token"},
         },
-        "icon_dream_global": {
-            "paths": {"dst_dir_raw": str(Path(tmp_path, "icon_dream_global"))},
-        },
         "icon_dream_eu": {
             "paths": {"dst_dir_raw": str(Path(tmp_path, "icon_dream_eu"))},
         },
-        "barra2": {
-            "paths": {"dst_dir_raw": str(Path(tmp_path, "barra2"))},
+        "icon_dream_global": {
+            "paths": {"dst_dir_raw": str(Path(tmp_path, "icon_dream_global"))},
         },
     }
 

--- a/tests/energy/aeso/test_downloader.py
+++ b/tests/energy/aeso/test_downloader.py
@@ -1,0 +1,499 @@
+# tests/energy/aeso/test_downloader.py
+"""Tests for AESO energy data downloader."""
+
+import io
+import pickle
+import zipfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+import pytest
+from requests import exceptions
+
+from rbc.energy.aeso import AesoDownloader
+from rbc.energy.aeso.downloader import EXPECTED_COLS
+from rbc.energy.utils import DataStructureError, DownloadTask, MissingDataError
+
+
+# ----------------------------------
+# Fixtures
+# ----------------------------------
+@pytest.fixture
+def init_args(tmp_path: Path) -> dict:
+    """Creates a basic setup with a temporary directory.
+
+    Args:
+        tmp_path (Path): Path to the temporary directory.
+
+    Returns:
+        dict: Initialisation arguments.
+    """
+    return {
+        "token": "fake_token",
+        "output_path": tmp_path,
+        "years": [2020],
+        "temporal_resolutions": ["1h", "5min"],
+        "resume": False,
+    }
+
+
+@pytest.fixture
+def mock_lookup(init_args: dict) -> dict:
+    """Creates a mocked lookup of source files 'available' to download.
+
+    Args:
+        init_args (dict): Arguments used to initialize an AesoDownloader instance.
+
+    Returns:
+        dict: Mock lookup dictionary of source files.
+    """
+    y = init_args["years"][0]
+    tasks = pd.date_range(f"{y}-01", f"{y}-12", freq="MS").strftime("%Y-%m").tolist()
+    source_dict = {t: {"id": "fake_id", "name": "fake_name"} for t in tasks}
+    return {"1h": source_dict, "5min": source_dict}
+
+
+@pytest.fixture
+def downloader(init_args: dict, mock_lookup: dict) -> AesoDownloader:
+    """Provides an AesoDownloader instance with a mocked, positive return code response.
+
+    Args:
+        init_args (dict): Arguments used to initialize an AesoDownloader instance.
+        mock_lookup (dict): Dictionary of mocked source files to download.
+
+    Returns:
+        AesoDownloader: AesoDownloader instance.
+    """
+    with patch("rbc.energy.aeso.downloader.requests.get") as mock_get:
+        with patch("rbc.energy.aeso.downloader.BoxClient"):
+            with patch.object(AesoDownloader, "_build_source_lookup") as mock_build:
+                mock_get.return_value = MagicMock(status_code=200)
+                mock_build.return_value = mock_lookup
+                return AesoDownloader(**init_args)
+
+
+@pytest.fixture(params=["1h", "5min"])
+def task(request: pytest.FixtureRequest, init_args: dict) -> DownloadTask:
+    """Gets a task as 'date=YYYY-MM, temporal_resolution=1h' from the init arguments.
+
+    Args:
+        request (FixtureRequest): Special pytest fixture used to access 'params' values.
+        init_args (dict): Arguments used to initialize an AesoDownloader instance.
+
+    Returns:
+        DownloadTask: The metadata of a downloading task, here: date (YYYY-MM)
+    """
+    return DownloadTask(
+        date=f"{init_args['years'][0]}-01",
+        temporal_resolution=request.param,
+    )
+
+
+def get_mock_df(spec_task: DownloadTask) -> pd.DataFrame:
+    """Gets a mock dataframe for a specific task.
+
+    Args:
+        spec_task (DownloadTask): The metadata of a download task, here: date (YYYY-MM), t_res
+
+    Returns:
+        pandas.DataFrame: Mock dataframe.
+    """
+    row: dict[str, object] = {c: ["A"] for c in EXPECTED_COLS}
+    row.update(
+        {c: f"{spec_task.date}-01 00:00:00" for c in EXPECTED_COLS if "Date" in c}
+    )
+    row.update(
+        {
+            "Volume": 10.0,
+            "Maximum Capability": 20.0,
+            "System Capability": 10.0,
+            "Planning Area": 10,
+        }
+    )
+    return pd.DataFrame(row, index=[0])
+
+
+# ----------------------------------
+# Tests - Initialization
+# ----------------------------------
+def test_downloader_initialization(
+    downloader: AesoDownloader, init_args: dict, mock_lookup: dict
+) -> None:
+    """Happy path for class initialization.
+
+    Check that the AesoDownloader sets up paths and checkpoint correctly.
+
+    Args:
+        downloader (AesoDownloader): Instance of AesoDownloader class.
+        init_args (dict): Arguments used to initialize an AesoDownloader instance.
+        mock_lookup (dict): Dictionary of mocked source files to download.
+    """
+    assert downloader.years == init_args["years"]
+    assert downloader.output_path == init_args["output_path"]
+    assert downloader.checkpoint_path == Path(init_args["output_path"], "status.pickle")
+    assert downloader.checkpoint == {}
+    assert downloader._source_lookup == mock_lookup
+
+
+def test_downloader_initialization_invalid_request(init_args: dict) -> None:
+    """Failure path for class initialization with invalid request.
+
+    Args:
+        init_args (dict): Arguments used to initialize an AesoDownloader instance.
+    """
+    with patch("rbc.energy.aeso.downloader.requests.get") as mock_get:
+        mock_get.return_value.raise_for_status.side_effect = exceptions.HTTPError("404")
+
+        with pytest.raises(
+            ConnectionError, match="AESO box cloud storage is unreachable"
+        ):
+            AesoDownloader(**init_args)
+
+
+def test_download_data_resume(init_args: dict) -> None:
+    """Happy path for "download_data" method when resuming from checkpoint.
+
+    Args:
+        init_args (dict): Arguments used to initialize an AesoDownloader instance.
+    """
+    args = init_args.copy()
+
+    # save a fake checkpoint file
+    y = args["years"][0]
+    checkpoint = {
+        DownloadTask(date=d, temporal_resolution=t_res).identifier: 1
+        for t_res in args["temporal_resolutions"]
+        for d in pd.date_range(start=f"{y}-01", end=f"{y}-12", freq="MS").strftime(
+            "%Y-%m"
+        )
+    }
+    checkpoint_path = Path(args["output_path"], "status.pickle")
+    checkpoint_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(checkpoint_path, "wb") as f:
+        pickle.dump(checkpoint, f)
+
+    args["resume"] = True
+
+    with patch("rbc.energy.aeso.downloader.requests.get") as mock_get:
+        with patch("rbc.energy.aeso.downloader.BoxClient"):
+            with patch.object(AesoDownloader, "_build_source_lookup", return_value={}):
+                mock_get.return_value = MagicMock(status_code=200)
+                downloader = AesoDownloader(**args)
+
+                with patch.object(downloader, "_download_task_data") as mock_dump:
+                    mock_dump.return_value = 1
+                    downloader.download_data()
+
+                    assert mock_dump.call_count == 0
+                    assert downloader.checkpoint == checkpoint
+
+
+# ----------------------------------
+# Tests - Data crawling logic
+# ----------------------------------
+def test_download_task_data(downloader: AesoDownloader, task: DownloadTask) -> None:
+    """Happy path for "_download_task_data" method when resuming from checkpoint.
+
+    Args:
+        downloader (IesoDownloader): Instance of AesoDownloader class.
+        task (DownloadTask): The metadata of a downloading task, here: date (YYYY-MM), t_res
+    """
+    mock_df = pd.DataFrame({"Volume": [16.2]})
+
+    with patch.object(downloader, "_get_task_data", return_value=mock_df):
+        status = downloader._download_task_data(task)
+
+        assert status == 1
+        expected_file = downloader._build_task_path(task)
+        assert expected_file.is_file(), f"The CSV {expected_file} was not created!"
+
+        saved_df = pd.read_csv(expected_file)
+        assert saved_df.iloc[0]["Volume"] == 16.2
+
+
+def test_get_task_data(downloader: AesoDownloader, task: DownloadTask) -> None:
+    """Happy path for "_get_task_data" method.
+
+    Args:
+        downloader (AesoDownloader): Instance of AesoDownloader class.
+        task (DownloadTask): The metadata of a downloading task, here: date (YYYY-MM), t_res
+    """
+    mock_df = get_mock_df(task)
+    with patch.object(downloader, "_load_zip", return_value=mock_df) as mock_load:
+        df = downloader._get_task_data(task)
+
+    assert not df.empty
+    assert len(df) == 1
+    assert df.iloc[0]["Date (MST)"] == f"{task.date}-01 00:00:00"
+    assert df.iloc[0]["Asset Name"] == "A"
+    assert df.iloc[0]["Volume"] == 10.0
+    assert mock_load.call_count == 1
+
+
+def test_get_task_data_no_lookup_match(init_args: dict, task: DownloadTask) -> None:
+    """Failure path for "_get_task_data" method when no matching file in lookup exists.
+
+    Args:
+        init_args (dict): Arguments used to initialize an AesoDownloader instance.
+        task (DownloadTask): The metadata of a downloading task, here: date (YYYY-MM), t_res
+    """
+    with patch("rbc.energy.aeso.downloader.requests.get") as mock_get:
+        with patch("rbc.energy.aeso.downloader.BoxClient"):
+            with patch.object(AesoDownloader, "_build_source_lookup") as mock_build:
+                mock_get.return_value = MagicMock(status_code=200)
+                mock_build.return_value = {}
+                downloader = AesoDownloader(**init_args)
+
+                with patch.object(downloader, "_load_zip"):
+                    with pytest.raises(
+                        MissingDataError, match="No AESO data that matches"
+                    ):
+                        downloader._get_task_data(task)
+
+
+def test_get_task_data_no_generation_data(
+    downloader: AesoDownloader, task: DownloadTask
+) -> None:
+    """Failure path for "_get_task_data" method when no generation data is available.
+
+    Args:
+        downloader (AesoDownloader): Instance of AesoDownloader class.
+        task (DownloadTask): The metadata of a downloading task, here: date (YYYY-MM), t_res
+    """
+    mock_df = pd.DataFrame(columns=EXPECTED_COLS)
+
+    with patch.object(downloader, "_load_zip", return_value=mock_df):
+        with pytest.raises(MissingDataError, match="No energy generation"):
+            downloader._get_task_data(task)
+
+
+def test_get_task_data_structure_changed(
+    downloader: AesoDownloader, task: DownloadTask
+) -> None:
+    """Failure path for "_get_task_data" method when dataframe doesn't have all columns.
+
+    Args:
+        downloader (AesoDownloader): Instance of AesoDownloader class.
+        task (DownloadTask): The metadata of a downloading task, here: date (YYYY-MM), t_res
+    """
+    mock_df = get_mock_df(task).drop(columns="Asset Name")
+
+    with patch.object(downloader, "_load_zip", return_value=mock_df):
+        with pytest.raises(DataStructureError, match="Missing columns"):
+            downloader._get_task_data(task)
+
+
+def test_get_task_data_date_unparsable(
+    downloader: AesoDownloader, task: DownloadTask
+) -> None:
+    """Failure path for "_get_task_data" method when dataframe doesn't have parsable dates.
+
+    Args:
+        downloader (AesoDownloader): Instance of AesoDownloader class.
+        task (DownloadTask): The metadata of a downloading task, here: date (YYYY-MM), t_res
+    """
+    mock_df = get_mock_df(task)
+    mock_df["Date (MPT)"] = "invalid_date"
+
+    with patch.object(downloader, "_load_zip", return_value=mock_df):
+        with pytest.raises(DataStructureError, match="contains unparsable"):
+            downloader._get_task_data(task)
+
+
+def test_get_task_data_no_generation_data_after_month_filter(
+    downloader: AesoDownloader, task: DownloadTask
+) -> None:
+    """Failure path for _get_task_data when month filter removes all rows.
+
+    Args:
+        downloader (AesoDownloader): Instance of AesoDownloader class.
+        task (DownloadTask): The metadata of a downloading task, here: date (YYYY-MM), t_res
+    """
+    other_month = "2020-02" if task.date != "2020-02" else "2020-03"
+    mock_df = get_mock_df(task)
+    mock_df["Date (MPT)"] = f"{other_month}-01 00:00:00"
+    mock_df["Date (MST)"] = f"{other_month}-01 00:00:00"
+
+    with patch.object(downloader, "_load_zip", return_value=mock_df):
+        with pytest.raises(MissingDataError, match="after month filter"):
+            downloader._get_task_data(task)
+
+
+# ----------------------------------
+# Tests - Data crawling helper methods
+# ----------------------------------
+def test_load_zip(downloader: AesoDownloader, task: DownloadTask) -> None:
+    """Happy path for _load_zip method.
+
+    Args:
+        downloader (AesoDownloader): Instance of AesoDownloader class.
+        task (DownloadTask): The metadata of a downloading task, here: date (YYYY-MM), t_res
+    """
+    # store the mocked df as bytes to buffer
+    mock_df = get_mock_df(task)
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, mode="w", compression=zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr("test.csv", mock_df.to_csv(index=False))
+
+    mock_stream = MagicMock()
+    mock_stream.read.return_value = buffer.getvalue()
+
+    with patch.object(downloader.client.downloads, "download_file") as mock_download:
+        mock_download.return_value = mock_stream
+        df = downloader._load_zip(item_id="fake_id", item_name="fake_name")
+
+    assert not df.empty
+    assert len(df) == 1
+    assert df.iloc[0]["Asset Name"] == "A"
+    mock_download.assert_called_once()
+
+
+def test_load_zip_lru_cache_works(
+    downloader: AesoDownloader, task: DownloadTask
+) -> None:
+    """Happy path for @lru_cache decorator for _load_zip method.
+
+    Args:
+        downloader (AesoDownloader): Instance of AesoDownloader class.
+        task (DownloadTask): The metadata of a downloading task, here: date (YYYY-MM), t_res
+    """
+    mock_df = get_mock_df(task)
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, mode="w", compression=zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr("test.csv", mock_df.to_csv(index=False))
+
+    mock_stream = MagicMock()
+    mock_stream.read.return_value = buffer.getvalue()
+
+    downloader._load_zip.cache_clear()
+
+    with patch.object(downloader.client.downloads, "download_file") as mock_download:
+        mock_download.return_value = mock_stream
+        df1 = downloader._load_zip(item_id="fake_id", item_name="fake_name")
+        df2 = downloader._load_zip(item_id="fake_id", item_name="fake_name")
+        df3 = downloader._load_zip(item_id="fake_id", item_name="fake_name")
+
+    assert mock_download.call_count == 1
+    assert not df1.empty
+    assert df1.equals(df2)
+    assert df2.equals(df3)
+
+
+@pytest.mark.parametrize(
+    "filenames, contents, error_msg",
+    [
+        (["test.txt"], ["hello"], "expected CSV"),
+        (["a.csv", "b.csv"], ["x\n1\n", "x\n2\n"], "expected exactly one file"),
+    ],
+)
+def test_load_zip_structure_change(
+    downloader: AesoDownloader, filenames: list, contents: list, error_msg: str
+) -> None:
+    """Failure path for _load_zip when structure has changed (non-CSV or multiple file(s)).
+
+    Args:
+        downloader (AesoDownloader): Instance of AesoDownloader class.
+        filenames (list): List of filenames.
+        contents (list): List of file contents.
+        error_msg (str): Error message.
+    """
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, mode="w", compression=zipfile.ZIP_DEFLATED) as zf:
+        for f, c in zip(filenames, contents):
+            zf.writestr(f, c)
+
+    mock_stream = MagicMock()
+    mock_stream.read.return_value = buffer.getvalue()
+
+    with patch.object(downloader.client.downloads, "download_file") as mock_download:
+        mock_download.return_value = mock_stream
+        with pytest.raises(DataStructureError, match=error_msg):
+            downloader._load_zip(item_id="fake_id", item_name="fake_name")
+
+
+# ---------------- HELPER FUNCTION ------------------
+def get_item(name: str, item_id: str = "fake_id") -> MagicMock:
+    """Create a fake Box item entry.
+
+    Args:
+        name (str): Name of the box.
+        item_id (str): Identifier of the box.
+
+    Returns:
+        MagicMock: Box item entry.
+    """
+    item = MagicMock()
+    item.name = name
+    item.id = item_id
+    item.type = "file"
+    return item
+
+
+def test_build_source_lookup(downloader: AesoDownloader) -> None:
+    """Happy path for _build_source_lookup with single-date filenames.
+
+    Args:
+        downloader (AesoDownloader): Instance of AesoDownloader class.
+    """
+    page_1h = MagicMock()
+    page_1h.entries = [
+        get_item("(hourly) - 2020-01.zip", "1h_01"),
+        get_item("(hourly) - 2020-02.zip", "1h_02"),
+    ]
+    page_1h.total_count = len(page_1h.entries)
+
+    page_5min = MagicMock()
+    page_5min.entries = [get_item("(5-min) - 2020-01.zip", "5m_01")]
+    page_5min.total_count = len(page_5min.entries)
+
+    with patch.object(downloader.client.folders, "get_folder_items") as mock_items:
+        mock_items.side_effect = [page_1h, page_5min]
+        lookup = downloader._build_source_lookup()
+
+    assert lookup["1h"]["2020-01"] == {"id": "1h_01", "name": "(hourly) - 2020-01.zip"}
+    assert lookup["1h"]["2020-02"] == {"id": "1h_02", "name": "(hourly) - 2020-02.zip"}
+    assert lookup["5min"]["2020-01"] == {"id": "5m_01", "name": "(5-min) - 2020-01.zip"}
+
+
+@pytest.mark.parametrize(
+    "entries_1h, entries_5min, error_msg",
+    [
+        (
+            [get_item("badname.zip", "bad")],
+            [get_item("2020-01.zip", "ok")],
+            "Naming convention",
+        ),
+        (
+            [],
+            [get_item("2020-01.zip", "ok")],
+            "No data for temporal",
+        ),
+    ],
+)
+def test_build_source_lookup_structure_changed(
+    downloader: AesoDownloader,
+    entries_1h: list[MagicMock],
+    entries_5min: list[MagicMock],
+    error_msg: str,
+) -> None:
+    """Failure paths for _build_source_lookup when the structure has changed.
+
+    Args:
+        downloader (AesoDownloader): Instance of AesoDownloader class.
+        entries_1h (list[MagicMock]): Mocked Box entries for the 1h folder.
+        entries_5min (list[MagicMock]): Mocked Box entries for the 5min folder.
+        error_msg (str): Expected error message.
+    """
+    page_1h = MagicMock()
+    page_1h.entries = entries_1h
+    page_1h.total_count = len(entries_1h)
+
+    page_5min = MagicMock()
+    page_5min.entries = entries_5min
+    page_5min.total_count = len(entries_5min)
+
+    with patch.object(downloader.client.folders, "get_folder_items") as mock_items:
+        mock_items.side_effect = [page_1h, page_5min]
+        with pytest.raises(DataStructureError, match=error_msg):
+            downloader._build_source_lookup()

--- a/tests/energy/aeso/test_downloader.py
+++ b/tests/energy/aeso/test_downloader.py
@@ -13,7 +13,12 @@ from requests import exceptions
 
 from rbc.energy.aeso import AesoDownloader
 from rbc.energy.aeso.downloader import EXPECTED_COLS
-from rbc.energy.utils import DataStructureError, DownloadTask, MissingDataError
+from rbc.energy.utils import (
+    DataStructureError,
+    DownloadTask,
+    InvalidError,
+    MissingDataError,
+)
 
 
 # ----------------------------------
@@ -134,6 +139,19 @@ def test_downloader_initialization(
     assert downloader.checkpoint_path == Path(init_args["output_path"], "status.pickle")
     assert downloader.checkpoint == {}
     assert downloader._source_lookup == mock_lookup
+
+
+def test_downloader_initialization_invalid_tres(init_args: dict) -> None:
+    """Failure path for class initialization with invalid temporal resolution.
+
+    Args:
+        init_args (dict): Arguments used to initialize an AesoDownloader instance.
+    """
+    args = init_args.copy()
+    args["temporal_resolutions"] = ["invalid"]
+
+    with pytest.raises(InvalidError, match="Invalid temporal resolution"):
+        AesoDownloader(**args)
 
 
 def test_downloader_initialization_invalid_request(init_args: dict) -> None:
@@ -431,7 +449,7 @@ def get_item(name: str, item_id: str = "fake_id") -> MagicMock:
 
 
 def test_build_source_lookup(downloader: AesoDownloader) -> None:
-    """Happy path for _build_source_lookup with single-date filenames.
+    """Happy path for _build_source_lookup with one- and two-date filenames.
 
     Args:
         downloader (AesoDownloader): Instance of AesoDownloader class.
@@ -439,7 +457,7 @@ def test_build_source_lookup(downloader: AesoDownloader) -> None:
     page_1h = MagicMock()
     page_1h.entries = [
         get_item("(hourly) - 2020-01.zip", "1h_01"),
-        get_item("(hourly) - 2020-02.zip", "1h_02"),
+        get_item("(hourly) - 2020-06 - 2020-12.zip", "1h_06"),
     ]
     page_1h.total_count = len(page_1h.entries)
 
@@ -451,9 +469,15 @@ def test_build_source_lookup(downloader: AesoDownloader) -> None:
         mock_items.side_effect = [page_1h, page_5min]
         lookup = downloader._build_source_lookup()
 
+    # check single file items
     assert lookup["1h"]["2020-01"] == {"id": "1h_01", "name": "(hourly) - 2020-01.zip"}
-    assert lookup["1h"]["2020-02"] == {"id": "1h_02", "name": "(hourly) - 2020-02.zip"}
     assert lookup["5min"]["2020-01"] == {"id": "5m_01", "name": "(5-min) - 2020-01.zip"}
+    # check two-file item (range between items)
+    for i in range(6, 12):
+        assert lookup["1h"][f"2020-{i:02d}"] == {
+            "id": "1h_06",
+            "name": "(hourly) - 2020-06 - 2020-12.zip",
+        }
 
 
 @pytest.mark.parametrize(

--- a/tests/energy/eia/test_downloader.py
+++ b/tests/energy/eia/test_downloader.py
@@ -10,7 +10,7 @@ import pytest
 from requests import exceptions
 
 from rbc.energy.eia import EiaDownloader
-from rbc.energy.utils import MAX_RATE_LIMIT_RETRIES, RateLimitError
+from rbc.energy.utils import MAX_RATE_LIMIT_RETRIES, DownloadKey, RateLimitError
 
 
 # ----------------------------------
@@ -50,17 +50,17 @@ def downloader(init_args: dict) -> EiaDownloader:
 
 
 @pytest.fixture
-def date(init_args: dict) -> str:
-    """Gets a date from the given year.
+def task(init_args: dict) -> DownloadKey:
+    """Gets a task (date) as YYYY-MM-DD from the given year.
 
     Args:
         init_args (dict): Arguments used to initialize an EiaDownloader instance.
 
     Returns:
-        str: Single date to download.
+        DownloadKey: The metadata of a downloading task, here: date (YYYY-MM-DD)
     """
     year = init_args["years"][0]
-    return f"{year}-01-01"
+    return DownloadKey(date=f"{year}-01-01")
 
 
 def mock_eia_json(
@@ -69,7 +69,7 @@ def mock_eia_json(
     """Helper to generate an argument-dependant EIA response body.
 
     Args:
-        date (str): Date to download.
+        date (str): The task date (YYYY-MM-DD)
         data (list): Data list of EIA response body.
         total (int): Total number of data that should exist.
 
@@ -133,7 +133,7 @@ def test_download_data_resume(init_args: dict) -> None:
     # save a fake checkpoint file
     y = args["years"][0]
     checkpoint = {
-        d: 1
+        EiaDownloader._turn_task_into_checkpoint_key(DownloadKey(date=d)): 1
         for d in pd.date_range(start=f"{y}-01-01", end=f"{y}-12-31")
         .strftime("%Y-%m-%d")
         .tolist()
@@ -159,81 +159,87 @@ def test_download_data_resume(init_args: dict) -> None:
 # ----------------------------------
 # Tests - Data crawling logic
 # ----------------------------------
-def test_download_task_data(downloader: EiaDownloader, date: str) -> None:
+def test_download_task_data(downloader: EiaDownloader, task: DownloadKey) -> None:
     """Happy path for "_download_task_data" method when resuming from checkpoint.
 
     Args:
         downloader (EiaDownloader): Instance of EiaDownloader class.
-        date (str): Date to download.
+        task (DownloadKey): The metadata of a downloading task, here: date (YYYY-MM-DD)
     """
     mock_df = pd.DataFrame({"total": [16.2]})
 
     with patch.object(downloader, "_get_task_data", return_value=mock_df):
-        status = downloader._download_task_data(date)
+        status = downloader._download_task_data(task)
 
         assert status == 1
-        expected_file = Path(downloader.output_path, f"{date}.csv")
+        expected_file = Path(downloader.output_path, "1h", f"{task.date}.csv")
         assert expected_file.is_file(), f"The CSV {expected_file} was not created!"
 
         saved_df = pd.read_csv(expected_file)
         assert saved_df.iloc[0]["total"] == 16.2
 
 
-def test_get_task_data(downloader: EiaDownloader, date: str) -> None:
+def test_get_task_data(downloader: EiaDownloader, task: DownloadKey) -> None:
     """Happy path for "_get_task_data" method.
 
     Args:
         downloader (EiaDownloader): Instance of EiaDownloader class.
-        date (str): Date to download.
+        task (DownloadKey): The metadata of a downloading task, here: date (YYYY-MM-DD)
     """
     mock_response = MagicMock(status_code=200)
-    mock_response.json.return_value = mock_eia_json(date)
+    mock_response.json.return_value = mock_eia_json(task.date)
 
     with patch("rbc.energy.eia.downloader.requests.get") as mock_get:
         mock_get.return_value = mock_response
-        df = downloader._get_task_data(date)
+        df = downloader._get_task_data(task)
 
     assert not df.empty
     assert len(df) == 1
-    assert df.iloc[0]["period"] == f"{date}T00"
+    assert df.iloc[0]["period"] == f"{task.date}T00"
     assert df.iloc[0]["value"] == "10"
     assert mock_get.call_count == 1
 
 
-def test_get_task_data_request_failed(downloader: EiaDownloader, date: str) -> None:
+def test_get_task_data_request_failed(
+    downloader: EiaDownloader, task: DownloadKey
+) -> None:
     """Failure path for "_get_task_data" method when the request fails directly.
 
     Args:
         downloader (EiaDownloader): Instance of EiaDownloader class.
-        date (str): Date to download.
+        task (DownloadKey): The metadata of a downloading task, here: date (YYYY-MM-DD)
     """
     with patch("rbc.energy.eia.downloader.requests.get") as mock_get:
         mock_get.side_effect = exceptions.ConnectionError
 
         with pytest.raises(exceptions.ConnectionError, match="request failed"):
-            downloader._get_task_data(date)
+            downloader._get_task_data(task)
 
         mock_get.side_effect = exceptions.Timeout
 
         with pytest.raises(exceptions.Timeout, match="request failed"):
-            downloader._get_task_data(date)
+            downloader._get_task_data(task)
 
 
-def test_get_task_data_fail_return_code(downloader: EiaDownloader, date: str) -> None:
+def test_get_task_data_fail_return_code(
+    downloader: EiaDownloader, task: DownloadKey
+) -> None:
     """Failure path for "_get_task_data" method when the return code is unsuccessful.
 
     Args:
         downloader (EiaDownloader): Instance of EiaDownloader class.
-        date (str): Date to download.
+        task (DownloadKey): The metadata of a downloading task, here: date (YYYY-MM-DD)
     """
     with patch("rbc.energy.eia.downloader.requests.get") as mock_get:
         mock_get.return_value = MagicMock(status_code=500)
 
         with pytest.raises(exceptions.HTTPError, match="request failed"):
-            downloader._get_task_data(date)
+            downloader._get_task_data(task)
 
 
-def test_get_task_data_rate_limit_fail(downloader: EiaDownloader, date: str) -> None:
+def test_get_task_data_rate_limit_fail(
+    downloader: EiaDownloader, task: DownloadKey
+) -> None:
     """Failure path for "_get_task_data" method when the rate limit is reached (code 429).
 
     Checks that the warning message is logged when the return code is 429 on a first
@@ -241,7 +247,7 @@ def test_get_task_data_rate_limit_fail(downloader: EiaDownloader, date: str) -> 
 
     Args:
         downloader (EiaDownloader): Instance of EiaDownloader class.
-        date (str): Date to download.
+        task (DownloadKey): The metadata of a downloading task, here: date (YYYY-MM-DD)
     """
     with patch("rbc.energy.eia.downloader.requests.get") as mock_get, patch(
         "rbc.energy.eia.downloader.time.sleep"
@@ -251,7 +257,7 @@ def test_get_task_data_rate_limit_fail(downloader: EiaDownloader, date: str) -> 
         )
 
         with pytest.raises(RateLimitError, match="limit has been exceeded"):
-            downloader._get_task_data(date)
+            downloader._get_task_data(task)
 
         assert mock_get.call_count == MAX_RATE_LIMIT_RETRIES + 1
         assert mock_sleep.call_count == MAX_RATE_LIMIT_RETRIES
@@ -259,13 +265,13 @@ def test_get_task_data_rate_limit_fail(downloader: EiaDownloader, date: str) -> 
 
 @pytest.mark.parametrize("return_val", [{}, {"response": {}}])
 def test_get_task_data_failed_response_parsing(
-    downloader: EiaDownloader, date: str, return_val: dict
+    downloader: EiaDownloader, task: DownloadKey, return_val: dict
 ) -> None:
     """Failure path for "_get_task_data" method when the parsed response is incomplete.
 
     Args:
         downloader (EiaDownloader): Instance of EiaDownloader class.
-        date (str): Date to download.
+        task (DownloadKey): The metadata of a downloading task, here: date (YYYY-MM-DD)
         return_val (dict): Incomplete return values from parsing.
     """
     mock_response = MagicMock(status_code=200)
@@ -275,17 +281,17 @@ def test_get_task_data_failed_response_parsing(
         mock_get.return_value = mock_response
 
         with pytest.raises(ValueError, match="Failed parsing"):
-            downloader._get_task_data(date)
+            downloader._get_task_data(task)
 
 
 def test_get_task_data_incomplete_download(
-    downloader: EiaDownloader, date: str
+    downloader: EiaDownloader, task: DownloadKey
 ) -> None:
     """Failure path for "_get_task_data" method when the download isn't complete.
 
     Args:
         downloader (EiaDownloader): Instance of EiaDownloader class.
-        date (str): Date to download.
+        task (DownloadKey): The metadata of a downloading task, here: date (YYYY-MM-DD)
     """
     mock_response = MagicMock(status_code=200)
     mock_response.json.return_value = mock_eia_json(total=1)
@@ -294,15 +300,17 @@ def test_get_task_data_incomplete_download(
         mock_get.return_value = mock_response
 
         with pytest.raises(ValueError, match="Incomplete download"):
-            downloader._get_task_data(date)
+            downloader._get_task_data(task)
 
 
-def test_get_task_data_empty_response(downloader: EiaDownloader, date: str) -> None:
+def test_get_task_data_empty_response(
+    downloader: EiaDownloader, task: DownloadKey
+) -> None:
     """Failure path for "_get_task_data" method when the API returns no data.
 
     Args:
         downloader (EiaDownloader): Instance of EiaDownloader class.
-        date (str): Date to download.
+        task (DownloadKey): The metadata of a downloading task, here: date (YYYY-MM-DD)
     """
     mock_response = MagicMock(status_code=200)
     mock_response.json.return_value = mock_eia_json()
@@ -311,4 +319,4 @@ def test_get_task_data_empty_response(downloader: EiaDownloader, date: str) -> N
         mock_get.return_value = mock_response
 
         with pytest.raises(ValueError, match="No generation data available"):
-            downloader._get_task_data(date)
+            downloader._get_task_data(task)

--- a/tests/energy/eia/test_downloader.py
+++ b/tests/energy/eia/test_downloader.py
@@ -70,7 +70,7 @@ def task(init_args: dict) -> DownloadTask:
     return DownloadTask(date=f"{year}-01-01")
 
 
-def mock_eia_json(
+def get_mock_eia_json(
     date: str | None = None, data: list | None = None, total: int | None = None
 ) -> dict:
     """Helper to generate an argument-dependant EIA response body.
@@ -85,7 +85,17 @@ def mock_eia_json(
     """
     if date is not None:
         if data is None:
-            data = [{"period": f"{date}T00", "respondent": "A", "value": "10"}]
+            data = [
+                {
+                    "period": f"{date}T00",
+                    "respondent": "A",
+                    "respondent-name": "Company A",
+                    "fueltype": "NG",
+                    "type-name": "Natural Gas",
+                    "value": "10",
+                    "value-units": "megawatthours",
+                }
+            ]
     else:
         data = []
 
@@ -194,7 +204,7 @@ def test_get_task_data(downloader: EiaDownloader, task: DownloadTask) -> None:
         task (DownloadTask): The metadata of a downloading task, here: date (YYYY-MM-DD)
     """
     mock_response = MagicMock(status_code=200)
-    mock_response.json.return_value = mock_eia_json(task.date)
+    mock_response.json.return_value = get_mock_eia_json(task.date)
 
     with patch("rbc.energy.eia.downloader.requests.get") as mock_get:
         mock_get.return_value = mock_response
@@ -301,7 +311,7 @@ def test_get_task_data_incomplete_download(
         task (DownloadTask): The metadata of a downloading task, here: date (YYYY-MM-DD)
     """
     mock_response = MagicMock(status_code=200)
-    mock_response.json.return_value = mock_eia_json(total=1)
+    mock_response.json.return_value = get_mock_eia_json(total=1)
 
     with patch("rbc.energy.eia.downloader.requests.get") as mock_get:
         mock_get.return_value = mock_response
@@ -320,7 +330,7 @@ def test_get_task_data_no_generation_data(
         task (DownloadTask): The metadata of a downloading task, here: date (YYYY-MM-DD)
     """
     mock_response = MagicMock(status_code=200)
-    mock_response.json.return_value = mock_eia_json()
+    mock_response.json.return_value = get_mock_eia_json()
 
     with patch("rbc.energy.eia.downloader.requests.get") as mock_get:
         mock_get.return_value = mock_response
@@ -328,4 +338,25 @@ def test_get_task_data_no_generation_data(
         with pytest.raises(
             MissingDataError, match="No energy generation data available"
         ):
+            downloader._get_task_data(task)
+
+
+def test_get_task_data_structure_changed(
+    downloader: EiaDownloader, task: DownloadTask
+) -> None:
+    """Failure path for "_get_task_data" method when dataframe doesn't have all columns.
+
+    Args:
+        downloader (EiaDownloader): Instance of EiaDownloader class.
+        task (DownloadTask): The metadata of a downloading task, here: date (YYYY-MM-DD)
+    """
+    mock_response = MagicMock(status_code=200)
+    mock_response.json.return_value = get_mock_eia_json(
+        date="2020-01-01", data=[{"period": f"{task.date}T00"}]
+    )
+
+    with patch("rbc.energy.eia.downloader.requests.get") as mock_get:
+        mock_get.return_value = mock_response
+
+        with pytest.raises(DataStructureError, match="Missing columns"):
             downloader._get_task_data(task)

--- a/tests/energy/eia/test_downloader.py
+++ b/tests/energy/eia/test_downloader.py
@@ -58,7 +58,7 @@ def downloader(init_args: dict) -> EiaDownloader:
 
 @pytest.fixture
 def task(init_args: dict) -> DownloadTask:
-    """Gets a task (date) as YYYY-MM-DD from the given year.
+    """Gets a task as 'date=YYYY-MM-DD' from the init arguments.
 
     Args:
         init_args (dict): Arguments used to initialize an EiaDownloader instance.

--- a/tests/energy/eia/test_downloader.py
+++ b/tests/energy/eia/test_downloader.py
@@ -10,7 +10,14 @@ import pytest
 from requests import exceptions
 
 from rbc.energy.eia import EiaDownloader
-from rbc.energy.utils import MAX_RATE_LIMIT_RETRIES, DownloadKey, RateLimitError
+from rbc.energy.utils import (
+    MAX_RATE_LIMIT_RETRIES,
+    DataStructureError,
+    DownloadKey,
+    InvalidError,
+    MissingDataError,
+    RateLimitError,
+)
 
 
 # ----------------------------------
@@ -118,7 +125,7 @@ def test_downloader_initialization_invalid_token(init_args: dict) -> None:
     with patch("rbc.energy.eia.downloader.requests.get") as mock_get:
         mock_get.return_value = MagicMock(status_code=400)
 
-        with pytest.raises(ValueError, match="incorrect"):
+        with pytest.raises(InvalidError, match="incorrect"):
             EiaDownloader(**init_args)
 
 
@@ -280,7 +287,7 @@ def test_get_task_data_failed_response_parsing(
     with patch("rbc.energy.eia.downloader.requests.get") as mock_get:
         mock_get.return_value = mock_response
 
-        with pytest.raises(ValueError, match="Failed parsing"):
+        with pytest.raises(DataStructureError, match="Failed parsing"):
             downloader._get_task_data(task)
 
 
@@ -299,7 +306,7 @@ def test_get_task_data_incomplete_download(
     with patch("rbc.energy.eia.downloader.requests.get") as mock_get:
         mock_get.return_value = mock_response
 
-        with pytest.raises(ValueError, match="Incomplete download"):
+        with pytest.raises(ConnectionError, match="Incomplete download"):
             downloader._get_task_data(task)
 
 
@@ -318,5 +325,5 @@ def test_get_task_data_empty_response(
     with patch("rbc.energy.eia.downloader.requests.get") as mock_get:
         mock_get.return_value = mock_response
 
-        with pytest.raises(ValueError, match="No generation data available"):
+        with pytest.raises(MissingDataError, match="No generation data available"):
             downloader._get_task_data(task)

--- a/tests/energy/eia/test_downloader.py
+++ b/tests/energy/eia/test_downloader.py
@@ -13,7 +13,7 @@ from rbc.energy.eia import EiaDownloader
 from rbc.energy.utils import (
     MAX_RATE_LIMIT_RETRIES,
     DataStructureError,
-    DownloadKey,
+    DownloadTask,
     InvalidError,
     MissingDataError,
     RateLimitError,
@@ -57,17 +57,17 @@ def downloader(init_args: dict) -> EiaDownloader:
 
 
 @pytest.fixture
-def task(init_args: dict) -> DownloadKey:
+def task(init_args: dict) -> DownloadTask:
     """Gets a task (date) as YYYY-MM-DD from the given year.
 
     Args:
         init_args (dict): Arguments used to initialize an EiaDownloader instance.
 
     Returns:
-        DownloadKey: The metadata of a downloading task, here: date (YYYY-MM-DD)
+        DownloadTask: The metadata of a downloading task, here: date (YYYY-MM-DD)
     """
     year = init_args["years"][0]
-    return DownloadKey(date=f"{year}-01-01")
+    return DownloadTask(date=f"{year}-01-01")
 
 
 def mock_eia_json(
@@ -140,7 +140,7 @@ def test_download_data_resume(init_args: dict) -> None:
     # save a fake checkpoint file
     y = args["years"][0]
     checkpoint = {
-        EiaDownloader._turn_task_into_checkpoint_key(DownloadKey(date=d)): 1
+        DownloadTask(date=d).identifier: 1
         for d in pd.date_range(start=f"{y}-01-01", end=f"{y}-12-31")
         .strftime("%Y-%m-%d")
         .tolist()
@@ -166,12 +166,12 @@ def test_download_data_resume(init_args: dict) -> None:
 # ----------------------------------
 # Tests - Data crawling logic
 # ----------------------------------
-def test_download_task_data(downloader: EiaDownloader, task: DownloadKey) -> None:
+def test_download_task_data(downloader: EiaDownloader, task: DownloadTask) -> None:
     """Happy path for "_download_task_data" method when resuming from checkpoint.
 
     Args:
         downloader (EiaDownloader): Instance of EiaDownloader class.
-        task (DownloadKey): The metadata of a downloading task, here: date (YYYY-MM-DD)
+        task (DownloadTask): The metadata of a downloading task, here: date (YYYY-MM-DD)
     """
     mock_df = pd.DataFrame({"total": [16.2]})
 
@@ -179,19 +179,19 @@ def test_download_task_data(downloader: EiaDownloader, task: DownloadKey) -> Non
         status = downloader._download_task_data(task)
 
         assert status == 1
-        expected_file = Path(downloader.output_path, "1h", f"{task.date}.csv")
+        expected_file = downloader._build_task_path(task)
         assert expected_file.is_file(), f"The CSV {expected_file} was not created!"
 
         saved_df = pd.read_csv(expected_file)
         assert saved_df.iloc[0]["total"] == 16.2
 
 
-def test_get_task_data(downloader: EiaDownloader, task: DownloadKey) -> None:
+def test_get_task_data(downloader: EiaDownloader, task: DownloadTask) -> None:
     """Happy path for "_get_task_data" method.
 
     Args:
         downloader (EiaDownloader): Instance of EiaDownloader class.
-        task (DownloadKey): The metadata of a downloading task, here: date (YYYY-MM-DD)
+        task (DownloadTask): The metadata of a downloading task, here: date (YYYY-MM-DD)
     """
     mock_response = MagicMock(status_code=200)
     mock_response.json.return_value = mock_eia_json(task.date)
@@ -208,13 +208,13 @@ def test_get_task_data(downloader: EiaDownloader, task: DownloadKey) -> None:
 
 
 def test_get_task_data_request_failed(
-    downloader: EiaDownloader, task: DownloadKey
+    downloader: EiaDownloader, task: DownloadTask
 ) -> None:
     """Failure path for "_get_task_data" method when the request fails directly.
 
     Args:
         downloader (EiaDownloader): Instance of EiaDownloader class.
-        task (DownloadKey): The metadata of a downloading task, here: date (YYYY-MM-DD)
+        task (DownloadTask): The metadata of a downloading task, here: date (YYYY-MM-DD)
     """
     with patch("rbc.energy.eia.downloader.requests.get") as mock_get:
         mock_get.side_effect = exceptions.ConnectionError
@@ -229,13 +229,13 @@ def test_get_task_data_request_failed(
 
 
 def test_get_task_data_fail_return_code(
-    downloader: EiaDownloader, task: DownloadKey
+    downloader: EiaDownloader, task: DownloadTask
 ) -> None:
     """Failure path for "_get_task_data" method when the return code is unsuccessful.
 
     Args:
         downloader (EiaDownloader): Instance of EiaDownloader class.
-        task (DownloadKey): The metadata of a downloading task, here: date (YYYY-MM-DD)
+        task (DownloadTask): The metadata of a downloading task, here: date (YYYY-MM-DD)
     """
     with patch("rbc.energy.eia.downloader.requests.get") as mock_get:
         mock_get.return_value = MagicMock(status_code=500)
@@ -245,7 +245,7 @@ def test_get_task_data_fail_return_code(
 
 
 def test_get_task_data_rate_limit_fail(
-    downloader: EiaDownloader, task: DownloadKey
+    downloader: EiaDownloader, task: DownloadTask
 ) -> None:
     """Failure path for "_get_task_data" method when the rate limit is reached (code 429).
 
@@ -254,7 +254,7 @@ def test_get_task_data_rate_limit_fail(
 
     Args:
         downloader (EiaDownloader): Instance of EiaDownloader class.
-        task (DownloadKey): The metadata of a downloading task, here: date (YYYY-MM-DD)
+        task (DownloadTask): The metadata of a downloading task, here: date (YYYY-MM-DD)
     """
     with patch("rbc.energy.eia.downloader.requests.get") as mock_get, patch(
         "rbc.energy.eia.downloader.time.sleep"
@@ -272,13 +272,13 @@ def test_get_task_data_rate_limit_fail(
 
 @pytest.mark.parametrize("return_val", [{}, {"response": {}}])
 def test_get_task_data_failed_response_parsing(
-    downloader: EiaDownloader, task: DownloadKey, return_val: dict
+    downloader: EiaDownloader, task: DownloadTask, return_val: dict
 ) -> None:
     """Failure path for "_get_task_data" method when the parsed response is incomplete.
 
     Args:
         downloader (EiaDownloader): Instance of EiaDownloader class.
-        task (DownloadKey): The metadata of a downloading task, here: date (YYYY-MM-DD)
+        task (DownloadTask): The metadata of a downloading task, here: date (YYYY-MM-DD)
         return_val (dict): Incomplete return values from parsing.
     """
     mock_response = MagicMock(status_code=200)
@@ -292,13 +292,13 @@ def test_get_task_data_failed_response_parsing(
 
 
 def test_get_task_data_incomplete_download(
-    downloader: EiaDownloader, task: DownloadKey
+    downloader: EiaDownloader, task: DownloadTask
 ) -> None:
     """Failure path for "_get_task_data" method when the download isn't complete.
 
     Args:
         downloader (EiaDownloader): Instance of EiaDownloader class.
-        task (DownloadKey): The metadata of a downloading task, here: date (YYYY-MM-DD)
+        task (DownloadTask): The metadata of a downloading task, here: date (YYYY-MM-DD)
     """
     mock_response = MagicMock(status_code=200)
     mock_response.json.return_value = mock_eia_json(total=1)
@@ -310,14 +310,14 @@ def test_get_task_data_incomplete_download(
             downloader._get_task_data(task)
 
 
-def test_get_task_data_empty_response(
-    downloader: EiaDownloader, task: DownloadKey
+def test_get_task_data_no_generation_data(
+    downloader: EiaDownloader, task: DownloadTask
 ) -> None:
-    """Failure path for "_get_task_data" method when the API returns no data.
+    """Failure path for "_get_task_data" method when no generation data is available.
 
     Args:
         downloader (EiaDownloader): Instance of EiaDownloader class.
-        task (DownloadKey): The metadata of a downloading task, here: date (YYYY-MM-DD)
+        task (DownloadTask): The metadata of a downloading task, here: date (YYYY-MM-DD)
     """
     mock_response = MagicMock(status_code=200)
     mock_response.json.return_value = mock_eia_json()
@@ -325,5 +325,7 @@ def test_get_task_data_empty_response(
     with patch("rbc.energy.eia.downloader.requests.get") as mock_get:
         mock_get.return_value = mock_response
 
-        with pytest.raises(MissingDataError, match="No generation data available"):
+        with pytest.raises(
+            MissingDataError, match="No energy generation data available"
+        ):
             downloader._get_task_data(task)

--- a/tests/energy/entsoe/test_downloader.py
+++ b/tests/energy/entsoe/test_downloader.py
@@ -105,6 +105,19 @@ def test_downloader_initialization(init_args: dict, bz: str, valid: bool) -> Non
         assert downloader.checkpoint == {}
 
 
+def test_downloader_initialization_invalid_config(init_args: dict) -> None:
+    """Failure path for class initialization with invalid API configuration.
+
+    Args:
+        init_args (dict): Arguments used to initialize an AesoDownloader instance.
+    """
+    with patch("rbc.energy.entsoe.downloader.set_config"):
+        with patch("rbc.energy.entsoe.downloader.get_config") as mock_config:
+            mock_config.return_value.security_token = None
+            with pytest.raises(InvalidError, match="failed to successfully configure"):
+                EntsoeDownloader(**init_args)
+
+
 def test_download_data_resume(init_args: dict) -> None:
     """Happy path for "download_data" method when resuming from checkpoint.
 
@@ -204,7 +217,22 @@ def test_get_task_data(downloader: EntsoeDownloader, task: DownloadTask) -> None
     assert mock_extract.call_count == 1
 
 
-def test_get_task_data_timed_service_unavailable(
+def test_get_task_data_no_data_for_old_year(
+    downloader: EntsoeDownloader, task: DownloadTask
+) -> None:
+    """Failure path for "_get_task_data" method when the bz has no data for the task's year.
+
+    Args:
+        downloader (EntsoeDownloader): Instance of EntsoeDownloader class.
+        task (DownloadTask): The metadata of a downloading task, here: date (YYYY-MM-DD), bz
+    """
+    invalid_task = task.update(date="1900-01-01")
+
+    with pytest.raises(MissingDataError, match="No data for year"):
+        downloader._get_task_data(invalid_task)
+
+
+def test_get_task_data_service_unavailable(
     downloader: EntsoeDownloader, task: DownloadTask
 ) -> None:
     """Failure path for "_get_task_data" method when the service is unavailable.

--- a/tests/energy/entsoe/test_downloader.py
+++ b/tests/energy/entsoe/test_downloader.py
@@ -11,7 +11,12 @@ import pytest
 from entsoe.query.decorators import ServiceUnavailableError
 
 from rbc.energy.entsoe import EntsoeDownloader
-from rbc.energy.utils import DataStructureError, DownloadKey
+from rbc.energy.utils import (
+    DataStructureError,
+    DownloadKey,
+    InvalidError,
+    MissingDataError,
+)
 
 
 # ----------------------------------
@@ -107,7 +112,7 @@ def test_downloader_initialization(
     args["bidding_zones"] = [bz]
 
     if not valid:
-        with pytest.raises(ValueError, match="not supported"):
+        with pytest.raises(InvalidError, match="not supported"):
             EntsoeDownloader(**args)
     else:
         downloader = EntsoeDownloader(**args)
@@ -273,7 +278,7 @@ def test_get_task_data_no_data_available(
     ) as mock_api:
         mock_api.return_value.query_api.return_value = []
 
-        with pytest.raises(ValueError, match="No data available"):
+        with pytest.raises(MissingDataError, match="No data available"):
             downloader._get_task_data(task)
 
 

--- a/tests/energy/entsoe/test_downloader.py
+++ b/tests/energy/entsoe/test_downloader.py
@@ -13,7 +13,7 @@ from entsoe.query.decorators import ServiceUnavailableError
 from rbc.energy.entsoe import EntsoeDownloader
 from rbc.energy.utils import (
     DataStructureError,
-    DownloadKey,
+    DownloadTask,
     InvalidError,
     MissingDataError,
 )
@@ -70,25 +70,19 @@ def downloader(api_config: Generator, init_args: dict) -> EntsoeDownloader:
 
 
 @pytest.fixture
-def download_args(init_args: dict) -> tuple[DownloadKey, dict, Path]:
-    """Gets a set of download arguments from the initialisation arguments.
+def task(init_args: dict) -> DownloadTask:
+    """Gets a task (month) as YYYY-MM-DD from the given year.
 
     Args:
         init_args (dict): Arguments used to initialize an EntsoeDownloader instance.
 
     Returns:
-        tuple[DownloadKey, dict, Path]: Tuple of (task, checkpoint, checkpoint_path) for
-            downloading.
+        DownloadTask: The metadata of a downloading task, here: date (YYYY-MM-DD), bz
     """
-    task = DownloadKey(
+    return DownloadTask(
         date=f"{init_args['years'][0]}-01-01",
         bidding_zone=init_args["bidding_zones"][0],
     )
-    checkpoint: dict = {}
-    checkpoint_path = Path(
-        init_args["output_path"], init_args["bidding_zones"][0], "status.pickle"
-    )
-    return task, checkpoint, checkpoint_path
 
 
 # ----------------------------------
@@ -120,6 +114,10 @@ def test_downloader_initialization(
         assert downloader.bidding_zones == args["bidding_zones"]
         assert downloader.years == args["years"]
         assert downloader.output_path == args["output_path"]
+        assert downloader.checkpoint_path == Path(
+            init_args["output_path"], "status.pickle"
+        )
+        assert downloader.checkpoint == {}
 
 
 def test_download_data_resume(api_config: Generator, init_args: dict) -> None:
@@ -135,39 +133,37 @@ def test_download_data_resume(api_config: Generator, init_args: dict) -> None:
     bz = args["bidding_zones"][0]
     y = args["years"][0]
     checkpoint = {
-        EntsoeDownloader._turn_task_into_checkpoint_key(
-            DownloadKey(date=d, bidding_zone=bz)
-        ): 1
+        DownloadTask(date=d, bidding_zone=bz).identifier: 1
         for d in pd.date_range(start=f"{y}-01-01", end=f"{y}-12-31")
         .strftime("%Y-%m-%d")
         .tolist()
     }
-
-    args["resume"] = True
-    downloader = EntsoeDownloader(**args)
-
-    checkpoint_path = downloader._build_checkpoint_path(DownloadKey(bidding_zone=bz))
+    checkpoint_path = Path(args["output_path"], "status.pickle")
     checkpoint_path.parent.mkdir(parents=True, exist_ok=True)
     with open(checkpoint_path, "wb") as f:
         pickle.dump(checkpoint, f)
 
+    args["resume"] = True
+
+    downloader = EntsoeDownloader(**args)
     with patch.object(downloader, "_download_task_data") as mock_dump:
+        mock_dump.return_value = 1
         downloader.download_data()
 
         assert mock_dump.call_count == 0
+        assert downloader.checkpoint == checkpoint
 
 
 # ----------------------------------
 # Tests - Data crawling logic
 # ----------------------------------
-def test_download_day_data(downloader: EntsoeDownloader, download_args: tuple) -> None:
+def test_download_day_data(downloader: EntsoeDownloader, task: DownloadTask) -> None:
     """Happy path for "_download_task_data" method when resuming from checkpoint.
 
     Args:
         downloader (EntsoeDownloader): Instance of EntsoeDownloader class.
-        download_args (tuple): Tuple of download arguments for running _get_task_data.
+        task (DownloadTask): The metadata of a downloading task, here: date (YYYY-MM-DD), bz
     """
-    task, checkpoint, checkpoint_path = download_args
     mock_df = pd.DataFrame({"Generation_MW": [16.2], "Temporal_Resolution": ["PT60M"]})
 
     with patch.object(downloader, "_get_task_data", return_value=mock_df):
@@ -181,14 +177,13 @@ def test_download_day_data(downloader: EntsoeDownloader, download_args: tuple) -
         assert saved_df.iloc[0]["Generation_MW"] == 16.2
 
 
-def test_get_task_data(downloader: EntsoeDownloader, download_args: tuple) -> None:
+def test_get_task_data(downloader: EntsoeDownloader, task: DownloadTask) -> None:
     """Happy path for "_get_task_data" method.
 
     Args:
         downloader (EntsoeDownloader): Instance of EntsoeDownloader class.
-        download_args (tuple): Tuple of download arguments for running _get_task_data.
+        task (DownloadTask): The metadata of a downloading task, here: date (YYYY-MM-DD), bz
     """
-    task, checkpoint, checkpoint_path = download_args
     timestamp = f"{task.date}T00:00:00+00:00"
     return_value = [
         {
@@ -223,16 +218,14 @@ def test_get_task_data(downloader: EntsoeDownloader, download_args: tuple) -> No
 
 
 def test_get_task_data_timed_service_unavailable(
-    downloader: EntsoeDownloader, download_args: tuple
+    downloader: EntsoeDownloader, task: DownloadTask
 ) -> None:
     """Failure path for "_get_task_data" method when the service is unavailable.
 
     Args:
         downloader (EntsoeDownloader): Instance of EntsoeDownloader class.
-        download_args (tuple): Tuple of download arguments for running _get_task_data.
+        task (DownloadTask): The metadata of a downloading task, here: date (YYYY-MM-DD), bz
     """
-    task, _, _ = download_args
-
     with patch(
         "rbc.energy.entsoe.downloader.ActualGenerationPerGenerationUnit"
     ) as mock_api:
@@ -242,17 +235,15 @@ def test_get_task_data_timed_service_unavailable(
             downloader._get_task_data(task)
 
 
-def test_get_task_data_requested_data_not_returned(
-    downloader: EntsoeDownloader, download_args: tuple
+def test_get_task_data_requested_no_requested_data_returned(
+    downloader: EntsoeDownloader, task: DownloadTask
 ) -> None:
     """Failure path for "_get_task_data" method when the requested data is not returned.
 
     Args:
         downloader (EntsoeDownloader): Instance of EntsoeDownloader class.
-        download_args (tuple): Tuple of download arguments for running _get_task_data.
+        task (DownloadTask): The metadata of a downloading task, here: date (YYYY-MM-DD), bz
     """
-    task, _, _ = download_args
-
     with patch(
         "rbc.energy.entsoe.downloader.ActualGenerationPerGenerationUnit"
     ) as mock_api:
@@ -262,37 +253,35 @@ def test_get_task_data_requested_data_not_returned(
             downloader._get_task_data(task)
 
 
-def test_get_task_data_no_data_available(
-    downloader: EntsoeDownloader, download_args: tuple
+def test_get_task_data_no_generation_data(
+    downloader: EntsoeDownloader, task: DownloadTask
 ) -> None:
-    """Failure path for "_get_task_data" method when the requested data is empty.
+    """Failure path for "_get_task_data" method when no generation data is available.
 
     Args:
         downloader (EntsoeDownloader): Instance of EntsoeDownloader class.
-        download_args (tuple): Tuple of download arguments for running _get_task_data.
+        task (DownloadTask): The metadata of a downloading task, here: date (YYYY-MM-DD), bz
     """
-    task, _, _ = download_args
-
     with patch(
         "rbc.energy.entsoe.downloader.ActualGenerationPerGenerationUnit"
     ) as mock_api:
         mock_api.return_value.query_api.return_value = []
 
-        with pytest.raises(MissingDataError, match="No data available"):
+        with pytest.raises(
+            MissingDataError, match="No energy generation data available"
+        ):
             downloader._get_task_data(task)
 
 
 def test_get_task_data_structure_change(
-    downloader: EntsoeDownloader, download_args: tuple
+    downloader: EntsoeDownloader, task: DownloadTask
 ) -> None:
     """Failure path for "_get_task_data" method when the expected columns are missing.
 
     Args:
         downloader (EntsoeDownloader): Instance of EntsoeDownloader class.
-        download_args (tuple): Tuple of download arguments for running _get_task_data.
+        task (DownloadTask): The metadata of a downloading task, here: date (YYYY-MM-DD), bz
     """
-    task, _, _ = download_args
-
     with patch(
         "rbc.energy.entsoe.downloader.ActualGenerationPerGenerationUnit"
     ) as mock_api, patch(

--- a/tests/energy/entsoe/test_downloader.py
+++ b/tests/energy/entsoe/test_downloader.py
@@ -226,10 +226,10 @@ def test_get_task_data_no_data_for_old_year(
         downloader (EntsoeDownloader): Instance of EntsoeDownloader class.
         task (DownloadTask): The metadata of a downloading task, here: date (YYYY-MM-DD), bz
     """
-    invalid_task = task.update(date="1900-01-01")
+    old_year_task = task.update(date="1900-01-01")
 
     with pytest.raises(MissingDataError, match="No data for year"):
-        downloader._get_task_data(invalid_task)
+        downloader._get_task_data(old_year_task)
 
 
 def test_get_task_data_service_unavailable(

--- a/tests/energy/entsoe/test_downloader.py
+++ b/tests/energy/entsoe/test_downloader.py
@@ -3,7 +3,6 @@
 
 import pickle
 from pathlib import Path
-from typing import Generator
 from unittest.mock import patch
 
 import pandas as pd
@@ -22,19 +21,6 @@ from rbc.energy.utils import (
 # ----------------------------------
 # Fixtures
 # ----------------------------------
-@pytest.fixture
-def api_config() -> Generator:
-    """Fixture that patches the entsoe-apy package configuration.
-
-    Yields:
-       patched successful api configuration.
-    """
-    with patch("rbc.energy.entsoe.downloader.set_config"):
-        with patch("rbc.energy.entsoe.downloader.get_config") as mock_get:
-            mock_get.return_value.security_token = "fake_token"
-            yield
-
-
 @pytest.fixture
 def init_args(tmp_path: Path) -> dict:
     """Creates a basic setup with a temporary directory.
@@ -55,18 +41,18 @@ def init_args(tmp_path: Path) -> dict:
 
 
 @pytest.fixture
-def downloader(api_config: Generator, init_args: dict) -> EntsoeDownloader:
+def downloader(init_args: dict) -> EntsoeDownloader:
     """Returns an instantiated EntsoeDownloader.
 
     Args:
-        api_config (Generator): Fixture that patches the ENTSO-E global configuration.
         init_args (dict): Arguments used to initialize an EntsoeDownloader instance.
 
     Returns:
-        dl (EntsoeDownloader): Instance of EntsoeDownloader class.
+        EntsoeDownloader: Instance of EntsoeDownloader class.
     """
-    dl = EntsoeDownloader(**init_args)
-    return dl
+    with patch("rbc.energy.entsoe.downloader.set_config"):
+        with patch("rbc.energy.entsoe.downloader.get_config"):
+            return EntsoeDownloader(**init_args)
 
 
 @pytest.fixture
@@ -89,15 +75,12 @@ def task(init_args: dict) -> DownloadTask:
 # Tests - Initialization
 # ----------------------------------
 @pytest.mark.parametrize("bz, valid", [("10YES-REE------0", True), (" ", False)])
-def test_downloader_initialization(
-    api_config: Generator, init_args: dict, bz: str, valid: bool
-) -> None:
+def test_downloader_initialization(init_args: dict, bz: str, valid: bool) -> None:
     """Happy path for class initialization.
 
     Check that the EntsoeDownloader sets up paths and checkpoint correctly.
 
     Args:
-        api_config (Generator): Fixture that patches the ENTSO-E global configuration.
         init_args (dict): Arguments used to initialize an EntsoeDownloader instance.
         bz (str): The bidding zone to use.
         valid (bool): Whether the bidding zone is valid (True) or not (False).
@@ -109,7 +92,9 @@ def test_downloader_initialization(
         with pytest.raises(InvalidError, match="not supported"):
             EntsoeDownloader(**args)
     else:
-        downloader = EntsoeDownloader(**args)
+        with patch("rbc.energy.entsoe.downloader.set_config"):
+            with patch("rbc.energy.entsoe.downloader.get_config"):
+                downloader = EntsoeDownloader(**args)
 
         assert downloader.bidding_zones == args["bidding_zones"]
         assert downloader.years == args["years"]
@@ -120,11 +105,10 @@ def test_downloader_initialization(
         assert downloader.checkpoint == {}
 
 
-def test_download_data_resume(api_config: Generator, init_args: dict) -> None:
+def test_download_data_resume(init_args: dict) -> None:
     """Happy path for "download_data" method when resuming from checkpoint.
 
     Args:
-        api_config (Generator): Fixture that patches the ENTSO-E global configuration.
         init_args (dict): Arguments used to initialize an EntsoeDownloader instance.
     """
     args = init_args.copy()
@@ -145,13 +129,16 @@ def test_download_data_resume(api_config: Generator, init_args: dict) -> None:
 
     args["resume"] = True
 
-    downloader = EntsoeDownloader(**args)
-    with patch.object(downloader, "_download_task_data") as mock_dump:
-        mock_dump.return_value = 1
-        downloader.download_data()
+    with patch("rbc.energy.entsoe.downloader.set_config"):
+        with patch("rbc.energy.entsoe.downloader.get_config"):
+            downloader = EntsoeDownloader(**args)
 
-        assert mock_dump.call_count == 0
-        assert downloader.checkpoint == checkpoint
+            with patch.object(downloader, "_download_task_data") as mock_dump:
+                mock_dump.return_value = 1
+                downloader.download_data()
+
+                assert mock_dump.call_count == 0
+                assert downloader.checkpoint == checkpoint
 
 
 # ----------------------------------
@@ -273,7 +260,7 @@ def test_get_task_data_no_generation_data(
             downloader._get_task_data(task)
 
 
-def test_get_task_data_structure_change(
+def test_get_task_data_structure_changed(
     downloader: EntsoeDownloader, task: DownloadTask
 ) -> None:
     """Failure path for "_get_task_data" method when the expected columns are missing.

--- a/tests/energy/entsoe/test_downloader.py
+++ b/tests/energy/entsoe/test_downloader.py
@@ -293,3 +293,107 @@ def test_get_task_data_structure_change(
 
         with pytest.raises(DataStructureError, match="structure change detected"):
             downloader._get_task_data(task)
+
+
+# ----------------------------------
+# Tests - Data crawling helper methods
+# ----------------------------------
+def test_save_task_data_single_tres(
+    downloader: EntsoeDownloader, task: DownloadTask
+) -> None:
+    """Happy path for _save_task_data with one temporal res and missing data rows are removed.
+
+    Args:
+        downloader (EntsoeDownloader): Instance of EntsoeDownloader class.
+        task (DownloadTask): The metadata of a downloading task, here: date (YYYY-MM-DD), bz
+    """
+    df = pd.DataFrame(
+        {
+            "Generation_MW": [10.0, 20.0],
+            "Temporal_Resolution": ["PT60M", None],
+        }
+    )
+    downloader._save_task_data(task, df)
+
+    expected_file = downloader._build_task_path(task.update(temporal_resolution="1h"))
+    assert expected_file.is_file()
+
+    saved_df = pd.read_csv(expected_file)
+    assert len(saved_df) == 1  # row with missing temporal resolution value removed
+    assert saved_df.iloc[0]["Generation_MW"] == 10.0
+
+
+def test_save_task_data_two_tres(
+    downloader: EntsoeDownloader, task: DownloadTask
+) -> None:
+    """Happy path for _save_task_data with two temporal resolutions.
+
+    Args:
+        downloader (EntsoeDownloader): Instance of EntsoeDownloader class.
+        task (DownloadTask): The metadata of a downloading task, here: date (YYYY-MM-DD), bz
+    """
+    df = pd.DataFrame(
+        {
+            "Generation_MW": [10.0, 20.0],
+            "Temporal_Resolution": ["PT60M", "PT20M"],
+        }
+    )
+    downloader._save_task_data(task, df)
+
+    file_1h = downloader._build_task_path(task.update(temporal_resolution="1h"))
+    file_20min = downloader._build_task_path(task.update(temporal_resolution="20min"))
+
+    assert file_1h.is_file()
+    assert file_20min.is_file()
+
+    df_1h = pd.read_csv(file_1h)
+    df_20min = pd.read_csv(file_20min)
+
+    assert len(df_1h) == 1
+    assert len(df_20min) == 1
+    assert df_1h.iloc[0]["Generation_MW"] == 10.0
+    assert df_20min.iloc[0]["Generation_MW"] == 20.0
+
+
+def test_save_task_data_invalid_tres(
+    downloader: EntsoeDownloader, task: DownloadTask
+) -> None:
+    """Failure path for _save_task_data when provided temporal resolution isn't supported."""
+    df = pd.DataFrame(
+        {
+            "timestamp": [f"{task.date}T00:00:00+00:00"],
+            "Generation_MW": [16.2],
+            "Temporal_Resolution": ["INVALID"],
+        }
+    )
+    with pytest.raises(DataStructureError, match="Unknown ENTSO-E temporal resolution"):
+        downloader._save_task_data(task, df)
+
+
+@pytest.mark.parametrize(
+    "tres, tres_normalized",
+    [
+        ("PT60M", "1h"),
+        ("PT20M", "20min"),
+        ("PT5M", "5min"),
+    ],
+)
+def test_normalize_temporal_resolution(tres: str, tres_normalized: str) -> None:
+    """Happy path for _normalize_temporal_resolution.
+
+    Args:
+        tres (str): Raw temporal resolution string.
+        tres_normalized (str): Expected temporal resolution string.
+    """
+    assert EntsoeDownloader._normalize_temporal_resolution(tres) == tres_normalized
+
+
+@pytest.mark.parametrize("invalid_tres", ["PT1H", "invalid", "", "60M"])
+def test_normalize_temporal_resolution_invalid(invalid_tres: str) -> None:
+    """Failure path for _normalize_temporal_resolution with unsupported format.
+
+    Args:
+        invalid_tres (str): Invalid raw temporal resolution string.
+    """
+    with pytest.raises(DataStructureError, match="Unknown ENTSO-E temporal resolution"):
+        EntsoeDownloader._normalize_temporal_resolution(invalid_tres)

--- a/tests/energy/entsoe/test_downloader.py
+++ b/tests/energy/entsoe/test_downloader.py
@@ -11,7 +11,7 @@ import pytest
 from entsoe.query.decorators import ServiceUnavailableError
 
 from rbc.energy.entsoe import EntsoeDownloader
-from rbc.energy.utils import DataStructureError
+from rbc.energy.utils import DataStructureError, DownloadKey
 
 
 # ----------------------------------
@@ -65,17 +65,20 @@ def downloader(api_config: Generator, init_args: dict) -> EntsoeDownloader:
 
 
 @pytest.fixture
-def download_args(init_args: dict) -> tuple[tuple, dict, Path]:
+def download_args(init_args: dict) -> tuple[DownloadKey, dict, Path]:
     """Gets a set of download arguments from the initialisation arguments.
 
     Args:
         init_args (dict): Arguments used to initialize an EntsoeDownloader instance.
 
     Returns:
-        tuple[tuple, dict, Path]: Tuple of ((bidding zone, date), checkpoint,
-        checkpoint_path) for downloading.
+        tuple[DownloadKey, dict, Path]: Tuple of (task, checkpoint, checkpoint_path) for
+            downloading.
     """
-    task = (init_args["bidding_zones"][0], f"{init_args['years'][0]}-01-01")
+    task = DownloadKey(
+        date=f"{init_args['years'][0]}-01-01",
+        bidding_zone=init_args["bidding_zones"][0],
+    )
     checkpoint: dict = {}
     checkpoint_path = Path(
         init_args["output_path"], init_args["bidding_zones"][0], "status.pickle"
@@ -127,20 +130,21 @@ def test_download_data_resume(api_config: Generator, init_args: dict) -> None:
     bz = args["bidding_zones"][0]
     y = args["years"][0]
     checkpoint = {
-        (bz, d): 1
+        EntsoeDownloader._turn_task_into_checkpoint_key(
+            DownloadKey(date=d, bidding_zone=bz)
+        ): 1
         for d in pd.date_range(start=f"{y}-01-01", end=f"{y}-12-31")
         .strftime("%Y-%m-%d")
         .tolist()
     }
 
-    bz_path = Path(args["output_path"], bz)
-    bz_path.mkdir(parents=True, exist_ok=True)
-    checkpoint_path = Path(bz_path, "status.pickle")
-    with open(checkpoint_path, "wb") as f:
-        pickle.dump(checkpoint, f)
-
     args["resume"] = True
     downloader = EntsoeDownloader(**args)
+
+    checkpoint_path = downloader._build_checkpoint_path(DownloadKey(bidding_zone=bz))
+    checkpoint_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(checkpoint_path, "wb") as f:
+        pickle.dump(checkpoint, f)
 
     with patch.object(downloader, "_download_task_data") as mock_dump:
         downloader.download_data()
@@ -159,13 +163,13 @@ def test_download_day_data(downloader: EntsoeDownloader, download_args: tuple) -
         download_args (tuple): Tuple of download arguments for running _get_task_data.
     """
     task, checkpoint, checkpoint_path = download_args
-    mock_df = pd.DataFrame({"Generation_MW": [16.2]})
+    mock_df = pd.DataFrame({"Generation_MW": [16.2], "Temporal_Resolution": ["PT60M"]})
 
     with patch.object(downloader, "_get_task_data", return_value=mock_df):
         status = downloader._download_task_data(task)
 
         assert status == 1
-        expected_file = Path(downloader.output_path, task[0], task[1] + ".csv")
+        expected_file = downloader._build_task_path(task)
         assert expected_file.is_file(), f"The CSV {expected_file} was not created!"
 
         saved_df = pd.read_csv(expected_file)
@@ -180,7 +184,7 @@ def test_get_task_data(downloader: EntsoeDownloader, download_args: tuple) -> No
         download_args (tuple): Tuple of download arguments for running _get_task_data.
     """
     task, checkpoint, checkpoint_path = download_args
-    timestamp = f"{task[1]}T00:00:00+00:00"
+    timestamp = f"{task.date}T00:00:00+00:00"
     return_value = [
         {
             "timestamp": timestamp,

--- a/tests/energy/entsoe/test_downloader.py
+++ b/tests/energy/entsoe/test_downloader.py
@@ -57,7 +57,7 @@ def downloader(init_args: dict) -> EntsoeDownloader:
 
 @pytest.fixture
 def task(init_args: dict) -> DownloadTask:
-    """Gets a task (month) as YYYY-MM-DD from the given year.
+    """Gets a task as 'date=YYYY-MM-DD,bidding_zone=<ZONE>' from the init arguments.
 
     Args:
         init_args (dict): Arguments used to initialize an EntsoeDownloader instance.
@@ -118,9 +118,9 @@ def test_download_data_resume(init_args: dict) -> None:
     y = args["years"][0]
     checkpoint = {
         DownloadTask(date=d, bidding_zone=bz).identifier: 1
-        for d in pd.date_range(start=f"{y}-01-01", end=f"{y}-12-31")
-        .strftime("%Y-%m-%d")
-        .tolist()
+        for d in pd.date_range(start=f"{y}-01-01", end=f"{y}-12-31").strftime(
+            "%Y-%m-%d"
+        )
     }
     checkpoint_path = Path(args["output_path"], "status.pickle")
     checkpoint_path.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/energy/epias/test_downloader.py
+++ b/tests/energy/epias/test_downloader.py
@@ -9,6 +9,7 @@ import pandas as pd
 import pytest
 
 from rbc.energy.epias import EpiasDownloader
+from rbc.energy.epias.downloader import EXPECTED_COLS
 from rbc.energy.utils import (
     DataStructureError,
     DownloadTask,
@@ -55,7 +56,7 @@ def downloader(init_args: dict) -> EpiasDownloader:
 
 @pytest.fixture
 def task(init_args: dict) -> DownloadTask:
-    """Gets a task (date) as YYYY-MM-DD from the given year.
+    """Gets a task as 'date=YYYY-MM-DD' from the init arguments.
 
     Args:
         init_args (dict): Arguments used to initialize an EpiasDownloader instance.
@@ -73,31 +74,19 @@ def get_mock_df(date: str) -> pd.DataFrame:
     Args:
         date (str): Date to return a mock EPIAS generation dataframe.
 
+    Returns:
+        pandas.DataFrame: Mock dataframe.
     """
-    return pd.DataFrame(
+    row: dict[str, object] = {c: 0.0 for c in EXPECTED_COLS}
+    row.update(
         {
-            "date": [date],
-            "hour": [1],
-            "total": [16.2],
-            "powerPlantName": ["3S KALE JES-40W000000012366M-2336"],
-            "naturalGas": [0.0],
-            "dammedHydro": [0.0],
-            "lignite": [0.0],
-            "river": [0.0],
-            "importCoal": [0.0],
-            "wind": [0.0],
-            "sun": [0.0],
-            "fueloil": [0.0],
-            "geothermal": [0.0],
-            "asphaltiteCoal": [0.0],
-            "blackCoal": [0.0],
-            "biomass": [0.0],
-            "naphta": [0.0],
-            "lng": [0.0],
-            "importExport": [0.0],
-            "wasteheat": [0.0],
+            "date": date,
+            "hour": 1,
+            "total": 16.2,
+            "powerPlantName": "3S KALE JES-40W000000012366M-2336",
         }
     )
+    return pd.DataFrame(row, index=[0])
 
 
 # ----------------------------------

--- a/tests/energy/epias/test_downloader.py
+++ b/tests/energy/epias/test_downloader.py
@@ -9,7 +9,7 @@ import pandas as pd
 import pytest
 
 from rbc.energy.epias import EpiasDownloader
-from rbc.energy.utils import DownloadKey, InvalidError, MissingDataError
+from rbc.energy.utils import DownloadTask, InvalidError, MissingDataError
 
 
 # ----------------------------------
@@ -49,17 +49,17 @@ def downloader(init_args: dict) -> EpiasDownloader:
 
 
 @pytest.fixture
-def task(init_args: dict) -> DownloadKey:
+def task(init_args: dict) -> DownloadTask:
     """Gets a task (date) as YYYY-MM-DD from the given year.
 
     Args:
         init_args (dict): Arguments used to initialize an EpiasDownloader instance.
 
     Returns:
-        DownloadKey: The metadata of a downloading task, here: date (YYYY-MM-DD)
+        DownloadTask: The metadata of a downloading task, here: date (YYYY-MM-DD)
     """
     year = init_args["years"][0]
-    return DownloadKey(date=f"{year}-01-01")
+    return DownloadTask(date=f"{year}-01-01")
 
 
 # ----------------------------------
@@ -112,7 +112,7 @@ def test_download_data_resume(init_args: dict) -> None:
     # save a fake checkpoint file
     y = args["years"][0]
     checkpoint = {
-        EpiasDownloader._turn_task_into_checkpoint_key(DownloadKey(date=d)): 1
+        DownloadTask(date=d).identifier: 1
         for d in pd.date_range(start=f"{y}-01-01", end=f"{y}-12-31")
         .strftime("%Y-%m-%d")
         .tolist()
@@ -137,12 +137,12 @@ def test_download_data_resume(init_args: dict) -> None:
 # ----------------------------------
 # Tests - Data crawling logic
 # ----------------------------------
-def test_download_task_data(downloader: EpiasDownloader, task: DownloadKey) -> None:
+def test_download_task_data(downloader: EpiasDownloader, task: DownloadTask) -> None:
     """Happy path for "_download_task_data" method when resuming from checkpoint.
 
     Args:
         downloader (EpiasDownloader): Instance of EpiasDownloader class.
-        task (DownloadKey): The metadata of a downloading task, here: date (YYYY-MM-DD)
+        task (DownloadTask): The metadata of a downloading task, here: date (YYYY-MM-DD)
     """
     mock_df = pd.DataFrame({"total": [16.2]})
 
@@ -150,19 +150,19 @@ def test_download_task_data(downloader: EpiasDownloader, task: DownloadKey) -> N
         status = downloader._download_task_data(task)
 
         assert status == 1
-        expected_file = Path(downloader.output_path, "1h", f"{task.date}.csv")
+        expected_file = downloader._build_task_path(task)
         assert expected_file.is_file(), f"The CSV {expected_file} was not created!"
 
         saved_df = pd.read_csv(expected_file)
         assert saved_df.iloc[0]["total"] == 16.2
 
 
-def test_get_task_data(downloader: EpiasDownloader, task: DownloadKey) -> None:
+def test_get_task_data(downloader: EpiasDownloader, task: DownloadTask) -> None:
     """Happy path for "_get_task_data" method.
 
     Args:
         downloader (EpiasDownloader): Instance of EpiasDownloader class.
-        task (DownloadKey): The metadata of a downloading task, here: date (YYYY-MM-DD)
+        task (DownloadTask): The metadata of a downloading task, here: date (YYYY-MM-DD)
     """
     mock_pp_data = pd.DataFrame(
         {
@@ -194,13 +194,13 @@ def test_get_task_data(downloader: EpiasDownloader, task: DownloadKey) -> None:
 
 
 def test_get_task_data_no_pp_data(
-    downloader: EpiasDownloader, task: DownloadKey
+    downloader: EpiasDownloader, task: DownloadTask
 ) -> None:
     """Failure path for "_get_task_data" method when no power plant data is available.
 
     Args:
         downloader (EpiasDownloader): Instance of EpiasDownloader class.
-        task (DownloadKey): The metadata of a downloading task, here: date (YYYY-MM-DD)
+        task (DownloadTask): The metadata of a downloading task, here: date (YYYY-MM-DD)
     """
     mock_pp_data = pd.DataFrame({})
     mock_gen_data = pd.DataFrame({})
@@ -218,14 +218,14 @@ def test_get_task_data_no_pp_data(
         downloader._get_task_data(task)
 
 
-def test_get_task_data_no_gen_data(
-    downloader: EpiasDownloader, task: DownloadKey
+def test_get_task_data_no_generation_data(
+    downloader: EpiasDownloader, task: DownloadTask
 ) -> None:
     """Failure path for "_get_task_data" method when no generation data is available.
 
     Args:
         downloader (EpiasDownloader): Instance of EpiasDownloader class.
-        task (DownloadKey): The metadata of a downloading task, here: date (YYYY-MM-DD)
+        task (DownloadTask): The metadata of a downloading task, here: date (YYYY-MM-DD)
     """
     mock_pp_data = pd.DataFrame({"id": ["2336"]})
     mock_gen_data = pd.DataFrame({})
@@ -239,5 +239,5 @@ def test_get_task_data_no_gen_data(
 
     downloader.eptr.call.side_effect = call_side_effect
 
-    with pytest.raises(MissingDataError, match="No generation data"):
+    with pytest.raises(MissingDataError, match="No energy generation data available"):
         downloader._get_task_data(task)

--- a/tests/energy/epias/test_downloader.py
+++ b/tests/energy/epias/test_downloader.py
@@ -9,6 +9,7 @@ import pandas as pd
 import pytest
 
 from rbc.energy.epias import EpiasDownloader
+from rbc.energy.utils import DownloadKey
 
 
 # ----------------------------------
@@ -48,17 +49,17 @@ def downloader(init_args: dict) -> EpiasDownloader:
 
 
 @pytest.fixture
-def date(init_args: dict) -> str:
-    """Gets a date from the given year.
+def task(init_args: dict) -> DownloadKey:
+    """Gets a task (date) as YYYY-MM-DD from the given year.
 
     Args:
         init_args (dict): Arguments used to initialize an EpiasDownloader instance.
 
     Returns:
-        str: Single date to download.
+        DownloadKey: The metadata of a downloading task, here: date (YYYY-MM-DD)
     """
     year = init_args["years"][0]
-    return f"{year}-01-01"
+    return DownloadKey(date=f"{year}-01-01")
 
 
 # ----------------------------------
@@ -111,7 +112,7 @@ def test_download_data_resume(init_args: dict) -> None:
     # save a fake checkpoint file
     y = args["years"][0]
     checkpoint = {
-        d: 1
+        EpiasDownloader._turn_task_into_checkpoint_key(DownloadKey(date=d)): 1
         for d in pd.date_range(start=f"{y}-01-01", end=f"{y}-12-31")
         .strftime("%Y-%m-%d")
         .tolist()
@@ -136,32 +137,32 @@ def test_download_data_resume(init_args: dict) -> None:
 # ----------------------------------
 # Tests - Data crawling logic
 # ----------------------------------
-def test_download_task_data(downloader: EpiasDownloader, date: str) -> None:
+def test_download_task_data(downloader: EpiasDownloader, task: DownloadKey) -> None:
     """Happy path for "_download_task_data" method when resuming from checkpoint.
 
     Args:
         downloader (EpiasDownloader): Instance of EpiasDownloader class.
-        date (str): Date to download.
+        task (DownloadKey): The metadata of a downloading task, here: date (YYYY-MM-DD)
     """
     mock_df = pd.DataFrame({"total": [16.2]})
 
     with patch.object(downloader, "_get_task_data", return_value=mock_df):
-        status = downloader._download_task_data(date)
+        status = downloader._download_task_data(task)
 
         assert status == 1
-        expected_file = Path(downloader.output_path, f"{date}.csv")
+        expected_file = Path(downloader.output_path, "1h", f"{task.date}.csv")
         assert expected_file.is_file(), f"The CSV {expected_file} was not created!"
 
         saved_df = pd.read_csv(expected_file)
         assert saved_df.iloc[0]["total"] == 16.2
 
 
-def test_get_task_data(downloader: EpiasDownloader, date: str) -> None:
+def test_get_task_data(downloader: EpiasDownloader, task: DownloadKey) -> None:
     """Happy path for "_get_task_data" method.
 
     Args:
         downloader (EpiasDownloader): Instance of EpiasDownloader class.
-        date (str): Date to download.
+        task (DownloadKey): The metadata of a downloading task, here: date (YYYY-MM-DD)
     """
     mock_pp_data = pd.DataFrame(
         {
@@ -171,7 +172,7 @@ def test_get_task_data(downloader: EpiasDownloader, date: str) -> None:
     )
     mock_gen_data = pd.DataFrame(
         {
-            "date": [date],
+            "date": [task.date],
             "total": [16.2],
             "powerPlantName": ["3S KALE JES-40W000000012366M-2336"],
         }
@@ -185,19 +186,21 @@ def test_get_task_data(downloader: EpiasDownloader, date: str) -> None:
         return pd.DataFrame()
 
     downloader.eptr.call.side_effect = call_side_effect
-    df = downloader._get_task_data(date)
+    df = downloader._get_task_data(task)
 
     assert not df.empty
-    assert df.iloc[0]["date"] == date
+    assert df.iloc[0]["date"] == task.date
     assert df.iloc[0]["total"] == 16.2
 
 
-def test_get_task_data_no_pp_data(downloader: EpiasDownloader, date: str) -> None:
+def test_get_task_data_no_pp_data(
+    downloader: EpiasDownloader, task: DownloadKey
+) -> None:
     """Failure path for "_get_task_data" method when no power plant data is available.
 
     Args:
         downloader (EpiasDownloader): Instance of EpiasDownloader class.
-        date (str): Date to download.
+        task (DownloadKey): The metadata of a downloading task, here: date (YYYY-MM-DD)
     """
     mock_pp_data = pd.DataFrame({})
     mock_gen_data = pd.DataFrame({})
@@ -212,15 +215,17 @@ def test_get_task_data_no_pp_data(downloader: EpiasDownloader, date: str) -> Non
     downloader.eptr.call.side_effect = call_side_effect
 
     with pytest.raises(ValueError, match="No power plant data"):
-        downloader._get_task_data(date)
+        downloader._get_task_data(task)
 
 
-def test_get_task_data_no_gen_data(downloader: EpiasDownloader, date: str) -> None:
+def test_get_task_data_no_gen_data(
+    downloader: EpiasDownloader, task: DownloadKey
+) -> None:
     """Failure path for "_get_task_data" method when no generation data is available.
 
     Args:
         downloader (EpiasDownloader): Instance of EpiasDownloader class.
-        date (str): Date to download.
+        task (DownloadKey): The metadata of a downloading task, here: date (YYYY-MM-DD)
     """
     mock_pp_data = pd.DataFrame({"id": ["2336"]})
     mock_gen_data = pd.DataFrame({})
@@ -235,4 +240,4 @@ def test_get_task_data_no_gen_data(downloader: EpiasDownloader, date: str) -> No
     downloader.eptr.call.side_effect = call_side_effect
 
     with pytest.raises(ValueError, match="No generation data"):
-        downloader._get_task_data(date)
+        downloader._get_task_data(task)

--- a/tests/energy/epias/test_downloader.py
+++ b/tests/energy/epias/test_downloader.py
@@ -9,7 +9,7 @@ import pandas as pd
 import pytest
 
 from rbc.energy.epias import EpiasDownloader
-from rbc.energy.utils import DownloadKey
+from rbc.energy.utils import DownloadKey, InvalidError, MissingDataError
 
 
 # ----------------------------------
@@ -97,7 +97,7 @@ def test_downloader_initialization_invalid_credentials(init_args: dict) -> None:
     with patch("rbc.energy.epias.downloader.EPTR2") as mock_eptr2:
         mock_eptr2.side_effect = Exception("Login Failed")
 
-        with pytest.raises(ValueError, match="incorrect"):
+        with pytest.raises(InvalidError, match="incorrect"):
             EpiasDownloader(**init_args)
 
 
@@ -214,7 +214,7 @@ def test_get_task_data_no_pp_data(
 
     downloader.eptr.call.side_effect = call_side_effect
 
-    with pytest.raises(ValueError, match="No power plant data"):
+    with pytest.raises(MissingDataError, match="No power plant data"):
         downloader._get_task_data(task)
 
 
@@ -239,5 +239,5 @@ def test_get_task_data_no_gen_data(
 
     downloader.eptr.call.side_effect = call_side_effect
 
-    with pytest.raises(ValueError, match="No generation data"):
+    with pytest.raises(MissingDataError, match="No generation data"):
         downloader._get_task_data(task)

--- a/tests/energy/epias/test_downloader.py
+++ b/tests/energy/epias/test_downloader.py
@@ -9,7 +9,12 @@ import pandas as pd
 import pytest
 
 from rbc.energy.epias import EpiasDownloader
-from rbc.energy.utils import DownloadTask, InvalidError, MissingDataError
+from rbc.energy.utils import (
+    DataStructureError,
+    DownloadTask,
+    InvalidError,
+    MissingDataError,
+)
 
 
 # ----------------------------------
@@ -60,6 +65,39 @@ def task(init_args: dict) -> DownloadTask:
     """
     year = init_args["years"][0]
     return DownloadTask(date=f"{year}-01-01")
+
+
+def get_mock_df(date: str) -> pd.DataFrame:
+    """Return a valid mock EPIAS generation dataframe.
+
+    Args:
+        date (str): Date to return a mock EPIAS generation dataframe.
+
+    """
+    return pd.DataFrame(
+        {
+            "date": [date],
+            "hour": [1],
+            "total": [16.2],
+            "powerPlantName": ["3S KALE JES-40W000000012366M-2336"],
+            "naturalGas": [0.0],
+            "dammedHydro": [0.0],
+            "lignite": [0.0],
+            "river": [0.0],
+            "importCoal": [0.0],
+            "wind": [0.0],
+            "sun": [0.0],
+            "fueloil": [0.0],
+            "geothermal": [0.0],
+            "asphaltiteCoal": [0.0],
+            "blackCoal": [0.0],
+            "biomass": [0.0],
+            "naphta": [0.0],
+            "lng": [0.0],
+            "importExport": [0.0],
+            "wasteheat": [0.0],
+        }
+    )
 
 
 # ----------------------------------
@@ -164,19 +202,8 @@ def test_get_task_data(downloader: EpiasDownloader, task: DownloadTask) -> None:
         downloader (EpiasDownloader): Instance of EpiasDownloader class.
         task (DownloadTask): The metadata of a downloading task, here: date (YYYY-MM-DD)
     """
-    mock_pp_data = pd.DataFrame(
-        {
-            "id": ["2336"],
-            "name": ["3S KALE JES-40W000000012366M-2336"],
-        }
-    )
-    mock_gen_data = pd.DataFrame(
-        {
-            "date": [task.date],
-            "total": [16.2],
-            "powerPlantName": ["3S KALE JES-40W000000012366M-2336"],
-        }
-    )
+    mock_pp_data = pd.DataFrame({"id": ["2336"]})
+    mock_gen_data = get_mock_df(task.date)
 
     def call_side_effect(endpoint, **kwargs):
         if endpoint == "pp-list-for-date-range":
@@ -193,16 +220,21 @@ def test_get_task_data(downloader: EpiasDownloader, task: DownloadTask) -> None:
     assert df.iloc[0]["total"] == 16.2
 
 
-def test_get_task_data_no_pp_data(
-    downloader: EpiasDownloader, task: DownloadTask
+@pytest.mark.parametrize(
+    "pp_data, error_msg", [({}, "No power plant"), ({"id": ["2336"]}, "No energy")]
+)
+def test_get_task_data_no_data(
+    downloader: EpiasDownloader, task: DownloadTask, pp_data: dict, error_msg: str
 ) -> None:
-    """Failure path for "_get_task_data" method when no power plant data is available.
+    """Failure path for "_get_task_data" method when no power plant / energy data is available.
 
     Args:
         downloader (EpiasDownloader): Instance of EpiasDownloader class.
         task (DownloadTask): The metadata of a downloading task, here: date (YYYY-MM-DD)
+        pp_data (dict): Dictionary of power plant data.
+        error_msg (str): Error message.
     """
-    mock_pp_data = pd.DataFrame({})
+    mock_pp_data = pd.DataFrame(pp_data)
     mock_gen_data = pd.DataFrame({})
 
     def call_side_effect(endpoint, **kwargs):
@@ -214,30 +246,30 @@ def test_get_task_data_no_pp_data(
 
     downloader.eptr.call.side_effect = call_side_effect
 
-    with pytest.raises(MissingDataError, match="No power plant data"):
+    with pytest.raises(MissingDataError, match=error_msg):
         downloader._get_task_data(task)
 
 
-def test_get_task_data_no_generation_data(
+def test_get_task_data_structure_changed(
     downloader: EpiasDownloader, task: DownloadTask
 ) -> None:
-    """Failure path for "_get_task_data" method when no generation data is available.
+    """Failure path for "_get_task_data" method when dataframe doesn't have all columns.
 
     Args:
         downloader (EpiasDownloader): Instance of EpiasDownloader class.
-        task (DownloadTask): The metadata of a downloading task, here: date (YYYY-MM-DD)
+        task (DownloadTask): The metadata of a downloading task, here: date (YYYY-MM)
     """
     mock_pp_data = pd.DataFrame({"id": ["2336"]})
-    mock_gen_data = pd.DataFrame({})
+    mock_gen_df = get_mock_df(task.date).drop(columns="hour")
 
     def call_side_effect(endpoint, **kwargs):
         if endpoint == "pp-list-for-date-range":
             return mock_pp_data
         if endpoint == "rt-gen-bulk":
-            return mock_gen_data
+            return mock_gen_df
         return pd.DataFrame()
 
     downloader.eptr.call.side_effect = call_side_effect
 
-    with pytest.raises(MissingDataError, match="No energy generation data available"):
+    with pytest.raises(DataStructureError, match="Missing columns"):
         downloader._get_task_data(task)

--- a/tests/energy/ieso/test_downloader.py
+++ b/tests/energy/ieso/test_downloader.py
@@ -226,8 +226,8 @@ def test_get_task_data(
     assert mock_new.call_count == expect_new
 
 
-def test_get_task_data_no_data_before_2010(downloader: IesoDownloader) -> None:
-    """Failure path for "_get_task_data" method when dataframe is empty.
+def test_get_task_data_no_data_for_old_year(downloader: IesoDownloader) -> None:
+    """Failure path for "_get_task_data" method when a task with year before 2010 is provided.
 
     Args:
         downloader (IesoDownloader): Instance of IesoDownloader class.

--- a/tests/energy/ieso/test_downloader.py
+++ b/tests/energy/ieso/test_downloader.py
@@ -63,20 +63,6 @@ def task(init_args: dict) -> DownloadTask:
     return DownloadTask(date=f"{year}-01")
 
 
-def get_task_year_month(task: DownloadTask) -> tuple[int, int]:
-    """Return (year, month) from a monthly DownloadTask.
-
-    Args:
-        task (DownloadTask): The metadata of a downloading task, here: date (YYYY-MM)
-
-    Returns:
-        tuple[int, int]: Tuple containing (year, month).
-    """
-    assert task.date is not None
-    year, month = task.date.split("-")
-    return int(year), int(month)
-
-
 def get_mock_df(specific_task: DownloadTask) -> pd.DataFrame:
     """Gets a mock dataframe for a specific task.
 
@@ -98,6 +84,20 @@ def get_mock_df(specific_task: DownloadTask) -> pd.DataFrame:
         },
         index=[0],
     )
+
+
+def get_task_year_month(task: DownloadTask) -> tuple[int, int]:
+    """Return (year, month) from a monthly DownloadTask.
+
+    Args:
+        task (DownloadTask): The metadata of a downloading task, here: date (YYYY-MM)
+
+    Returns:
+        tuple[int, int]: Tuple containing (year, month).
+    """
+    assert task.date is not None
+    year, month = task.date.split("-")
+    return int(year), int(month)
 
 
 # ----------------------------------

--- a/tests/energy/ieso/test_downloader.py
+++ b/tests/energy/ieso/test_downloader.py
@@ -11,7 +11,7 @@ from requests import exceptions
 
 from rbc.energy.ieso import IesoDownloader
 from rbc.energy.ieso.downloader import EXPECTED_COLS, URL_NEW_BASE, URL_OLD_BASE
-from rbc.energy.utils import DataStructureError
+from rbc.energy.utils import DataStructureError, DownloadKey
 
 
 # ----------------------------------
@@ -39,7 +39,7 @@ def downloader(init_args: dict) -> IesoDownloader:
     """Provides an IesoDownloader instance with a mocked, positive return code response.
 
     Args:
-        init_args (dict): Arguments used to initialize an EiaDownloader instance.
+        init_args (dict): Arguments used to initialize an IesoDownloader instance.
 
     Returns:
         IesoDownloader: IesoDownloader instance.
@@ -50,24 +50,38 @@ def downloader(init_args: dict) -> IesoDownloader:
 
 
 @pytest.fixture
-def task(init_args: dict) -> str:
+def task(init_args: dict) -> DownloadKey:
     """Gets a task (month) as YYYY-MM from the given year.
 
     Args:
         init_args (dict): Arguments used to initialize an IesoDownloader instance.
 
     Returns:
-        str: Single month to download.
+        DownloadKey: The metadata of a downloading task, here: date (YYYY-MM)
     """
     year = init_args["years"][0]
-    return f"{year}-01"
+    return DownloadKey(date=f"{year}-01")
 
 
-def get_mock_df(specific_task: str) -> pd.DataFrame:
+def get_task_year_month(task: DownloadKey) -> tuple[int, int]:
+    """Return (year, month) from a monthly DownloadKey.
+
+    Args:
+        task (DownloadKey): The metadata of a downloading task, here: date (YYYY-MM)
+
+    Returns:
+        tuple[int, int]: Tuple containing (year, month).
+    """
+    assert task.date is not None
+    year, month = task.date.split("-")
+    return int(year), int(month)
+
+
+def get_mock_df(specific_task: DownloadKey) -> pd.DataFrame:
     """Gets a mock dataframe for a specific task.
 
     Args:
-        specific_task (str): Month to download.
+        specific_task (DownloadKey): The metadata of a downloading task, here: date (YYYY-MM)
 
     Returns:
         pandas.DataFrame: Mock dataframe.
@@ -75,7 +89,7 @@ def get_mock_df(specific_task: str) -> pd.DataFrame:
     return pd.DataFrame(
         {
             **{
-                "Delivery Date": f"{specific_task}-01",
+                "Delivery Date": f"{specific_task.date}-01",
                 "Generator": "A",
                 "Fuel Type": None,
                 "Measurement": "Output",
@@ -123,15 +137,15 @@ def test_download_data_resume(init_args: dict) -> None:
     """Happy path for "download_data" method when resuming from checkpoint.
 
     Args:
-        init_args (dict): Arguments used to initialize an EiaDownloader instance.
+        init_args (dict): Arguments used to initialize an IesoDownloader instance.
     """
     args = init_args.copy()
     y = args["years"][0]
 
     # save a fake checkpoint file
     checkpoint = {
-        d: 1
-        for d in pd.date_range(start=f"{y}-01", end=f"{y}-12")
+        IesoDownloader._turn_task_into_checkpoint_key(DownloadKey(date=d)): 1
+        for d in pd.date_range(start=f"{y}-01", end=f"{y}-12", freq="MS")
         .strftime("%Y-%m")
         .tolist()
     }
@@ -156,12 +170,12 @@ def test_download_data_resume(init_args: dict) -> None:
 # ----------------------------------
 # Tests - Data crawling logic
 # ----------------------------------
-def test_download_task_data(downloader: IesoDownloader, task: str) -> None:
+def test_download_task_data(downloader: IesoDownloader, task: DownloadKey) -> None:
     """Happy path for "_download_task_data" method when resuming from checkpoint.
 
     Args:
         downloader (IesoDownloader): Instance of IesoDownloader class.
-        task (str): Month to download.
+        task (DownloadKey): The metadata of a downloading task, here: date (YYYY-MM)
     """
     mock_df = pd.DataFrame({"Hour 1": [16.2]})
 
@@ -169,7 +183,7 @@ def test_download_task_data(downloader: IesoDownloader, task: str) -> None:
         status = downloader._download_task_data(task)
 
         assert status == 1
-        expected_file = Path(downloader.output_path, f"{task}.csv")
+        expected_file = Path(downloader.output_path, "1h", f"{task.date}.csv")
         assert expected_file.is_file(), f"The CSV {expected_file} was not created!"
 
         saved_df = pd.read_csv(expected_file)
@@ -179,18 +193,18 @@ def test_download_task_data(downloader: IesoDownloader, task: str) -> None:
 @pytest.mark.parametrize(
     "task, expect_old, expect_new",
     [
-        ("2019-04", 1, 0),  # last month routed to old source
-        ("2019-05", 0, 1),  # first month routed to new source
+        (DownloadKey(date="2019-04"), 1, 0),  # last month routed to old source
+        (DownloadKey(date="2019-05"), 0, 1),  # first month routed to new source
     ],
 )
 def test_get_task_data(
-    downloader: IesoDownloader, task: str, expect_old: int, expect_new: int
+    downloader: IesoDownloader, task: DownloadKey, expect_old: int, expect_new: int
 ) -> None:
     """Happy path for "_get_task_data" method.
 
     Args:
         downloader (IesoDownloader): Instance of IesoDownloader class.
-        task (str): Month to download.
+        task (DownloadKey): The metadata of a downloading task, here: date (YYYY-MM)
         expect_old (int): Expected call count for _get_from_old_source.
         expect_new (int): Expected call count for _get_from_new_source.
     """
@@ -205,7 +219,7 @@ def test_get_task_data(
 
     assert not df.empty
     assert len(df) == 1
-    assert df.iloc[0]["Delivery Date"] == f"{task}-01"
+    assert df.iloc[0]["Delivery Date"] == f"{task.date}-01"
     assert df.iloc[0]["Generator"] == "A"
     assert df.iloc[0]["Hour 1"] == "10"
     assert mock_old.call_count == expect_old
@@ -218,21 +232,21 @@ def test_get_task_data_year_before_2010(downloader: IesoDownloader) -> None:
     Args:
         downloader (IesoDownloader): Instance of IesoDownloader class.
     """
-    month = "2009-01"
+    task = DownloadKey(date="2009-01")
     mock_df = pd.DataFrame(columns=EXPECTED_COLS)
 
     with patch.object(downloader, "_get_from_old_source", return_value=mock_df):
         with patch.object(downloader, "_get_from_new_source", return_value=mock_df):
             with pytest.raises(ValueError, match="No data for year"):
-                downloader._get_task_data(month)
+                downloader._get_task_data(task)
 
 
-def test_get_task_data_df_empty(downloader: IesoDownloader, task: str) -> None:
+def test_get_task_data_df_empty(downloader: IesoDownloader, task: DownloadKey) -> None:
     """Failure path for "_get_task_data" method when dataframe is empty.
 
     Args:
         downloader (IesoDownloader): Instance of IesoDownloader class.
-        task (str): Month to download.
+        task (DownloadKey): The metadata of a downloading task, here: date (YYYY-MM)
     """
     mock_df = pd.DataFrame(columns=EXPECTED_COLS)
 
@@ -242,12 +256,14 @@ def test_get_task_data_df_empty(downloader: IesoDownloader, task: str) -> None:
                 downloader._get_task_data(task)
 
 
-def test_get_task_data_structure_changed(downloader: IesoDownloader, task: str) -> None:
+def test_get_task_data_structure_changed(
+    downloader: IesoDownloader, task: DownloadKey
+) -> None:
     """Failure path for "_get_task_data" method when dataframe doesn't have all columns.
 
     Args:
         downloader (IesoDownloader): Instance of IesoDownloader class.
-        task (str): Month to download.
+        task (DownloadKey): The metadata of a downloading task, here: date (YYYY-MM)
     """
     mock_df = get_mock_df(task).drop(columns="Generator")
 
@@ -260,14 +276,14 @@ def test_get_task_data_structure_changed(downloader: IesoDownloader, task: str) 
 # ----------------------------------
 # Tests - Data crawling helper methods
 # ----------------------------------
-def test_get_from_new_source(downloader: IesoDownloader, task: str) -> None:
+def test_get_from_new_source(downloader: IesoDownloader, task: DownloadKey) -> None:
     """Happy path for "_get_from_new_source" method, ensuring correct URL and no 'Forecast'.
 
     Args:
         downloader (IesoDownloader): Instance of IesoDownloader class.
-        task (str): Month to download.
+        task (DownloadKey): The metadata of a downloading task, here: date (YYYY-MM)
     """
-    year, month = task.split("-")
+    year, month = get_task_year_month(task)
     mock_df = pd.DataFrame(
         {"Measurement": ["Output", "Forecast", "Capability"], "Value": [10, 20, 30]}
     )
@@ -275,10 +291,12 @@ def test_get_from_new_source(downloader: IesoDownloader, task: str) -> None:
     with patch(
         "rbc.energy.ieso.downloader.load_df_from_file", return_value=mock_df
     ) as mock_load:
-        df = downloader._get_from_new_source(year=int(year), month=int(month))
+        df = downloader._get_from_new_source(year=year, month=month)
 
         # check correct URL was created
-        expected_url = f"{URL_NEW_BASE}/PUB_GenOutputCapabilityMonth_{year}{month}.csv"
+        expected_url = (
+            f"{URL_NEW_BASE}/PUB_GenOutputCapabilityMonth_{year}{month:02d}.csv"
+        )
         mock_load.assert_called_with(expected_url, header=3, index_col=False)
 
         # check forecast data was filtered out
@@ -287,42 +305,46 @@ def test_get_from_new_source(downloader: IesoDownloader, task: str) -> None:
 
 
 def test_get_from_new_source_missing_measurement(
-    downloader: IesoDownloader, task: str
+    downloader: IesoDownloader, task: DownloadKey
 ) -> None:
     """Failure path for "_get_from_new_source" method when the 'Measurement' column is missing.
 
     Args:
         downloader (IesoDownloader): Instance of IesoDownloader class.
-        task (str): Month to download.
+        task (DownloadKey): The metadata of a downloading task, here: date (YYYY-MM)
     """
-    year, month = task.split("-")
+    year, month = get_task_year_month(task)
     mock_df = get_mock_df(task).drop(columns="Measurement")
 
     with patch("rbc.energy.ieso.downloader.load_df_from_file", return_value=mock_df):
         with pytest.raises(DataStructureError, match="'Measurement' column is missing"):
-            downloader._get_from_new_source(year=int(year), month=int(month))
+            downloader._get_from_new_source(year=year, month=month)
 
 
 @pytest.mark.parametrize(
     "task, suffix",
     [
-        ("2018-01", "2018.xlsx"),
-        ("2019-01", "2019-Jan-April.xlsx"),  # edge case
+        (DownloadKey(date="2018-01"), "2018.xlsx"),
+        (DownloadKey(date="2019-01"), "2019-Jan-April.xlsx"),  # edge case
     ],
 )
 def test_get_from_old_source(
-    downloader: IesoDownloader, task: str, suffix: str
+    downloader: IesoDownloader, task: DownloadKey, suffix: str
 ) -> None:
     """Happy path for "_get_from_old_source" method, ensuring correct URL and month filter.
 
     Args:
         downloader (IesoDownloader): Instance of IesoDownloader class.
-        task (str): Month to download.
+        task (DownloadKey): The metadata of a downloading task, here: date (YYYY-MM)
         suffix (str): Expected suffix of URL.
     """
-    year, month = map(int, task.split("-"))
+    year, month = get_task_year_month(task)
     mock_df = pd.DataFrame(
-        {"Delivery Date": pd.to_datetime([f"{task}-01", f"{year}-{month + 1:02d}-01"])}
+        {
+            "Delivery Date": pd.to_datetime(
+                [f"{task.date}-01", f"{year}-{month + 1:02d}-01"]
+            )
+        }
     )
 
     with patch.object(downloader, "_load_yearly_excel", return_value=mock_df) as mock_f:
@@ -339,16 +361,16 @@ def test_get_from_old_source(
         assert df["Delivery Date"].dt.month.iloc[0] == month
 
 
-def test_lru_cache_works(downloader: IesoDownloader) -> None:
+def test_lru_cache_works(downloader: IesoDownloader, task: DownloadKey) -> None:
     """Happy path for @lru_cache decorator of _load_yearly_excel method.
 
     Args:
         downloader (IesoDownloader): Instance of IesoDownloader class.
+        task (DownloadKey): The metadata of a downloading task, here: date (YYYY-MM)
     """
-    task = "2018-01"
-    year, month = map(int, task.split("-"))
+    year, month = get_task_year_month(task)
     mock_df = pd.DataFrame(
-        {"DATE": pd.to_datetime(f"{task}-01"), "HOUR": [1], "GEN_A": [10]}
+        {"DATE": pd.to_datetime(f"{task.date}-01"), "HOUR": [1], "GEN_A": [10]}
     )
 
     downloader._load_yearly_excel.cache_clear()
@@ -364,30 +386,37 @@ def test_lru_cache_works(downloader: IesoDownloader) -> None:
         assert mock_load.call_count == 2
 
 
-def test_get_from_old_source_structure_changed(downloader: IesoDownloader) -> None:
+def test_get_from_old_source_structure_changed(
+    downloader: IesoDownloader, task: DownloadKey
+) -> None:
     """Failure path for "_get_from_new_source" method when the URL is unavailable.
 
     Args:
         downloader (IesoDownloader): Instance of IesoDownloader class.
+        task (DownloadKey): The metadata of a downloading task, here: date (YYYY-MM)
     """
-    task = "2018-01"
-    year, month = map(int, task.split("-"))
+    year, month = get_task_year_month(task)
 
     with patch.object(downloader, "_load_yearly_excel") as mock_load:
-        mock_load.return_value = pd.DataFrame({"Delivery Date": [f"{task}-01"]})
+        mock_load.return_value = pd.DataFrame({"Delivery Date": [f"{task.date}-01"]})
 
         with pytest.raises(DataStructureError, match="no longer datetimelike"):
             downloader._get_from_old_source(year=year, month=month)
 
 
-def test_load_yearly_excel(downloader: IesoDownloader) -> None:
+def test_load_yearly_excel(downloader: IesoDownloader, task: DownloadKey) -> None:
     """Happy path for "_load_yearly_excel" method, with concatenation and capacity finding.
 
     Args:
         downloader (IesoDownloader): Instance of IesoDownloader class.
+        task (DownloadKey): The metadata of a downloading task, here: date (YYYY-MM)
     """
-    mock_df_out = pd.DataFrame({"DATE": ["2018-01-01"], "HOUR": [1], "GEN_A": [10]})
-    mock_df_cap = pd.DataFrame({"DATE": ["2018-01-01"], "HOUR": [1], "GEN_A": [100]})
+    mock_df_out = pd.DataFrame(
+        {"DATE": [f"{task.date}-01"], "HOUR": [1], "GEN_A": [10]}
+    )
+    mock_df_cap = pd.DataFrame(
+        {"DATE": [f"{task.date}-01"], "HOUR": [1], "GEN_A": [100]}
+    )
 
     with patch("rbc.energy.ieso.downloader.load_df_from_file") as mock_load:
         mock_load.side_effect = [mock_df_out, ValueError, mock_df_cap]
@@ -410,13 +439,18 @@ def test_load_yearly_excel(downloader: IesoDownloader) -> None:
         assert sheet_name_2 == "Capability - see Notes"
 
 
-def test_load_yearly_excel_missing_capacity(downloader: IesoDownloader) -> None:
+def test_load_yearly_excel_missing_capacity(
+    downloader: IesoDownloader, task: DownloadKey
+) -> None:
     """Failure path for "_load_yearly_excel" method when no suitable capacity sheets exist.
 
     Args:
         downloader (IesoDownloader): Instance of IesoDownloader class.
+        task (DownloadKey): The metadata of a downloading task, here: date (YYYY-MM)
     """
-    mock_df_out = pd.DataFrame({"DATE": ["2018-01-01"], "HOUR": [1], "GEN_A": [10]})
+    mock_df_out = pd.DataFrame(
+        {"DATE": [f"{task.date}-01"], "HOUR": [1], "GEN_A": [10]}
+    )
 
     with patch("rbc.energy.ieso.downloader.load_df_from_file") as mock_load:
         mock_load.side_effect = [mock_df_out, ValueError, ValueError, ValueError]
@@ -425,15 +459,16 @@ def test_load_yearly_excel_missing_capacity(downloader: IesoDownloader) -> None:
             downloader._load_yearly_excel(url="http://fake.xlsx")
 
 
-def test_standardize_old_data(downloader: IesoDownloader) -> None:
+def test_standardize_old_data(downloader: IesoDownloader, task: DownloadKey) -> None:
     """Happy path for "_standardize_old_data" method, ensuring transformations work.
 
     Args:
         downloader (IesoDownloader): Instance of IesoDownloader class.
+        task (DownloadKey): The metadata of a downloading task, here: date (YYYY-MM)
     """
     mock_df = pd.DataFrame(
         {
-            "DATE": ["2018-01-01", "2018-01-01"],
+            "DATE": [f"{task.date}-01", f"{task.date}-01"],
             "HOUR": [1, 2],
             "GEN_A": [10, 11],
             "GEN_B": [20, 21],

--- a/tests/energy/ieso/test_downloader.py
+++ b/tests/energy/ieso/test_downloader.py
@@ -232,13 +232,13 @@ def test_get_task_data_no_data_for_old_year(downloader: IesoDownloader) -> None:
     Args:
         downloader (IesoDownloader): Instance of IesoDownloader class.
     """
-    task = DownloadTask(date="2009-01")
+    old_year_task = DownloadTask(date="2009-01")
     mock_df = pd.DataFrame(columns=EXPECTED_COLS)
 
     with patch.object(downloader, "_get_from_old_source", return_value=mock_df):
         with patch.object(downloader, "_get_from_new_source", return_value=mock_df):
             with pytest.raises(MissingDataError, match="No data for year"):
-                downloader._get_task_data(task)
+                downloader._get_task_data(old_year_task)
 
 
 def test_get_task_data_no_generation_data(

--- a/tests/energy/ieso/test_downloader.py
+++ b/tests/energy/ieso/test_downloader.py
@@ -51,7 +51,7 @@ def downloader(init_args: dict) -> IesoDownloader:
 
 @pytest.fixture
 def task(init_args: dict) -> DownloadTask:
-    """Gets a task (month) as YYYY-MM from the given year.
+    """Gets a task as 'date=YYYY-MM' from the init arguments.
 
     Args:
         init_args (dict): Arguments used to initialize an IesoDownloader instance.
@@ -366,7 +366,7 @@ def test_get_from_old_source(
 
 
 def test_lru_cache_works(downloader: IesoDownloader, task: DownloadTask) -> None:
-    """Happy path for @lru_cache decorator of _load_yearly_excel method.
+    """Happy path for @lru_cache decorator for _load_yearly_excel method.
 
     Args:
         downloader (IesoDownloader): Instance of IesoDownloader class.

--- a/tests/energy/ieso/test_downloader.py
+++ b/tests/energy/ieso/test_downloader.py
@@ -11,7 +11,7 @@ from requests import exceptions
 
 from rbc.energy.ieso import IesoDownloader
 from rbc.energy.ieso.downloader import EXPECTED_COLS, URL_NEW_BASE, URL_OLD_BASE
-from rbc.energy.utils import DataStructureError, DownloadKey
+from rbc.energy.utils import DataStructureError, DownloadKey, MissingDataError
 
 
 # ----------------------------------
@@ -237,7 +237,7 @@ def test_get_task_data_year_before_2010(downloader: IesoDownloader) -> None:
 
     with patch.object(downloader, "_get_from_old_source", return_value=mock_df):
         with patch.object(downloader, "_get_from_new_source", return_value=mock_df):
-            with pytest.raises(ValueError, match="No data for year"):
+            with pytest.raises(MissingDataError, match="No data for year"):
                 downloader._get_task_data(task)
 
 
@@ -252,7 +252,7 @@ def test_get_task_data_df_empty(downloader: IesoDownloader, task: DownloadKey) -
 
     with patch.object(downloader, "_get_from_old_source", return_value=mock_df):
         with patch.object(downloader, "_get_from_new_source", return_value=mock_df):
-            with pytest.raises(ValueError, match="No generation data available"):
+            with pytest.raises(MissingDataError, match="No generation data available"):
                 downloader._get_task_data(task)
 
 

--- a/tests/energy/ieso/test_downloader.py
+++ b/tests/energy/ieso/test_downloader.py
@@ -11,7 +11,7 @@ from requests import exceptions
 
 from rbc.energy.ieso import IesoDownloader
 from rbc.energy.ieso.downloader import EXPECTED_COLS, URL_NEW_BASE, URL_OLD_BASE
-from rbc.energy.utils import DataStructureError, DownloadKey, MissingDataError
+from rbc.energy.utils import DataStructureError, DownloadTask, MissingDataError
 
 
 # ----------------------------------
@@ -50,24 +50,24 @@ def downloader(init_args: dict) -> IesoDownloader:
 
 
 @pytest.fixture
-def task(init_args: dict) -> DownloadKey:
+def task(init_args: dict) -> DownloadTask:
     """Gets a task (month) as YYYY-MM from the given year.
 
     Args:
         init_args (dict): Arguments used to initialize an IesoDownloader instance.
 
     Returns:
-        DownloadKey: The metadata of a downloading task, here: date (YYYY-MM)
+        DownloadTask: The metadata of a downloading task, here: date (YYYY-MM)
     """
     year = init_args["years"][0]
-    return DownloadKey(date=f"{year}-01")
+    return DownloadTask(date=f"{year}-01")
 
 
-def get_task_year_month(task: DownloadKey) -> tuple[int, int]:
-    """Return (year, month) from a monthly DownloadKey.
+def get_task_year_month(task: DownloadTask) -> tuple[int, int]:
+    """Return (year, month) from a monthly DownloadTask.
 
     Args:
-        task (DownloadKey): The metadata of a downloading task, here: date (YYYY-MM)
+        task (DownloadTask): The metadata of a downloading task, here: date (YYYY-MM)
 
     Returns:
         tuple[int, int]: Tuple containing (year, month).
@@ -77,11 +77,11 @@ def get_task_year_month(task: DownloadKey) -> tuple[int, int]:
     return int(year), int(month)
 
 
-def get_mock_df(specific_task: DownloadKey) -> pd.DataFrame:
+def get_mock_df(specific_task: DownloadTask) -> pd.DataFrame:
     """Gets a mock dataframe for a specific task.
 
     Args:
-        specific_task (DownloadKey): The metadata of a downloading task, here: date (YYYY-MM)
+        specific_task (DownloadTask): The metadata of a downloading task, here: date (YYYY-MM)
 
     Returns:
         pandas.DataFrame: Mock dataframe.
@@ -144,7 +144,7 @@ def test_download_data_resume(init_args: dict) -> None:
 
     # save a fake checkpoint file
     checkpoint = {
-        IesoDownloader._turn_task_into_checkpoint_key(DownloadKey(date=d)): 1
+        DownloadTask(date=d).identifier: 1
         for d in pd.date_range(start=f"{y}-01", end=f"{y}-12", freq="MS")
         .strftime("%Y-%m")
         .tolist()
@@ -170,12 +170,12 @@ def test_download_data_resume(init_args: dict) -> None:
 # ----------------------------------
 # Tests - Data crawling logic
 # ----------------------------------
-def test_download_task_data(downloader: IesoDownloader, task: DownloadKey) -> None:
+def test_download_task_data(downloader: IesoDownloader, task: DownloadTask) -> None:
     """Happy path for "_download_task_data" method when resuming from checkpoint.
 
     Args:
         downloader (IesoDownloader): Instance of IesoDownloader class.
-        task (DownloadKey): The metadata of a downloading task, here: date (YYYY-MM)
+        task (DownloadTask): The metadata of a downloading task, here: date (YYYY-MM)
     """
     mock_df = pd.DataFrame({"Hour 1": [16.2]})
 
@@ -183,7 +183,7 @@ def test_download_task_data(downloader: IesoDownloader, task: DownloadKey) -> No
         status = downloader._download_task_data(task)
 
         assert status == 1
-        expected_file = Path(downloader.output_path, "1h", f"{task.date}.csv")
+        expected_file = downloader._build_task_path(task)
         assert expected_file.is_file(), f"The CSV {expected_file} was not created!"
 
         saved_df = pd.read_csv(expected_file)
@@ -193,18 +193,18 @@ def test_download_task_data(downloader: IesoDownloader, task: DownloadKey) -> No
 @pytest.mark.parametrize(
     "task, expect_old, expect_new",
     [
-        (DownloadKey(date="2019-04"), 1, 0),  # last month routed to old source
-        (DownloadKey(date="2019-05"), 0, 1),  # first month routed to new source
+        (DownloadTask(date="2019-04"), 1, 0),  # last month routed to old source
+        (DownloadTask(date="2019-05"), 0, 1),  # first month routed to new source
     ],
 )
 def test_get_task_data(
-    downloader: IesoDownloader, task: DownloadKey, expect_old: int, expect_new: int
+    downloader: IesoDownloader, task: DownloadTask, expect_old: int, expect_new: int
 ) -> None:
     """Happy path for "_get_task_data" method.
 
     Args:
         downloader (IesoDownloader): Instance of IesoDownloader class.
-        task (DownloadKey): The metadata of a downloading task, here: date (YYYY-MM)
+        task (DownloadTask): The metadata of a downloading task, here: date (YYYY-MM)
         expect_old (int): Expected call count for _get_from_old_source.
         expect_new (int): Expected call count for _get_from_new_source.
     """
@@ -226,13 +226,13 @@ def test_get_task_data(
     assert mock_new.call_count == expect_new
 
 
-def test_get_task_data_year_before_2010(downloader: IesoDownloader) -> None:
+def test_get_task_data_no_data_before_2010(downloader: IesoDownloader) -> None:
     """Failure path for "_get_task_data" method when dataframe is empty.
 
     Args:
         downloader (IesoDownloader): Instance of IesoDownloader class.
     """
-    task = DownloadKey(date="2009-01")
+    task = DownloadTask(date="2009-01")
     mock_df = pd.DataFrame(columns=EXPECTED_COLS)
 
     with patch.object(downloader, "_get_from_old_source", return_value=mock_df):
@@ -241,29 +241,33 @@ def test_get_task_data_year_before_2010(downloader: IesoDownloader) -> None:
                 downloader._get_task_data(task)
 
 
-def test_get_task_data_df_empty(downloader: IesoDownloader, task: DownloadKey) -> None:
-    """Failure path for "_get_task_data" method when dataframe is empty.
+def test_get_task_data_no_generation_data(
+    downloader: IesoDownloader, task: DownloadTask
+) -> None:
+    """Failure path for "_get_task_data" method when no generation data is available.
 
     Args:
         downloader (IesoDownloader): Instance of IesoDownloader class.
-        task (DownloadKey): The metadata of a downloading task, here: date (YYYY-MM)
+        task (DownloadTask): The metadata of a downloading task, here: date (YYYY-MM)
     """
     mock_df = pd.DataFrame(columns=EXPECTED_COLS)
 
     with patch.object(downloader, "_get_from_old_source", return_value=mock_df):
         with patch.object(downloader, "_get_from_new_source", return_value=mock_df):
-            with pytest.raises(MissingDataError, match="No generation data available"):
+            with pytest.raises(
+                MissingDataError, match="No energy generation data available"
+            ):
                 downloader._get_task_data(task)
 
 
 def test_get_task_data_structure_changed(
-    downloader: IesoDownloader, task: DownloadKey
+    downloader: IesoDownloader, task: DownloadTask
 ) -> None:
     """Failure path for "_get_task_data" method when dataframe doesn't have all columns.
 
     Args:
         downloader (IesoDownloader): Instance of IesoDownloader class.
-        task (DownloadKey): The metadata of a downloading task, here: date (YYYY-MM)
+        task (DownloadTask): The metadata of a downloading task, here: date (YYYY-MM)
     """
     mock_df = get_mock_df(task).drop(columns="Generator")
 
@@ -276,12 +280,12 @@ def test_get_task_data_structure_changed(
 # ----------------------------------
 # Tests - Data crawling helper methods
 # ----------------------------------
-def test_get_from_new_source(downloader: IesoDownloader, task: DownloadKey) -> None:
+def test_get_from_new_source(downloader: IesoDownloader, task: DownloadTask) -> None:
     """Happy path for "_get_from_new_source" method, ensuring correct URL and no 'Forecast'.
 
     Args:
         downloader (IesoDownloader): Instance of IesoDownloader class.
-        task (DownloadKey): The metadata of a downloading task, here: date (YYYY-MM)
+        task (DownloadTask): The metadata of a downloading task, here: date (YYYY-MM)
     """
     year, month = get_task_year_month(task)
     mock_df = pd.DataFrame(
@@ -305,13 +309,13 @@ def test_get_from_new_source(downloader: IesoDownloader, task: DownloadKey) -> N
 
 
 def test_get_from_new_source_missing_measurement(
-    downloader: IesoDownloader, task: DownloadKey
+    downloader: IesoDownloader, task: DownloadTask
 ) -> None:
     """Failure path for "_get_from_new_source" method when the 'Measurement' column is missing.
 
     Args:
         downloader (IesoDownloader): Instance of IesoDownloader class.
-        task (DownloadKey): The metadata of a downloading task, here: date (YYYY-MM)
+        task (DownloadTask): The metadata of a downloading task, here: date (YYYY-MM)
     """
     year, month = get_task_year_month(task)
     mock_df = get_mock_df(task).drop(columns="Measurement")
@@ -324,18 +328,18 @@ def test_get_from_new_source_missing_measurement(
 @pytest.mark.parametrize(
     "task, suffix",
     [
-        (DownloadKey(date="2018-01"), "2018.xlsx"),
-        (DownloadKey(date="2019-01"), "2019-Jan-April.xlsx"),  # edge case
+        (DownloadTask(date="2018-01"), "2018.xlsx"),
+        (DownloadTask(date="2019-01"), "2019-Jan-April.xlsx"),  # edge case
     ],
 )
 def test_get_from_old_source(
-    downloader: IesoDownloader, task: DownloadKey, suffix: str
+    downloader: IesoDownloader, task: DownloadTask, suffix: str
 ) -> None:
     """Happy path for "_get_from_old_source" method, ensuring correct URL and month filter.
 
     Args:
         downloader (IesoDownloader): Instance of IesoDownloader class.
-        task (DownloadKey): The metadata of a downloading task, here: date (YYYY-MM)
+        task (DownloadTask): The metadata of a downloading task, here: date (YYYY-MM)
         suffix (str): Expected suffix of URL.
     """
     year, month = get_task_year_month(task)
@@ -361,12 +365,12 @@ def test_get_from_old_source(
         assert df["Delivery Date"].dt.month.iloc[0] == month
 
 
-def test_lru_cache_works(downloader: IesoDownloader, task: DownloadKey) -> None:
+def test_lru_cache_works(downloader: IesoDownloader, task: DownloadTask) -> None:
     """Happy path for @lru_cache decorator of _load_yearly_excel method.
 
     Args:
         downloader (IesoDownloader): Instance of IesoDownloader class.
-        task (DownloadKey): The metadata of a downloading task, here: date (YYYY-MM)
+        task (DownloadTask): The metadata of a downloading task, here: date (YYYY-MM)
     """
     year, month = get_task_year_month(task)
     mock_df = pd.DataFrame(
@@ -387,13 +391,13 @@ def test_lru_cache_works(downloader: IesoDownloader, task: DownloadKey) -> None:
 
 
 def test_get_from_old_source_structure_changed(
-    downloader: IesoDownloader, task: DownloadKey
+    downloader: IesoDownloader, task: DownloadTask
 ) -> None:
     """Failure path for "_get_from_new_source" method when the URL is unavailable.
 
     Args:
         downloader (IesoDownloader): Instance of IesoDownloader class.
-        task (DownloadKey): The metadata of a downloading task, here: date (YYYY-MM)
+        task (DownloadTask): The metadata of a downloading task, here: date (YYYY-MM)
     """
     year, month = get_task_year_month(task)
 
@@ -404,12 +408,12 @@ def test_get_from_old_source_structure_changed(
             downloader._get_from_old_source(year=year, month=month)
 
 
-def test_load_yearly_excel(downloader: IesoDownloader, task: DownloadKey) -> None:
+def test_load_yearly_excel(downloader: IesoDownloader, task: DownloadTask) -> None:
     """Happy path for "_load_yearly_excel" method, with concatenation and capacity finding.
 
     Args:
         downloader (IesoDownloader): Instance of IesoDownloader class.
-        task (DownloadKey): The metadata of a downloading task, here: date (YYYY-MM)
+        task (DownloadTask): The metadata of a downloading task, here: date (YYYY-MM)
     """
     mock_df_out = pd.DataFrame(
         {"DATE": [f"{task.date}-01"], "HOUR": [1], "GEN_A": [10]}
@@ -440,13 +444,13 @@ def test_load_yearly_excel(downloader: IesoDownloader, task: DownloadKey) -> Non
 
 
 def test_load_yearly_excel_missing_capacity(
-    downloader: IesoDownloader, task: DownloadKey
+    downloader: IesoDownloader, task: DownloadTask
 ) -> None:
     """Failure path for "_load_yearly_excel" method when no suitable capacity sheets exist.
 
     Args:
         downloader (IesoDownloader): Instance of IesoDownloader class.
-        task (DownloadKey): The metadata of a downloading task, here: date (YYYY-MM)
+        task (DownloadTask): The metadata of a downloading task, here: date (YYYY-MM)
     """
     mock_df_out = pd.DataFrame(
         {"DATE": [f"{task.date}-01"], "HOUR": [1], "GEN_A": [10]}
@@ -459,12 +463,12 @@ def test_load_yearly_excel_missing_capacity(
             downloader._load_yearly_excel(url="http://fake.xlsx")
 
 
-def test_standardize_old_data(downloader: IesoDownloader, task: DownloadKey) -> None:
+def test_standardize_old_data(downloader: IesoDownloader, task: DownloadTask) -> None:
     """Happy path for "_standardize_old_data" method, ensuring transformations work.
 
     Args:
         downloader (IesoDownloader): Instance of IesoDownloader class.
-        task (DownloadKey): The metadata of a downloading task, here: date (YYYY-MM)
+        task (DownloadTask): The metadata of a downloading task, here: date (YYYY-MM)
     """
     mock_df = pd.DataFrame(
         {

--- a/tests/energy/test_utils.py
+++ b/tests/energy/test_utils.py
@@ -2,7 +2,6 @@
 """Tests for energy utility functions and classes."""
 
 import pickle
-from datetime import datetime
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, Callable, cast
@@ -21,10 +20,12 @@ from rbc.energy.utils import (
     write_df_to_csv,
 )
 
-
 # ----------------------------------
 # Fixtures
 # ----------------------------------
+TASK_YESTERDAY = (pd.Timestamp.now() - pd.Timedelta(days=1)).strftime("%Y-%m")
+
+
 class MockDownloader(EnergyDownloader):
     """A dummy child class to test EnergyDownloader logic directly."""
 
@@ -117,8 +118,13 @@ def test_threading_wrapper(
 
 
 @pytest.mark.parametrize(
-    "task, use_self_ckpt",
-    [("2020-01-01", True), (("ZONE_A", "2020-01-01"), False)],  # EIA/EPIAS, Entso-E
+    "task, use_self_ckpt, expected_valueerror_status",
+    [
+        ("2020-01-01", True, 1),  # for EIA/EPIAS/...
+        (TASK_YESTERDAY, True, 0),
+        (("ZONE_A", "2020-01-01"), False, 1),  # for Entso-E
+        (("ZONE_A", TASK_YESTERDAY), False, 0),
+    ],
 )
 @pytest.mark.parametrize(
     "code, expected_status, expected_sleep_calls",
@@ -134,6 +140,7 @@ def test_threading_error_catching(
     ckpt_setup: Callable,
     task: str | tuple[str, str],
     use_self_ckpt: bool,
+    expected_valueerror_status: int,
     code: int | None,
     expected_status: int,
     expected_sleep_calls: int,
@@ -149,6 +156,7 @@ def test_threading_error_catching(
         ckpt_setup (Callable): Function that defined checkpoint setup for specific task.
         task (str | tuple[str, str]): Task for downloading.
         use_self_ckpt (bool): Whether to use class attribute (self.) for checkpointing.
+        expected_valueerror_status (int): Expected ValueError status.
         code (int | None): Status code for HTTPError logic.
         expected_status (int): Expected status for resuming logic.
         expected_sleep_calls (int): Expected number of times sleep is called.
@@ -162,13 +170,13 @@ def test_threading_error_catching(
 
     mock_exit.assert_called_once_with(1)  # assert outside "with"-block for correct exec
 
-    # 2. Test missing data (ValueError -> status 1)
+    # 2. Test missing data (ValueError -> status 0 = current year, status 1 = prior year)
     checkpoint, checkpoint_path = ckpt_setup(task, use_self_ckpt)
     with patch.object(downloader, "_get_task_data", side_effect=ValueError):
         with patch.object(downloader, "_save_checkpoint") as mock_save:
             downloader._threading_wrapper(task, checkpoint, checkpoint_path)
 
-            assert checkpoint[task] == 1
+            assert checkpoint[task] == expected_valueerror_status
             mock_save.assert_called_once_with(checkpoint, checkpoint_path)
 
     # 3. Test HTTPError - no code: (->0), retry: code=300 (->0), missing: code=404 (->1), client: code=400 (->1)
@@ -310,7 +318,7 @@ def test_get_date_list_future_years(downloader: MockDownloader) -> None:
     Args:
         downloader (MockDownloader): Instance of the MockDownloader class.
     """
-    downloader.years = [datetime.now().year + 1]
+    downloader.years = [pd.Timestamp.now().year + 1]
 
     with pytest.raises(ValueError, match="lie in the future"):
         downloader._get_date_list()

--- a/tests/energy/test_utils.py
+++ b/tests/energy/test_utils.py
@@ -14,6 +14,7 @@ from requests import exceptions
 from rbc.energy.utils import (
     MAX_RETRIES,
     DataStructureError,
+    DownloadKey,
     EnergyDownloader,
     InvalidError,
     load_df_from_file,
@@ -23,17 +24,20 @@ from rbc.energy.utils import (
 # ----------------------------------
 # Fixtures
 # ----------------------------------
-TASK_YESTERDAY = (pd.Timestamp.now() - pd.Timedelta(days=1)).strftime("%Y-%m")
+TASK_DAY = DownloadKey(date="2020-01-01")
+TASK_YESTERDAY = DownloadKey(
+    date=(pd.Timestamp.now() - pd.Timedelta(days=1)).strftime("%Y-%m-%d")
+)
 
 
 class MockDownloader(EnergyDownloader):
     """A dummy child class to test EnergyDownloader logic directly."""
 
-    def _get_task_data(self, task: str | tuple[str, str]):
+    def _get_task_data(self, task: DownloadKey):
         """Dummy method to test EnergyDownloader._get_task_data function.
 
         Args:
-            task (str | tuple[str, str]): Task for downloading.
+            task (DownloadKey): The metadata for a task to download data for.
         """
         pass
 
@@ -63,11 +67,11 @@ def ckpt_setup(downloader: MockDownloader, tmp_path: Path) -> Callable:
         Callable: Function that defines checkpoint setup for specific task.
     """
 
-    def _setup(task: str | tuple[str, str], use_self_ckpt: bool) -> tuple[dict, Path]:
+    def _setup(task: DownloadKey, use_self_ckpt: bool) -> tuple[dict, Path]:
         """Function that defines checkpoint setup for specific task.
 
         Args:
-            task (str | tuple[str, str]): Task for downloading.
+            task (DownloadKey): The metadata for a task to download data for.
             use_self_ckpt (bool): Whether to use class attribute (self.) for checkpointing.
 
         Returns:
@@ -79,7 +83,12 @@ def ckpt_setup(downloader: MockDownloader, tmp_path: Path) -> Callable:
             d.checkpoint = {}
             return d.checkpoint, d.checkpoint_path
         else:
-            nested_path = Path(tmp_path, task[0], "status.pickle")
+            nested_path = downloader._build_checkpoint_path(
+                DownloadKey(
+                    temporal_resolution=task.temporal_resolution,
+                    bidding_zone=task.bidding_zone,
+                )
+            )
             nested_path.parent.mkdir(parents=True, exist_ok=True)  # Ensure dir exists
             return {}, nested_path
 
@@ -91,12 +100,15 @@ def ckpt_setup(downloader: MockDownloader, tmp_path: Path) -> Callable:
 # ----------------------------------
 @pytest.mark.parametrize(
     "task, use_self_ckpt",
-    [("2020-01-01", True), (("ZONE_A", "2020-01-01"), False)],  # EIA/EPIAS, Entso-E
+    [
+        (TASK_DAY, True),  # EIA/EPIAS
+        (TASK_DAY.update(bidding_zone="ZONE_A"), False),  # Entso-E
+    ],
 )
 def test_threading_wrapper(
     downloader: MockDownloader,
     ckpt_setup: Callable,
-    task: str | tuple[str, str],
+    task: DownloadKey,
     use_self_ckpt: bool,
 ) -> None:
     """Happy path for _threading_wrapper (and, inherently, _download_task_data).
@@ -104,26 +116,27 @@ def test_threading_wrapper(
     Args:
         downloader (MockDownloader): Instance of the MockDownloader class.
         ckpt_setup (Callable): Function that defined checkpoint setup for specific task.
-        task (str | tuple[str, str]): Task for downloading.
+        task (DownloadKey): The metadata for a task to download data for.
         use_self_ckpt (bool): Whether to use class attribute (self.) for checkpointing.
     """
     checkpoint, checkpoint_path = ckpt_setup(task, use_self_ckpt)
+    ckpt_key = downloader._turn_task_into_checkpoint_key(task)
 
     with patch.object(downloader, "_get_task_data"):
         with patch.object(downloader, "_save_checkpoint") as mock_save:
             downloader._threading_wrapper(task, checkpoint, checkpoint_path)
 
-            assert checkpoint[task] == 1
+            assert checkpoint[ckpt_key] == 1
             mock_save.assert_called_once_with(checkpoint, checkpoint_path)
 
 
 @pytest.mark.parametrize(
     "task, use_self_ckpt, expected_valueerror_status",
     [
-        ("2020-01-01", True, 1),  # for EIA/EPIAS/...
+        (TASK_DAY, True, 1),  # for EIA/EPIAS/...
         (TASK_YESTERDAY, True, 0),
-        (("ZONE_A", "2020-01-01"), False, 1),  # for Entso-E
-        (("ZONE_A", TASK_YESTERDAY), False, 0),
+        (TASK_DAY.update(bidding_zone="ZONE_A"), False, 1),  # for Entso-E
+        (TASK_YESTERDAY.update(bidding_zone="ZONE_A"), False, 0),
     ],
 )
 @pytest.mark.parametrize(
@@ -138,7 +151,7 @@ def test_threading_wrapper(
 def test_threading_error_catching(
     downloader: MockDownloader,
     ckpt_setup: Callable,
-    task: str | tuple[str, str],
+    task: DownloadKey,
     use_self_ckpt: bool,
     expected_valueerror_status: int,
     code: int | None,
@@ -154,13 +167,15 @@ def test_threading_error_catching(
     Args:
         downloader (MockDownloader): Instance of the MockDownloader class.
         ckpt_setup (Callable): Function that defined checkpoint setup for specific task.
-        task (str | tuple[str, str]): Task for downloading.
+        task (DownloadKey): The metadata for a task to download data for.
         use_self_ckpt (bool): Whether to use class attribute (self.) for checkpointing.
         expected_valueerror_status (int): Expected ValueError status.
         code (int | None): Status code for HTTPError logic.
         expected_status (int): Expected status for resuming logic.
         expected_sleep_calls (int): Expected number of times sleep is called.
     """
+    ckpt_key = downloader._turn_task_into_checkpoint_key(task)
+
     # 1. Test error requiring immediate exit (DataStructureError / RateLimitError -> exit)
     checkpoint, checkpoint_path = ckpt_setup(task, use_self_ckpt)
     with patch("os._exit", side_effect=SystemExit) as mock_exit:
@@ -176,7 +191,7 @@ def test_threading_error_catching(
         with patch.object(downloader, "_save_checkpoint") as mock_save:
             downloader._threading_wrapper(task, checkpoint, checkpoint_path)
 
-            assert checkpoint[task] == expected_valueerror_status
+            assert checkpoint[ckpt_key] == expected_valueerror_status
             mock_save.assert_called_once_with(checkpoint, checkpoint_path)
 
     # 3. Test HTTPError - no code: (->0), retry: code=300 (->0), missing: code=404 (->1), client: code=400 (->1)
@@ -189,7 +204,7 @@ def test_threading_error_catching(
                 with patch.object(downloader, "_save_checkpoint") as mock_save:
                     downloader._threading_wrapper(task, checkpoint, checkpoint_path)
 
-                    assert checkpoint[task] == expected_status
+                    assert checkpoint[ckpt_key] == expected_status
                     assert mock_sleep.call_count == expected_sleep_calls
                     mock_save.assert_called_once_with(checkpoint, checkpoint_path)
 
@@ -199,7 +214,7 @@ def test_threading_error_catching(
         with patch.object(downloader, "_save_checkpoint") as mock_save:
             downloader._threading_wrapper(task, checkpoint, checkpoint_path)
 
-            assert checkpoint[task] == 0
+            assert checkpoint[ckpt_key] == 0
             mock_save.assert_called_once_with(checkpoint, checkpoint_path)
 
 
@@ -225,35 +240,36 @@ def test_get_status_code(error: Exception, expected_return: str | None) -> None:
 
 
 @pytest.mark.parametrize(
-    "valid_input, expected_csv",
-    [("str", Path("str.csv")), (("str1", "str2"), Path("str1", "str2.csv"))],
+    "task, expected_csv",
+    [
+        (TASK_DAY, Path("1h", "2020-01-01.csv")),
+        (TASK_DAY.update(bidding_zone="A"), Path("1h", "A", "2020-01-01.csv")),
+        (TASK_DAY.update(temporal_resolution="5min"), Path("5min", "2020-01-01.csv")),
+    ],
 )
-def test_get_csv_path(
-    downloader: MockDownloader, valid_input: str | tuple[str, str], expected_csv: Path
+def test_build_task_path(
+    downloader: MockDownloader, task: DownloadKey, expected_csv: Path
 ) -> None:
-    """Happy path for _get_csv_path when valid inputs are provided.
+    """Happy path for _build_task_path when valid inputs are provided.
 
     Args:
         downloader (MockDownloader): Instance of the MockDownloader class.
-        valid_input (str | tuple[str, str]): Valid input for _get_csv_path.
+        task (DownloadKey): Valid DownloadKey for _build_task_path.
         expected_csv (str): Expected csv path name.
     """
-    path = downloader._get_csv_path(valid_input)
+    path = downloader._build_task_path(task)
     assert str(expected_csv) in str(path)
 
 
-@pytest.mark.parametrize("invalid_input", [12345, ("first", "second", "third")])
-def test_get_csv_path_invalid_task(
-    downloader: MockDownloader, invalid_input: Any
-) -> None:
-    """Failure path for _get_csv_path when invalid task is provided.
+def test_build_task_path_invalid_task(downloader: MockDownloader) -> None:
+    """Failure path for _build_task_path when invalid task is provided.
 
     Args:
         downloader (MockDownloader): Instance of the MockDownloader class.
-        invalid_input (Any): Invalid input for _get_csv_path.
     """
-    with pytest.raises(ValueError, match="Unsupported task format"):
-        downloader._get_csv_path(invalid_input)
+    invalid_task = DownloadKey()
+    with pytest.raises(AttributeError, match="Required attribute 'date'"):
+        downloader._build_task_path(invalid_task)
 
 
 def test_load_checkpoint_corrupted(downloader: MockDownloader) -> None:
@@ -271,12 +287,15 @@ def test_load_checkpoint_corrupted(downloader: MockDownloader) -> None:
 
 @pytest.mark.parametrize(
     "task, use_self_ckpt",
-    [("2020-01-01", True), (("ZONE_A", "2020-01-01"), False)],  # EIA/EPIAS, Entso-E
+    [
+        (TASK_DAY, True),  # EIA/EPIAS
+        (TASK_DAY.update(bidding_zone="ZONE_A"), False),  # Entso-E
+    ],
 )
 def test_save_checkpoint(
     downloader: MockDownloader,
     ckpt_setup: Callable,
-    task: str | tuple[str, str],
+    task: DownloadKey,
     use_self_ckpt: bool,
 ) -> None:
     """Happy path for _save_checkpoint with valid checkpoint setups.
@@ -284,11 +303,11 @@ def test_save_checkpoint(
     Args:
         downloader (MockDownloader): Instance of the MockDownloader class.
         ckpt_setup (Callable): Function that defined checkpoint setup for specific task.
-        task (str | tuple[str, str]): Task for downloading.
+        task (DownloadKey): The metadata for a task to download data for.
         use_self_ckpt (bool): Whether to use class attribute (self.) for checkpointing.
     """
     _, checkpoint_path = ckpt_setup(task, use_self_ckpt)
-    checkpoint = {task: 1}
+    checkpoint = {downloader._turn_task_into_checkpoint_key(task): 1}
     downloader._save_checkpoint(checkpoint, checkpoint_path)
 
     assert checkpoint_path.is_file()

--- a/tests/energy/test_utils.py
+++ b/tests/energy/test_utils.py
@@ -17,6 +17,7 @@ from rbc.energy.utils import (
     DownloadKey,
     EnergyDownloader,
     InvalidError,
+    MissingDataError,
     load_df_from_file,
     write_df_to_csv,
 )
@@ -131,7 +132,7 @@ def test_threading_wrapper(
 
 
 @pytest.mark.parametrize(
-    "task, use_self_ckpt, expected_valueerror_status",
+    "task, use_self_ckpt, expected_error_status",
     [
         (TASK_DAY, True, 1),  # for EIA/EPIAS/...
         (TASK_YESTERDAY, True, 0),
@@ -153,7 +154,7 @@ def test_threading_error_catching(
     ckpt_setup: Callable,
     task: DownloadKey,
     use_self_ckpt: bool,
-    expected_valueerror_status: int,
+    expected_error_status: int,
     code: int | None,
     expected_status: int,
     expected_sleep_calls: int,
@@ -169,7 +170,7 @@ def test_threading_error_catching(
         ckpt_setup (Callable): Function that defined checkpoint setup for specific task.
         task (DownloadKey): The metadata for a task to download data for.
         use_self_ckpt (bool): Whether to use class attribute (self.) for checkpointing.
-        expected_valueerror_status (int): Expected ValueError status.
+        expected_error_status (int): Expected MissingDataError status.
         code (int | None): Status code for HTTPError logic.
         expected_status (int): Expected status for resuming logic.
         expected_sleep_calls (int): Expected number of times sleep is called.
@@ -185,13 +186,13 @@ def test_threading_error_catching(
 
     mock_exit.assert_called_once_with(1)  # assert outside "with"-block for correct exec
 
-    # 2. Test missing data (ValueError -> status 0 = current year, status 1 = prior year)
+    # 2. Test missing data (MissingDataError -> status 0 = current year, status 1 = prior)
     checkpoint, checkpoint_path = ckpt_setup(task, use_self_ckpt)
-    with patch.object(downloader, "_get_task_data", side_effect=ValueError):
+    with patch.object(downloader, "_get_task_data", side_effect=MissingDataError):
         with patch.object(downloader, "_save_checkpoint") as mock_save:
             downloader._threading_wrapper(task, checkpoint, checkpoint_path)
 
-            assert checkpoint[ckpt_key] == expected_valueerror_status
+            assert checkpoint[ckpt_key] == expected_error_status
             mock_save.assert_called_once_with(checkpoint, checkpoint_path)
 
     # 3. Test HTTPError - no code: (->0), retry: code=300 (->0), missing: code=404 (->1), client: code=400 (->1)
@@ -268,7 +269,7 @@ def test_build_task_path_invalid_task(downloader: MockDownloader) -> None:
         downloader (MockDownloader): Instance of the MockDownloader class.
     """
     invalid_task = DownloadKey()
-    with pytest.raises(AttributeError, match="Required attribute 'date'"):
+    with pytest.raises(ValueError, match="Required attribute 'date'"):
         downloader._build_task_path(invalid_task)
 
 
@@ -339,7 +340,7 @@ def test_get_date_list_future_years(downloader: MockDownloader) -> None:
     """
     downloader.years = [pd.Timestamp.now().year + 1]
 
-    with pytest.raises(ValueError, match="lie in the future"):
+    with pytest.raises(InvalidError, match="lie in the future"):
         downloader._get_date_list()
 
 

--- a/tests/energy/test_utils.py
+++ b/tests/energy/test_utils.py
@@ -389,14 +389,14 @@ def test_downloadtask_initialise(tres: str | None, bz: str | None) -> None:
         assert task.identifier == f"date={date}|temporal_resolution={exp_tres}"
 
 
-@pytest.mark.parametrize("invalid_date", ["20200101", "invalid", ""])
+@pytest.mark.parametrize("invalid_date", ["20200101", "invalid", "", "2020-02-31"])
 def test_downloadtask_initialise_with_invalid_date(invalid_date: str) -> None:
     """Failure path for initialising a DownloadTask instance.
 
     Args:
         invalid_date (str): Invalid date.
     """
-    with pytest.raises(ValueError, match="Invalid date / date format"):
+    with pytest.raises(ValueError, match=r"Invalid.*date"):
         DownloadTask(date=invalid_date)
 
 

--- a/tests/energy/test_utils.py
+++ b/tests/energy/test_utils.py
@@ -4,7 +4,6 @@
 import pickle
 from pathlib import Path
 from types import SimpleNamespace
-from typing import Any, Callable, cast
 from unittest.mock import patch
 
 import pandas as pd
@@ -14,7 +13,7 @@ from requests import exceptions
 from rbc.energy.utils import (
     MAX_RETRIES,
     DataStructureError,
-    DownloadKey,
+    DownloadTask,
     EnergyDownloader,
     InvalidError,
     MissingDataError,
@@ -25,8 +24,8 @@ from rbc.energy.utils import (
 # ----------------------------------
 # Fixtures
 # ----------------------------------
-TASK_DAY = DownloadKey(date="2020-01-01")
-TASK_YESTERDAY = DownloadKey(
+TASK_DAY = DownloadTask(date="2020-01-01")
+TASK_YESTERDAY = DownloadTask(
     date=(pd.Timestamp.now() - pd.Timedelta(days=1)).strftime("%Y-%m-%d")
 )
 
@@ -34,110 +33,105 @@ TASK_YESTERDAY = DownloadKey(
 class MockDownloader(EnergyDownloader):
     """A dummy child class to test EnergyDownloader logic directly."""
 
-    def _get_task_data(self, task: DownloadKey):
+    def _get_task_data(self, task: DownloadTask) -> None:
         """Dummy method to test EnergyDownloader._get_task_data function.
 
         Args:
-            task (DownloadKey): The metadata for a task to download data for.
+            task (DownloadTask): The metadata for a task to download data for.
         """
         pass
 
 
 @pytest.fixture
-def downloader(tmp_path: Path) -> MockDownloader:
-    """Fixture to create an instance of EnergyDownloader.
+def init_args(tmp_path: Path) -> dict:
+    """Creates a basic setup with a temporary directory.
 
     Args:
-        tmp_path (Path): Path to temporary directory.
+        tmp_path (Path): Path to the temporary directory.
 
     Returns:
-        MockDownloader: Instance of the mock EnergyDownloader child class.
+        dict: Initialisation arguments.
     """
-    return MockDownloader(output_path=tmp_path, years=[2020])
+    return {
+        "output_path": tmp_path,
+        "years": [2020],
+    }
 
 
 @pytest.fixture
-def ckpt_setup(downloader: MockDownloader, tmp_path: Path) -> Callable:
-    """Fixture to define a setup function for setting up the checkpoint file and path.
+def downloader(init_args: dict) -> EnergyDownloader:
+    """Fixture to create an instance of EnergyDownloader.
 
     Args:
-        downloader (MockDownloader): Instance of the MockDownloader class.
-        tmp_path (Path): Path to temporary directory.
+        init_args (dict): Arguments used to initialize an EnergyDownloader instance.
 
     Returns:
-        Callable: Function that defines checkpoint setup for specific task.
+        EnergyDownloader: Instance of the mock EnergyDownloader child class.
     """
-
-    def _setup(task: DownloadKey, use_self_ckpt: bool) -> tuple[dict, Path]:
-        """Function that defines checkpoint setup for specific task.
-
-        Args:
-            task (DownloadKey): The metadata for a task to download data for.
-            use_self_ckpt (bool): Whether to use class attribute (self.) for checkpointing.
-
-        Returns:
-            tuple[dict, Path]: Checkpoint dictionary and checkpoint path.
-        """
-        if use_self_ckpt:
-            d = cast(Any, downloader)  # prevents mypy complaining about missing attribs
-            d.checkpoint_path = Path(tmp_path, "status.pickle")
-            d.checkpoint = {}
-            return d.checkpoint, d.checkpoint_path
-        else:
-            nested_path = downloader._build_checkpoint_path(
-                DownloadKey(
-                    temporal_resolution=task.temporal_resolution,
-                    bidding_zone=task.bidding_zone,
-                )
-            )
-            nested_path.parent.mkdir(parents=True, exist_ok=True)  # Ensure dir exists
-            return {}, nested_path
-
-    return _setup
+    return MockDownloader(
+        output_path=init_args["output_path"], years=init_args["years"]
+    )
 
 
 # ----------------------------------
 # Tests - EnergyDownloader
 # ----------------------------------
+def test_initialization(downloader: EnergyDownloader, init_args: dict) -> None:
+    """Happy path for EnergyDownloader initialization.
+
+    Args:
+        downloader (EnergyDownloader): Instance of EnergyDownloader class.
+        init_args (dict): Arguments used to initialize an EnergyDownloader instance.
+    """
+    assert downloader.years == init_args["years"]
+    assert downloader.output_path == init_args["output_path"]
+    assert downloader.checkpoint_path == Path(init_args["output_path"], "status.pickle")
+    assert downloader.checkpoint == {}
+
+
 @pytest.mark.parametrize(
-    "task, use_self_ckpt",
-    [
-        (TASK_DAY, True),  # EIA/EPIAS
-        (TASK_DAY.update(bidding_zone="ZONE_A"), False),  # Entso-E
-    ],
+    "task",
+    [TASK_DAY, TASK_DAY.update(bidding_zone="ZONE_A")],
 )
-def test_threading_wrapper(
-    downloader: MockDownloader,
-    ckpt_setup: Callable,
-    task: DownloadKey,
-    use_self_ckpt: bool,
-) -> None:
+def test_threading_wrapper(downloader: MockDownloader, task: DownloadTask) -> None:
     """Happy path for _threading_wrapper (and, inherently, _download_task_data).
 
     Args:
         downloader (MockDownloader): Instance of the MockDownloader class.
-        ckpt_setup (Callable): Function that defined checkpoint setup for specific task.
-        task (DownloadKey): The metadata for a task to download data for.
-        use_self_ckpt (bool): Whether to use class attribute (self.) for checkpointing.
+        task (DownloadTask): The metadata for a task to download data for.
     """
-    checkpoint, checkpoint_path = ckpt_setup(task, use_self_ckpt)
-    ckpt_key = downloader._turn_task_into_checkpoint_key(task)
-
-    with patch.object(downloader, "_get_task_data"):
+    with patch.object(downloader, "_download_task_data", return_value=1) as mock_dl:
         with patch.object(downloader, "_save_checkpoint") as mock_save:
-            downloader._threading_wrapper(task, checkpoint, checkpoint_path)
+            downloader._threading_wrapper(task)
 
-            assert checkpoint[ckpt_key] == 1
-            mock_save.assert_called_once_with(checkpoint, checkpoint_path)
+            assert downloader.checkpoint[task.identifier] == 1
+            mock_dl.assert_called_once_with(task=task)
+            mock_save.assert_called_once()
+
+
+def test_threading_wrapper_skip_existing_task(downloader: MockDownloader) -> None:
+    """Happy path for _threading_wrapper when task exists from previous run and is skipped.
+
+    Args:
+        downloader (MockDownloader): Instance of the MockDownloader class.
+    """
+    downloader.checkpoint = {TASK_DAY.identifier: 1}
+
+    with patch.object(downloader, "_download_task_data") as mock_dl:
+        with patch.object(downloader, "_save_checkpoint") as mock_save:
+            downloader._threading_wrapper(TASK_DAY)
+
+            mock_dl.assert_not_called()
+            mock_save.assert_not_called()
 
 
 @pytest.mark.parametrize(
-    "task, use_self_ckpt, expected_error_status",
+    "task, expected_error_status",
     [
-        (TASK_DAY, True, 1),  # for EIA/EPIAS/...
-        (TASK_YESTERDAY, True, 0),
-        (TASK_DAY.update(bidding_zone="ZONE_A"), False, 1),  # for Entso-E
-        (TASK_YESTERDAY.update(bidding_zone="ZONE_A"), False, 0),
+        (TASK_DAY, 1),  # for EIA/EPIAS/...
+        (TASK_YESTERDAY, 0),
+        (TASK_DAY.update(bidding_zone="ZONE_A"), 1),  # for Entso-E
+        (TASK_YESTERDAY.update(bidding_zone="ZONE_A"), 0),
     ],
 )
 @pytest.mark.parametrize(
@@ -151,9 +145,7 @@ def test_threading_wrapper(
 )
 def test_threading_error_catching(
     downloader: MockDownloader,
-    ckpt_setup: Callable,
-    task: DownloadKey,
-    use_self_ckpt: bool,
+    task: DownloadTask,
     expected_error_status: int,
     code: int | None,
     expected_status: int,
@@ -167,56 +159,53 @@ def test_threading_error_catching(
 
     Args:
         downloader (MockDownloader): Instance of the MockDownloader class.
-        ckpt_setup (Callable): Function that defined checkpoint setup for specific task.
-        task (DownloadKey): The metadata for a task to download data for.
-        use_self_ckpt (bool): Whether to use class attribute (self.) for checkpointing.
+        task (DownloadTask): The metadata for a task to download data for.
         expected_error_status (int): Expected MissingDataError status.
         code (int | None): Status code for HTTPError logic.
         expected_status (int): Expected status for resuming logic.
         expected_sleep_calls (int): Expected number of times sleep is called.
     """
-    ckpt_key = downloader._turn_task_into_checkpoint_key(task)
+    downloader.checkpoint = {}
 
     # 1. Test error requiring immediate exit (DataStructureError / RateLimitError -> exit)
-    checkpoint, checkpoint_path = ckpt_setup(task, use_self_ckpt)
     with patch("os._exit", side_effect=SystemExit) as mock_exit:
         with patch.object(downloader, "_get_task_data", side_effect=DataStructureError):
             with pytest.raises(SystemExit):
-                downloader._threading_wrapper(task, checkpoint, checkpoint_path)
+                downloader._threading_wrapper(task)
 
     mock_exit.assert_called_once_with(1)  # assert outside "with"-block for correct exec
 
     # 2. Test missing data (MissingDataError -> status 0 = current year, status 1 = prior)
-    checkpoint, checkpoint_path = ckpt_setup(task, use_self_ckpt)
+    downloader.checkpoint = {}
     with patch.object(downloader, "_get_task_data", side_effect=MissingDataError):
         with patch.object(downloader, "_save_checkpoint") as mock_save:
-            downloader._threading_wrapper(task, checkpoint, checkpoint_path)
+            downloader._threading_wrapper(task)
 
-            assert checkpoint[ckpt_key] == expected_error_status
-            mock_save.assert_called_once_with(checkpoint, checkpoint_path)
+            assert downloader.checkpoint[task.identifier] == expected_error_status
+            mock_save.assert_called_once()
 
     # 3. Test HTTPError - no code: (->0), retry: code=300 (->0), missing: code=404 (->1), client: code=400 (->1)
-    checkpoint, checkpoint_path = ckpt_setup(task, use_self_ckpt)
+    downloader.checkpoint = {}
     with patch.object(
         downloader, "_get_task_data", side_effect=exceptions.HTTPError("")
     ):
         with patch.object(downloader, "_get_status_code", return_value=code):
             with patch("rbc.energy.utils.time.sleep") as mock_sleep:
                 with patch.object(downloader, "_save_checkpoint") as mock_save:
-                    downloader._threading_wrapper(task, checkpoint, checkpoint_path)
+                    downloader._threading_wrapper(task)
 
-                    assert checkpoint[ckpt_key] == expected_status
+                    assert downloader.checkpoint[task.identifier] == expected_status
                     assert mock_sleep.call_count == expected_sleep_calls
-                    mock_save.assert_called_once_with(checkpoint, checkpoint_path)
+                    mock_save.assert_called_once()
 
     # 4. Test other errors (that are not specifically handled in _download_task_data)
-    checkpoint, checkpoint_path = ckpt_setup(task, use_self_ckpt)
+    downloader.checkpoint = {}
     with patch.object(downloader, "_get_task_data", side_effect=Exception):
         with patch.object(downloader, "_save_checkpoint") as mock_save:
-            downloader._threading_wrapper(task, checkpoint, checkpoint_path)
+            downloader._threading_wrapper(task)
 
-            assert checkpoint[ckpt_key] == 0
-            mock_save.assert_called_once_with(checkpoint, checkpoint_path)
+            assert downloader.checkpoint[task.identifier] == 0
+            mock_save.assert_called_once()
 
 
 # ----------------------------------
@@ -249,28 +238,53 @@ def test_get_status_code(error: Exception, expected_return: str | None) -> None:
     ],
 )
 def test_build_task_path(
-    downloader: MockDownloader, task: DownloadKey, expected_csv: Path
+    downloader: MockDownloader, task: DownloadTask, expected_csv: Path
 ) -> None:
     """Happy path for _build_task_path when valid inputs are provided.
 
     Args:
         downloader (MockDownloader): Instance of the MockDownloader class.
-        task (DownloadKey): Valid DownloadKey for _build_task_path.
+        task (DownloadTask): Valid DownloadTask for _build_task_path.
         expected_csv (str): Expected csv path name.
     """
     path = downloader._build_task_path(task)
     assert str(expected_csv) in str(path)
 
 
-def test_build_task_path_invalid_task(downloader: MockDownloader) -> None:
-    """Failure path for _build_task_path when invalid task is provided.
+@pytest.mark.parametrize(
+    "task",
+    [TASK_DAY, TASK_DAY.update(bidding_zone="ZONE_A")],
+)
+def test_save_checkpoint(
+    downloader: MockDownloader,
+    task: DownloadTask,
+) -> None:
+    """Happy path for _save_checkpoint with valid checkpoint setups.
+
+    Args:
+        downloader (MockDownloader): Instance of the MockDownloader class.
+        task (DownloadTask): The metadata for a task to download data for.
+    """
+    downloader.checkpoint = {task.identifier: 1}
+    downloader._save_checkpoint()
+
+    assert downloader.checkpoint_path.is_file()
+    with open(downloader.checkpoint_path, "rb") as f:
+        assert pickle.load(f) == downloader.checkpoint
+
+
+def test_load_checkpoint(downloader: MockDownloader) -> None:
+    """Happy path for _load_checkpoint.
 
     Args:
         downloader (MockDownloader): Instance of the MockDownloader class.
     """
-    invalid_task = DownloadKey()
-    with pytest.raises(ValueError, match="Required attribute 'date'"):
-        downloader._build_task_path(invalid_task)
+    assert downloader.resume is True
+    downloader.checkpoint = {"test": 1}
+    downloader._save_checkpoint()
+
+    result = downloader._load_checkpoint()
+    assert result == {"test": 1}
 
 
 def test_load_checkpoint_corrupted(downloader: MockDownloader) -> None:
@@ -282,38 +296,8 @@ def test_load_checkpoint_corrupted(downloader: MockDownloader) -> None:
     path = Path(downloader.output_path, "status.pickle")
     path.write_text("corrupted data")
 
-    result = downloader._load_checkpoint(path)
+    result = downloader._load_checkpoint()
     assert result == {}
-
-
-@pytest.mark.parametrize(
-    "task, use_self_ckpt",
-    [
-        (TASK_DAY, True),  # EIA/EPIAS
-        (TASK_DAY.update(bidding_zone="ZONE_A"), False),  # Entso-E
-    ],
-)
-def test_save_checkpoint(
-    downloader: MockDownloader,
-    ckpt_setup: Callable,
-    task: DownloadKey,
-    use_self_ckpt: bool,
-) -> None:
-    """Happy path for _save_checkpoint with valid checkpoint setups.
-
-    Args:
-        downloader (MockDownloader): Instance of the MockDownloader class.
-        ckpt_setup (Callable): Function that defined checkpoint setup for specific task.
-        task (DownloadKey): The metadata for a task to download data for.
-        use_self_ckpt (bool): Whether to use class attribute (self.) for checkpointing.
-    """
-    _, checkpoint_path = ckpt_setup(task, use_self_ckpt)
-    checkpoint = {downloader._turn_task_into_checkpoint_key(task): 1}
-    downloader._save_checkpoint(checkpoint, checkpoint_path)
-
-    assert checkpoint_path.is_file()
-    with open(checkpoint_path, "rb") as f:
-        assert pickle.load(f) == checkpoint
 
 
 def test_get_date_list_current_year(downloader: MockDownloader) -> None:
@@ -322,9 +306,7 @@ def test_get_date_list_current_year(downloader: MockDownloader) -> None:
     Args:
         downloader (MockDownloader): Instance of the MockDownloader class.
     """
-    fake_today = pd.Timestamp("2025-02-01")
-
-    with patch("pandas.Timestamp.now", return_value=fake_today):
+    with patch("pandas.Timestamp.now", return_value=pd.Timestamp("2025-02-01")):
         downloader.years = [2025]
         dates = downloader._get_date_list()
 
@@ -350,9 +332,7 @@ def test_get_month_list_current_year(downloader: MockDownloader) -> None:
     Args:
         downloader (MockDownloader): Instance of the MockDownloader class.
     """
-    fake_today = pd.Timestamp("2025-02-01")
-
-    with patch("pandas.Timestamp.now", return_value=fake_today):
+    with patch("pandas.Timestamp.now", return_value=pd.Timestamp("2025-02-01")):
         downloader.years = [2025]
         months = downloader._get_month_list()
 
@@ -366,14 +346,121 @@ def test_get_year_list_current_year(downloader: MockDownloader) -> None:
     Args:
         downloader (MockDownloader): Instance of the MockDownloader class.
     """
-    fake_today = pd.Timestamp("2025-02-01")
-
-    with patch("pandas.Timestamp.now", return_value=fake_today):
+    with patch("pandas.Timestamp.now", return_value=pd.Timestamp("2025-02-01")):
         downloader.years = [2025]
         years = downloader._get_year_list()
 
         assert len(years) == 1
         assert years[-1] == "2025"
+
+
+# ----------------------------------
+# Tests - DownloadTask class
+# ----------------------------------
+@pytest.mark.parametrize(
+    "tres, bz",
+    [(None, None), ("5min", None), (None, "ZONE_A"), ("5min", "ZONE_A")],
+)
+def test_downloadtask_initialise(tres: str | None, bz: str | None) -> None:
+    """Happy path for initialising a DownloadTask instance.
+
+    Args:
+        tres (str): Valid temporal resolution.
+        bz (str): Valid bidding zone.
+    """
+    date = "2020-01-01"
+    all_args = {"date": date, "temporal_resolution": tres, "bidding_zone": bz}
+    args = {k: v for k, v in all_args.items() if v is not None}
+    task = DownloadTask(**args)
+
+    exp_tres = tres if tres is not None else "1h"
+    exp_bz = bz if bz is not None else None
+
+    assert task.date == date
+    assert task.temporal_resolution == exp_tres
+    assert task.bidding_zone == exp_bz
+
+    if bz is not None:
+        assert (
+            task.identifier
+            == f"date={date}|temporal_resolution={exp_tres}|bidding_zone={bz}"
+        )
+    else:
+        assert task.identifier == f"date={date}|temporal_resolution={exp_tres}"
+
+
+@pytest.mark.parametrize("invalid_date", ["20200101", "invalid", ""])
+def test_downloadtask_initialise_with_invalid_date(invalid_date: str) -> None:
+    """Failure path for initialising a DownloadTask instance.
+
+    Args:
+        invalid_date (str): Invalid date.
+    """
+    with pytest.raises(ValueError, match="Invalid date / date format"):
+        DownloadTask(date=invalid_date)
+
+
+@pytest.mark.parametrize("invalid_tres", ["5days", "invalid", ""])
+def test_downloadtask_initialise_with_invalid_tres(invalid_tres: str) -> None:
+    """Failure path for initialising a DownloadTask instance.
+
+    Args:
+        invalid_tres (str): Invalid temporal resolution.
+    """
+    with pytest.raises(ValueError, match="Invalid temporal resolution"):
+        DownloadTask(date="2020-01-01", temporal_resolution=invalid_tres)
+
+
+def test_downloadtask_update() -> None:
+    """Happy path for DownloadTask method "update"."""
+    date = "2020-01-01"
+    task = DownloadTask(date=date)
+
+    new_date = "2020-02-01"
+    new_task = task.update(
+        date=new_date, temporal_resolution="10h", bidding_zone="ZONE_A"
+    )
+
+    assert task is not new_task
+    assert task.date != new_date
+    assert task.bidding_zone is None
+    assert new_task.date == new_date
+    assert new_task.temporal_resolution == "10h"
+    assert new_task.bidding_zone == "ZONE_A"
+
+
+def test_downloadtask_validate_required_fields() -> None:
+    """Happy path for DownloadTask's "validate_required_fields"."""
+    task = DownloadTask(date="2020-01-01", bidding_zone="ZONE_A")
+    task.validate_required_fields("date", "temporal_resolution", "bidding_zone")
+
+
+def test_downloadtask_validate_required_fields_value_missing() -> None:
+    """Failure path for DownloadTask's "validate_required_fields" when value is missing."""
+    task = DownloadTask(date="2020-01-01")
+    with pytest.raises(ValueError, match="Required attribute 'bidding_zone' missing"):
+        task.validate_required_fields("bidding_zone")
+
+
+@pytest.mark.parametrize("empty_bz", [None, "", "   "])
+def test_downloadtask_validate_required_fields_value_empty(
+    empty_bz: None | str,
+) -> None:
+    """Failure path for DownloadTask's "validate_required_fields" when exists but is empty.
+
+    Args:
+        empty_bz (str): Empty definition of attribute 'bidding_zone'.
+    """
+    task = DownloadTask(date="2020-01-01", bidding_zone=empty_bz)
+    with pytest.raises(ValueError, match="Required attribute 'bidding_zone' missing"):
+        task.validate_required_fields("bidding_zone")
+
+
+def test_downloadtask_validate_required_fields_field_not_an_attribute() -> None:
+    """Failure path for DownloadTask's "validate_required_fields" for non-existent attribute."""
+    task = DownloadTask(date="2020-01-01")
+    with pytest.raises(AttributeError):
+        task.validate_required_fields("invalid")
 
 
 # ----------------------------------


### PR DESCRIPTION
# New data crawler for AESO (Canada, Alberta) energy data and `EnergyDownloader` restructuring

Code and tests for downloading data from the [AESO box cloud storage](https://aeso.app.box.com/s/qofgn9axnnw6uq3ip1goiq2ngb11txe5/folder/196731538687) site via [boxsdk](https://github.com/box/box-python-sdk) and the `pandas` package's `read_csv`. This can function as an example for future data crawlers and encompasses:

- a config YAML file `aeso.yaml` for source-related settings,
- a data downloader in `rbc/energy/aeso/downloader.py`,
- a script for running the downloader in `scripts/energy/aeso_download.py`,
- tests for the downloader in `tests/energy/aeso/test_downloader.py`.

> **Please note:**
> To use the Box API and `boxsdk` package, a setup was designed using `OAuth 2.0`-based credentials and short-lived API tokens (s. [data_sources.md](https://github.com/RenewBench-Association/RenewBench-Crawler/blob/features/aeso/docs/data_sources.md?plain=1#L131)). As a user, you need to create an app in your personal [box account](https://app.box.com/developers/console/), where you can then generate a 60-min valid `Development Token`. Approaches that allow persistent access (`JWT` or `CCG`) unfortunately require a paid Box account / subscription plan...
> **Given that downloading 1 year of data (both 1h and 15min res) takes ~1 min, this should still work with the 60-min valid token!**

### Additional changes
The following additional changes were made to all / some crawler(-related) code. All tests were adapted to reflect these new amendments.

#### Source-specific
- IESO: documentation updates (`README.md`, `data_sources.md`)
- ENTSO-E: restrict default bidding zones to valid ones 
	- add `entsoe_get_zones.py` script for identifying relevant zones 
- EIA & EPIAS: define `EXPECTED_COLS` parameter as is done in all other downloaders to ensure downloaded data structure has not changed
 
#### For all sources
- In `scripts`: `--years` flag default now set as current year instead of static value
- In `downloaders`: raise new custom `MissingDataError` instead of `ValueError` for any missing data
 
#### Core refactor (EnergyDownloader)
- introduce `DownloadTask` (replaces str/tuple tasks; simplifies paths & typing)
- include hierarchical layer in storage `<temporal_resolution>`, per default `1h`
- centralize checkpointing (`status.pickle` in root output dir) -> greatly simplifies threading logic (`_threading_wrapper`)
- improve resume logic (do not skip current-year data by default)

These changes mean that the structure for saving raw data is now as follows (with optional hierarchies/values in `()`):
```
raw/energy
└── <source>  
    ├── status.pickle
    ├── logs
    │   └── <YYYY-MM-DD_HHMMSS>.log
    └── <temporal_resolution (default: "1h")>
        └── (<bidding_zone>)
            └── <YYYY-MM(-DD)>.csv
```
## New dependancies

`boxsdk`

## Related issues

- Closes #15
- Created related issue #39 as an expansion of the `AesoDownloader`
 
## Type of change

- [X] New feature (non-breaking change which adds functionality)

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules