### PR TITLE
Features/eat

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -148,7 +148,7 @@ env.bak/
 venv.bak/
 
 # General stuff
-outputs/
+outputs*/
 
 # Spyder project settings
 .spyderproject

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ The RenewBench-Crawler repository is structured as follows:
 │   │   └── schema.py             # Pydantic config models and registry
 │   ├── energy/                 # Energy data crawlers
 │   │   ├── aeso/                 # AESO (Canada, Alberta)
+│   │   ├── eat/                  # EA Te Mana Hiko (New Zealand)
 │   │   ├── eia/                  # EIA (US)
 │   │   ├── entsoe/               # ENTSO-e (EU)
 │   │   ├── epias/                # EPIAS (Turkey)

--- a/configs/energy/eat.yaml
+++ b/configs/energy/eat.yaml
@@ -1,0 +1,2 @@
+paths:
+  dst_dir_raw: /lsdf/raw/energy/eat/

--- a/docs/data_sources.md
+++ b/docs/data_sources.md
@@ -446,7 +446,7 @@ This section lists energy and meteorological sources that are currently ineligib
 
 ## Energy
 
-An energy data source is excluded if it fails to meet **any** of the following criteria:
+An energy data source is excluded if fails to meet **any** of the following criteria:
 1. Spatial resolution finer than "state/country" level (e.g., must be per plant, per
    company, or per small area)
 2. Temporal resolution of at least 1 hour (hourly or sub-hourly)
@@ -466,7 +466,7 @@ An energy data source is excluded if it fails to meet **any** of the following c
 
 ## Weather
 
-A reanalysis dataset is excluded if it fails to meet **all** of the following criteria:
+A reanalysis dataset is excluded if fails to meet **any** of the following criteria:
 1. Spatial resolution equal to or finer than ERA5 (grid spacing ≤ 0.25°)
 2. Temporal resolution of at least 1 hour (hourly or sub-hourly)
 3. Actively updated through at least the end of 2025

--- a/docs/data_sources.md
+++ b/docs/data_sources.md
@@ -239,7 +239,8 @@ RenewBench-Crawler package.
   midnight in half hour intervals. **NOTE:** Daylight saving is applied (46 TP = on
   the day saving starts, 50 TP = on the day it ends)
 
-> [!NOTE]
+> **PLEASE NOTE:**
+>
 > The EA website states: "This data series will be replaced by one that is more reliable and
 > contains a richer set of plant metadata at some point in the future."
 >

--- a/docs/data_sources.md
+++ b/docs/data_sources.md
@@ -450,18 +450,19 @@ An energy data source is excluded if it fails to meet **any** of the following c
 1. Spatial resolution finer than "state/country" level (e.g., must be per plant, per
    company, or per small area)
 2. Temporal resolution of at least 1 hour (hourly or sub-hourly)
-3. Absence of publication prohibitions or restrictive licensing
+3. Data based on actual historical observations (not purely simulated generation)
+4. Publicly accessible without restrictive publication prohibitions
 
-| Region       | Source                                                                                            | Status                                                 | Resolution                             | Data availability |
-|--------------|---------------------------------------------------------------------------------------------------|--------------------------------------------------------|----------------------------------------|-------------------|
-| World        | [IEA](https://www.iea.org/data-and-statistics/data-tools/renewable-energy-progress-tracker)       | Spatial and temporal resolutions too low, inaccessible | per country; **yearly**                | 2000 – 2024       |
-| World        | [IRENA](https://www.irena.org/Data/Downloads/IRENASTAT)                                           | Spatial and temporal resolutions too low               | per country; **yearly**	               | 2000 – 2024       |
-| India        | [CEA](https://cea.nic.in/dashboard/?lang=en)                                                      | Spatial and temporal resolutions too low               | per state (<=350,000 km²); **monthly** | 2019 – now        |
-| Paraguay     | [ANDE](https://ande.gov.py/documentos_contables/706/ande_-_compilacion_estadistica_1999-2019.pdf) | Spatial and temporal resolutions too low               | per country (~400,000 km²); **yearly** | 1996 – 2019       |
-| Mexico       | [CENACE](https://www.cenace.gob.mx/Paginas/SIM/Reportes/EnergiaGeneradaTipoTec.aspx)              | Spatial resolution too low                             | per country (~2,000,000 km²); hourly   | 2016 – now        |
-| South Africa | [Eskom](https://www.eskom.co.za/dataportal/supply-side/station-build-up-for-the-last-7-days/)     | Spatial resolution too low                             | per country (~1,000,000 km²); hourly   | 2021 – now        |
-| South Korea  | [KPX](https://www.eskom.co.za/dataportal/supply-side/station-build-up-for-the-last-7-days/)       | Spatial resolution too low                             | per country (~100,000 km²); 5 min      | 2022 – now        |
-| Europe       | [EMHIRES Dataset](https://new.kpx.or.kr/powerSource.es?mid=a10606030000&device=chart)             | Spatial resolution too low, simulated data!            | per country; hourly                    | 2006 – now        |
+| Region       | Source  | Status                                                 | Resolution                             | Data availability | Source                                                                                              |
+|--------------| ------- |--------------------------------------------------------| -------------------------------------- | ----------------- |-----------------------------------------------------------------------------------------------------|
+| World        | IEA     | Spatial and temporal resolutions too low, inaccessible | per country; **yearly**                | 2000 – 2024       | [Platform](https://www.iea.org/data-and-statistics/data-tools/renewable-energy-progress-tracker)    |
+| World        | IRENA   | Spatial and temporal resolutions too low               | per country; **yearly**                | 2000 – 2024       | [Data hosting](https://www.irena.org/Data/Downloads/IRENASTAT)                                      |
+| India        | CEA     | Spatial and temporal resolutions too low               | per state (<=350,000 km²); **monthly** | 2019 – now        | [Dashboard](https://cea.nic.in/dashboard/?lang=en)                                                  |
+| Paraguay     | ANDE    | Spatial and temporal resolutions too low               | per country (~400,000 km²); **yearly** | 1996 – 2019       | [Report](https://ande.gov.py/documentos_contables/706/ande_-_compilacion_estadistica_1999-2019.pdf) |
+| Mexico       | CENACE  | Spatial resolution too low                             | per country (~2,000,000 km²); hourly   | 2016 – now        | [Platform](https://www.cenace.gob.mx/Paginas/SIM/Reportes/EnergiaGeneradaTipoTec.aspx)              |
+| South Africa | Eskom   | Spatial resolution too low                             | per country (~1,000,000 km²); hourly   | 2021 – now        | [Dashboard](https://www.eskom.co.za/dataportal/supply-side/station-build-up-for-the-last-7-days/)   |
+| South Korea  | KPX     | Spatial resolution too low                             | per country (~100,000 km²); 5 min      | 2022 – now        | [Website](https://www.eskom.co.za/dataportal/supply-side/station-build-up-for-the-last-7-days/)     |
+| Europe       | EMHIRES | Spatial resolution too low, simulated data!            | per country; hourly                    | 2006 – now        | [Dataset](https://new.kpx.or.kr/powerSource.es?mid=a10606030000&device=chart)                       |
 
 ## Weather
 

--- a/docs/data_sources.md
+++ b/docs/data_sources.md
@@ -240,7 +240,6 @@ RenewBench-Crawler package.
   the day saving starts, 50 TP = on the day it ends)
 
 > [!NOTE]
->
 > The EA website states: "This data series will be replaced by one that is more reliable and
 > contains a richer set of plant metadata at some point in the future."
 >

--- a/docs/data_sources.md
+++ b/docs/data_sources.md
@@ -445,6 +445,23 @@ This section lists energy and meteorological sources that are currently ineligib
 
 ## Energy
 
+An energy data source is excluded if it fails to meet **any** of the following criteria:
+1. Spatial resolution finer than "state/country" level (e.g., must be per plant, per
+   company, or per small area)
+2. Temporal resolution of at least 1 hour (hourly or sub-hourly)
+3. Absence of publication prohibitions or restrictive licensing
+
+| Region       | Source                                                                                              | Status                                                 | Resolution                             | Data availability |
+|--------------|-----------------------------------------------------------------------------------------------------|--------------------------------------------------------|----------------------------------------|-------------------|
+| World        | [IEA]("https://www.iea.org/data-and-statistics/data-tools/renewable-energy-progress-tracker")       | Spatial and temporal resolutions too low, inaccessible | per country; **yearly**                | 2000 – 2024       |
+| World        | [IRENA]("https://www.irena.org/Data/Downloads/IRENASTAT")                                           | Spatial and temporal resolutions too low               | per country; **yearly**	               | 2000 – 2024       |
+| India        | [CEA]("https://cea.nic.in/dashboard/?lang=en")                                                      | Spatial and temporal resolutions too low               | per state (<=350,000 km²); **monthly** | 2019 – now        |
+| Paraguay     | [ANDE]("https://ande.gov.py/documentos_contables/706/ande_-_compilacion_estadistica_1999-2019.pdf") | Spatial and temporal resolutions too low               | per country (~400,000 km²); **yearly** | 1996 – 2019       |
+| Mexico       | [CENACE]("https://www.cenace.gob.mx/Paginas/SIM/Reportes/EnergiaGeneradaTipoTec.aspx")              | Spatial resolution too low                             | per country (~2,000,000 km²); hourly   | 2016 – now        |
+| South Africa | [Eskom]("https://www.eskom.co.za/dataportal/supply-side/station-build-up-for-the-last-7-days/")     | Spatial resolution too low                             | per country (~1,000,000 km²); hourly   | 2021 – now        |
+| South Korea  | [KPX]("https://www.eskom.co.za/dataportal/supply-side/station-build-up-for-the-last-7-days/")       | Spatial resolution too low                             | per country (~100,000 km²); 5 min      | 2022 – now        |
+| Europe       | [EMHIRES Dataset]("https://new.kpx.or.kr/powerSource.es?mid=a10606030000&device=chart")             | Spatial resolution too low, simulated data!            | per country; hourly                    | 2006 – now        |
+
 ## Weather
 
 A reanalysis dataset is excluded if it fails to meet **all** of the following criteria:

--- a/docs/data_sources.md
+++ b/docs/data_sources.md
@@ -19,7 +19,7 @@ RenewBench-Crawler package.
 | **Brazil**               | ONS      | planned            |                          |                   |                                                                                                                                                                                                                                                                                                                        |
 | **Uruguay**              | ADME     | planned            |                          |                   |                                                                                                                                                                                                                                                                                                                        |
 | **Australia**            | AEMO     | planned            |                          |                   |                                                                                                                                                                                                                                                                                                                        |
-| **New<br>Zealand**       | EAT      | planned            |                          |                   |                                                                                                                                                                                                                                                                                                                        |
+| **New<br>Zealand**       | EAT      | downloader &check; | 30 min; per plant        | public            | [Website / Data hosting](https://www.ea.govt.nz/data-and-insights/datasets/wholesale/generation/generation-output/)                                                                                                                                                                                                    |
 | **Japan**                | REI      | planned            | hourly; per region       |                   |                                                                                                                                                                                                                                                                                                                        |
 | **Taiwan**               | Taipower | downloader &check; | 10 min; per plant        | public            | [Website](https://www.taipower.com.tw/d006/loadGraph/loadGraph/genshx_e.html), [JSON](https://www.taipower.com.tw/d006/loadGraph/loadGraph/data/genary_eng.json),<br> [Example parser](https://github.com/electricitymaps/electricitymaps-contrib/blob/master/electricitymap/contrib/parsers/TAIPOWER.py)              |
 
@@ -203,6 +203,51 @@ RenewBench-Crawler package.
   00:00`) and measurement type
 
 </details>
+
+
+<details>
+<summary><b>EAT (New Zealand)</b></summary>
+
+**Access**
+- Website: [EA Te-Mana-Hiko power data](https://www.ea.govt.nz/data-and-insights/datasets/wholesale/generation/generation-output/)
+- Requirements: public, no authentication needed
+
+**Download & data structure**
+- Spatial resolution: per plant
+- Temporal resolution: 30 min
+- Available data timespan: 1997-08 to now
+- Downloadable files: 1 `.csv` per month
+- Files saved as **raw**: 1 `.csv` per month
+- Columns saved as **raw**:
+
+  `site_code` – ?
+
+  `poc_code` – the point of connection on the grid at which injections occur (three-letter
+  code denoting geographic location)
+
+  `nwk_code` – the network code
+
+  `gen_code` – a name given to the plant
+
+  `fuel_code` – the fuel type used at the plant
+
+  `tech_code` – the plant technology
+
+  `trading_date` – the date on which the injections occurred
+
+  `tp1`, `tp2`, …, `tp50` – generation values (in kWh) per trading period, starting at
+  midnight in half hour intervals. **NOTE:** Daylight saving is applied (46 TP = on
+  the day saving starts, 50 TP = on the day it ends)
+
+> [!NOTE]
+>
+> The EA website states: "This data series will be replaced by one that is more reliable and
+> contains a richer set of plant metadata at some point in the future."
+>
+> This will likely affect data parsing when it is implemented, but for now things work...
+
+</details>
+
 
 <details>
 <summary><b>Taipower (Taiwan)</b></summary>

--- a/docs/data_sources.md
+++ b/docs/data_sources.md
@@ -446,7 +446,7 @@ This section lists energy and meteorological sources that are currently ineligib
 
 ## Energy
 
-An energy data source is excluded if fails to meet **any** of the following criteria:
+An energy data source is excluded if it fails to meet **any** of the following criteria:
 1. Spatial resolution finer than "state/country" level (e.g., must be per plant, per
    company, or per small area)
 2. Temporal resolution of at least 1 hour (hourly or sub-hourly)
@@ -466,7 +466,7 @@ An energy data source is excluded if fails to meet **any** of the following crit
 
 ## Weather
 
-A reanalysis dataset is excluded if fails to meet **any** of the following criteria:
+A reanalysis dataset is excluded if it fails to meet **any** of the following criteria:
 1. Spatial resolution equal to or finer than ERA5 (grid spacing ≤ 0.25°)
 2. Temporal resolution of at least 1 hour (hourly or sub-hourly)
 3. Actively updated through at least the end of 2025

--- a/docs/data_sources.md
+++ b/docs/data_sources.md
@@ -452,16 +452,16 @@ An energy data source is excluded if it fails to meet **any** of the following c
 2. Temporal resolution of at least 1 hour (hourly or sub-hourly)
 3. Absence of publication prohibitions or restrictive licensing
 
-| Region       | Source                                                                                              | Status                                                 | Resolution                             | Data availability |
-|--------------|-----------------------------------------------------------------------------------------------------|--------------------------------------------------------|----------------------------------------|-------------------|
-| World        | [IEA]("https://www.iea.org/data-and-statistics/data-tools/renewable-energy-progress-tracker")       | Spatial and temporal resolutions too low, inaccessible | per country; **yearly**                | 2000 – 2024       |
-| World        | [IRENA]("https://www.irena.org/Data/Downloads/IRENASTAT")                                           | Spatial and temporal resolutions too low               | per country; **yearly**	               | 2000 – 2024       |
-| India        | [CEA]("https://cea.nic.in/dashboard/?lang=en")                                                      | Spatial and temporal resolutions too low               | per state (<=350,000 km²); **monthly** | 2019 – now        |
-| Paraguay     | [ANDE]("https://ande.gov.py/documentos_contables/706/ande_-_compilacion_estadistica_1999-2019.pdf") | Spatial and temporal resolutions too low               | per country (~400,000 km²); **yearly** | 1996 – 2019       |
-| Mexico       | [CENACE]("https://www.cenace.gob.mx/Paginas/SIM/Reportes/EnergiaGeneradaTipoTec.aspx")              | Spatial resolution too low                             | per country (~2,000,000 km²); hourly   | 2016 – now        |
-| South Africa | [Eskom]("https://www.eskom.co.za/dataportal/supply-side/station-build-up-for-the-last-7-days/")     | Spatial resolution too low                             | per country (~1,000,000 km²); hourly   | 2021 – now        |
-| South Korea  | [KPX]("https://www.eskom.co.za/dataportal/supply-side/station-build-up-for-the-last-7-days/")       | Spatial resolution too low                             | per country (~100,000 km²); 5 min      | 2022 – now        |
-| Europe       | [EMHIRES Dataset]("https://new.kpx.or.kr/powerSource.es?mid=a10606030000&device=chart")             | Spatial resolution too low, simulated data!            | per country; hourly                    | 2006 – now        |
+| Region       | Source                                                                                            | Status                                                 | Resolution                             | Data availability |
+|--------------|---------------------------------------------------------------------------------------------------|--------------------------------------------------------|----------------------------------------|-------------------|
+| World        | [IEA](https://www.iea.org/data-and-statistics/data-tools/renewable-energy-progress-tracker)       | Spatial and temporal resolutions too low, inaccessible | per country; **yearly**                | 2000 – 2024       |
+| World        | [IRENA](https://www.irena.org/Data/Downloads/IRENASTAT)                                           | Spatial and temporal resolutions too low               | per country; **yearly**	               | 2000 – 2024       |
+| India        | [CEA](https://cea.nic.in/dashboard/?lang=en)                                                      | Spatial and temporal resolutions too low               | per state (<=350,000 km²); **monthly** | 2019 – now        |
+| Paraguay     | [ANDE](https://ande.gov.py/documentos_contables/706/ande_-_compilacion_estadistica_1999-2019.pdf) | Spatial and temporal resolutions too low               | per country (~400,000 km²); **yearly** | 1996 – 2019       |
+| Mexico       | [CENACE](https://www.cenace.gob.mx/Paginas/SIM/Reportes/EnergiaGeneradaTipoTec.aspx)              | Spatial resolution too low                             | per country (~2,000,000 km²); hourly   | 2016 – now        |
+| South Africa | [Eskom](https://www.eskom.co.za/dataportal/supply-side/station-build-up-for-the-last-7-days/)     | Spatial resolution too low                             | per country (~1,000,000 km²); hourly   | 2021 – now        |
+| South Korea  | [KPX](https://www.eskom.co.za/dataportal/supply-side/station-build-up-for-the-last-7-days/)       | Spatial resolution too low                             | per country (~100,000 km²); 5 min      | 2022 – now        |
+| Europe       | [EMHIRES Dataset](https://new.kpx.or.kr/powerSource.es?mid=a10606030000&device=chart)             | Spatial resolution too low, simulated data!            | per country; hourly                    | 2006 – now        |
 
 ## Weather
 

--- a/rbc/config/schema.py
+++ b/rbc/config/schema.py
@@ -128,6 +128,18 @@ class AesoConfig(PathValidation, AccessValidation, BaseModel):
     access: AccessAPI
 
 
+class EatConfig(PathValidation, BaseModel):
+    """Configuration schema for the EAT energy data source.
+
+    Attributes:
+        source (Literal): Name of the data source.
+        paths (Paths): Paths pydantic model for paths.
+    """
+
+    source: Literal["eat"] = "eat"
+    paths: Paths
+
+
 class EiaConfig(PathValidation, AccessValidation, BaseModel):
     """Configuration schema for the EIA energy data source.
 
@@ -240,6 +252,7 @@ class Barra2Config(PathValidation, BaseModel):
 # ----------------------------------
 SCHEMA_REGISTRY: dict[str, Type[BaseModel]] = {
     "aeso": AesoConfig,
+    "eat": EatConfig,
     "eia": EiaConfig,
     "entsoe": EntsoeConfig,
     "epias": EpiasConfig,

--- a/rbc/energy/aeso/downloader.py
+++ b/rbc/energy/aeso/downloader.py
@@ -28,7 +28,7 @@ URL_BASE = "https://aeso.app.box.com/s/qofgn9axnnw6uq3ip1goiq2ngb11txe5"
 BOXAPI = f"shared_link={URL_BASE}"
 ROOT_ID = "196731538687"
 FOLDER_ID_DICT = {"1h": "196178549071", "5min": "196706124680"}
-
+MIN_YEAR = 2015
 EXPECTED_COLS = [
     "Date (MST)",
     "Date (MPT)",

--- a/rbc/energy/aeso/downloader.py
+++ b/rbc/energy/aeso/downloader.py
@@ -167,7 +167,7 @@ class AesoDownloader(EnergyDownloader):
         df = self._load_zip(item_id=item["id"], item_name=item["name"])
 
         if df.empty:
-            raise MissingDataError("No energy generation data available! Skipping...")
+            raise MissingDataError("No energy data available! Skipping...")
 
         missing_cols = [c for c in EXPECTED_COLS if c not in df.columns]
         if missing_cols:
@@ -187,9 +187,7 @@ class AesoDownloader(EnergyDownloader):
         df = df.loc[date_col.dt.to_period("M") == pd.Period(task.date, freq="M")].copy()
 
         if df.empty:
-            raise MissingDataError(
-                "No energy generation data after month filter! Skipping..."
-            )
+            raise MissingDataError("No energy data after month filter! Skipping...")
 
         df = df.sort_values(
             by=["Date (MST)", "Date (MPT)", "Asset Name"], ignore_index=True

--- a/rbc/energy/eat/__init__.py
+++ b/rbc/energy/eat/__init__.py
@@ -1,0 +1,3 @@
+from rbc.energy.eat.downloader import EatDownloader
+
+__all__ = ["EatDownloader"]

--- a/rbc/energy/eat/downloader.py
+++ b/rbc/energy/eat/downloader.py
@@ -21,14 +21,18 @@ from rbc.energy.utils import (
 
 URL_BASE = "https://emidatasets.blob.core.windows.net/publicdata/Datasets/Wholesale/Generation/Generation_MD"
 EXPECTED_COLS = [
-    "Site_Code",
-    "POC_Code",
-    "Nwk_Code",
-    "Gen_Code",
-    "Fuel_Code",
-    "Tech_Code",
-    "Trading_date",
-] + [f"TP{i}" for i in range(1, 51)]
+    c.lower()
+    for c in [
+        "Site_Code",
+        "POC_Code",
+        "Nwk_Code",
+        "Gen_Code",
+        "Fuel_Code",
+        "Tech_Code",
+        "Trading_date",
+    ]
+    + [f"TP{i}" for i in range(1, 51)]
+]  # make lower case because column capitalisation changes across the years in EAT data
 
 
 class EatDownloader(EnergyDownloader):
@@ -108,7 +112,8 @@ class EatDownloader(EnergyDownloader):
                 f"No energy generation data available for {year}-{month}. Skipping..."
             )
 
-        missing_cols = [c for c in EXPECTED_COLS if c not in df.columns]
+        df_columns_lower = [c.lower() for c in df.columns]
+        missing_cols = [c for c in EXPECTED_COLS if c not in df_columns_lower]
         if missing_cols:
             raise DataStructureError(
                 f"EAT file structure change detected for '{task.identifier}'! "

--- a/rbc/energy/eat/downloader.py
+++ b/rbc/energy/eat/downloader.py
@@ -20,6 +20,7 @@ from rbc.energy.utils import (
 )
 
 URL_BASE = "https://emidatasets.blob.core.windows.net/publicdata/Datasets/Wholesale/Generation/Generation_MD"
+MIN_YEAR = 1997
 EXPECTED_COLS = [
     c.lower()
     for c in [
@@ -95,9 +96,9 @@ class EatDownloader(EnergyDownloader):
             DataStructureError: If the data structure changed and relevant columns are now
                 missing (this will cause the entire run to be killed).
         """
-        if task.year < 1997:
+        if task.year < MIN_YEAR:
             raise MissingDataError(
-                f"No energy data for year {task.year} (it's before 1997). Skipping..."
+                f"No energy data for year {task.year} (it's before {MIN_YEAR}). Skipping..."
             )
 
         url = f"{URL_BASE}/{task.year}{str(task.month).zfill(2)}_Generation_MD.csv"

--- a/rbc/energy/eat/downloader.py
+++ b/rbc/energy/eat/downloader.py
@@ -95,21 +95,17 @@ class EatDownloader(EnergyDownloader):
             DataStructureError: If the data structure changed and relevant columns are now
                 missing (this will cause the entire run to be killed).
         """
-        dt = pd.Period(task.date, freq="M")
-        year = dt.year
-        month = dt.month
-
-        if year < 1997:
+        if task.year < 1997:
             raise MissingDataError(
-                f"No data for year {year} (it's before 1997). Skipping..."
+                f"No energy data for year {task.year} (it's before 1997). Skipping..."
             )
 
-        url = f"{URL_BASE}/{year}{str(month).zfill(2)}_Generation_MD.csv"
+        url = f"{URL_BASE}/{task.year}{str(task.month).zfill(2)}_Generation_MD.csv"
         df = load_df_from_file(url, index_col=False)
 
         if df.empty:
             raise MissingDataError(
-                f"No energy generation data available for {year}-{month}. Skipping..."
+                f"No energy data available for {task.year}-{task.month}. Skipping..."
             )
 
         df.columns = [c.strip().lower() for c in df.columns]

--- a/rbc/energy/eat/downloader.py
+++ b/rbc/energy/eat/downloader.py
@@ -112,8 +112,8 @@ class EatDownloader(EnergyDownloader):
                 f"No energy generation data available for {year}-{month}. Skipping..."
             )
 
-        df_columns_lower = [c.lower() for c in df.columns]
-        missing_cols = [c for c in EXPECTED_COLS if c not in df_columns_lower]
+        df.columns = [c.strip().lower() for c in df.columns]
+        missing_cols = [c for c in EXPECTED_COLS if c not in df.columns]
         if missing_cols:
             raise DataStructureError(
                 f"EAT file structure change detected for '{task.identifier}'! "

--- a/rbc/energy/eat/downloader.py
+++ b/rbc/energy/eat/downloader.py
@@ -1,0 +1,118 @@
+"""EAT DATA DOWNLOADER.
+
+Access of EAT site and their CSV files using the pandas package.
+"""
+
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+import pandas as pd
+import requests
+from loguru import logger
+
+from rbc.energy.utils import (
+    WORKERS,
+    DataStructureError,
+    DownloadTask,
+    EnergyDownloader,
+    MissingDataError,
+    load_df_from_file,
+)
+
+URL_BASE = "https://emidatasets.blob.core.windows.net/publicdata/Datasets/Wholesale/Generation/Generation_MD"
+EXPECTED_COLS = [
+    "Site_Code",
+    "POC_Code",
+    "Nwk_Code",
+    "Gen_Code",
+    "Fuel_Code",
+    "Tech_Code",
+    "Trading_date",
+] + [f"TP{i}" for i in range(1, 51)]
+
+
+class EatDownloader(EnergyDownloader):
+    """EAT data downloader."""
+
+    def __init__(
+        self,
+        output_path: Path,
+        years: list[int],
+        resume: bool = True,
+    ) -> None:
+        """Initializes the instance.
+
+        Args:
+            output_path (Path): Path to the output directory.
+            years (list[int]): List of years to get data for.
+            resume (bool, optional): Whether to resume from a previous download (True)
+                or start from scratch (False). Defaults to True.
+
+        Raises:
+            ConnectionError: If the base URLs aren't reachable.
+        """
+        super().__init__(output_path=output_path, years=years, resume=resume)
+        logger.info(f"EAT Downloader initialized for:\n- years:\t\t{years}")
+
+        try:
+            requests.head(URL_BASE, timeout=10).raise_for_status()
+
+        except Exception as e:
+            logger.error("Initialization EAT connectivity check failed!")
+            raise ConnectionError(f"EAT endpoint is unreachable: {e}")
+
+    def download_data(self) -> None:
+        """Parse data for all given years from EAT site and save to CSV."""
+        tasks = [
+            DownloadTask(date=d, temporal_resolution="30min")
+            for d in self._get_month_list()
+        ]
+
+        logger.info(
+            f"Downloading tasks: {tasks[0].identifier} --- {tasks[-1].identifier}"
+        )
+        with ThreadPoolExecutor(max_workers=WORKERS) as executor:
+            executor.map(self._threading_wrapper, tasks)
+
+    def _get_task_data(self, task: DownloadTask) -> pd.DataFrame:  # type: ignore[override]
+        """Get EAT generation data per plant for one specific month.
+
+        Args:
+            task (DownloadTask): The metadata of a downloading task, here: date (YYYY-MM)
+
+        Returns:
+            pd.DataFrame: Dataframe for specific date with the columns
+            ['Site_Code', 'POC_Code', 'Nwk_Code', 'Gen_Code', 'Fuel_Code', 'Tech_Code',
+             'Trading_date', 'TP1', 'TP2', 'TP3', ..., 'TP49', 'TP50']
+
+        Raises:
+            MissingDataError: If an earlier year was provided than data exists for or if the
+                dataframe is empty.
+            DataStructureError: If the data structure changed and relevant columns are now
+                missing (this will cause the entire run to be killed).
+        """
+        dt = pd.Period(task.date, freq="M")
+        year = dt.year
+        month = dt.month
+
+        if year < 1997:
+            raise MissingDataError(
+                f"No data for year {year} (it's before 1997). Skipping..."
+            )
+
+        url = f"{URL_BASE}/{year}{str(month).zfill(2)}_Generation_MD.csv"
+        df = load_df_from_file(url, index_col=False)
+
+        if df.empty:
+            raise MissingDataError(
+                f"No energy generation data available for {year}-{month}. Skipping..."
+            )
+
+        missing_cols = [c for c in EXPECTED_COLS if c not in df.columns]
+        if missing_cols:
+            raise DataStructureError(
+                f"EAT file structure change detected for '{task.identifier}'! "
+                f"Missing columns: {missing_cols}"
+            )
+
+        return df

--- a/rbc/energy/eia/downloader.py
+++ b/rbc/energy/eia/downloader.py
@@ -114,9 +114,10 @@ class EiaDownloader(EnergyDownloader):
                 relevant columns to be missed (this will cause the entire run to be killed).
             MissingDataError: If the loaded dataframe is empty.
         """
-        dt = pd.Period(task.date, freq="D")
-        start = dt.strftime("%Y-%m-%dT00")
-        end = pd.Period((dt + pd.Timedelta(days=1)), freq="D").strftime("%Y-%m-%dT00")
+        start = task.dt.strftime("%Y-%m-%dT00")
+        end = pd.Period((task.dt + pd.Timedelta(days=1)), freq="D").strftime(
+            "%Y-%m-%dT00"
+        )
 
         params = {
             "api_key": self.token,
@@ -193,7 +194,7 @@ class EiaDownloader(EnergyDownloader):
 
         df_gen = pd.DataFrame(all_data)
         if df_gen.empty:
-            raise MissingDataError("No energy generation data available! Skipping...")
+            raise MissingDataError("No energy data available! Skipping...")
 
         missing_cols = [c for c in EXPECTED_COLS if c not in df_gen.columns]
         if missing_cols:

--- a/rbc/energy/eia/downloader.py
+++ b/rbc/energy/eia/downloader.py
@@ -26,6 +26,7 @@ from rbc.energy.utils import (
 URL_ROOT = "https://api.eia.gov/v2/"
 URL = "https://api.eia.gov/v2/electricity/rto/fuel-type-data/data/"
 
+MIN_YEAR = 2019
 EXPECTED_COLS = [
     "period",
     "respondent",
@@ -114,6 +115,11 @@ class EiaDownloader(EnergyDownloader):
                 relevant columns to be missed (this will cause the entire run to be killed).
             MissingDataError: If the loaded dataframe is empty.
         """
+        if task.year < MIN_YEAR:
+            raise MissingDataError(
+                f"No energy data for year {task.year} (it's before {MIN_YEAR}). Skipping..."
+            )
+
         start = task.dt.strftime("%Y-%m-%dT00")
         end = pd.Period((task.dt + pd.Timedelta(days=1)), freq="D").strftime(
             "%Y-%m-%dT00"

--- a/rbc/energy/entsoe/downloader.py
+++ b/rbc/energy/entsoe/downloader.py
@@ -121,18 +121,17 @@ class EntsoeDownloader(EnergyDownloader):
                 missing (this will cause the entire run to be killed).
         """
         task.validate_required_fields("bidding_zone")
-        dt = pd.Period(task.date, freq="D")
 
         bz_start = int(ACTIVE_ZONES_METADATA[str(task.bidding_zone)]["start"])
-        if dt.year < bz_start:
+        if task.year < bz_start:
             raise MissingDataError(
-                f"No data for year {dt.year} (it's before start {bz_start}). Skipping..."
+                f"No energy data for year {task.year} (it's before {bz_start}). Skipping..."
             )
 
         try:
             result = ActualGenerationPerGenerationUnit(
-                period_start=int(dt.strftime("%Y%m%d0000")),  # start of day
-                period_end=int(dt.strftime("%Y%m%d2359")),  # end of day
+                period_start=int(task.dt.strftime("%Y%m%d0000")),  # start of day
+                period_end=int(task.dt.strftime("%Y%m%d2359")),  # end of day
                 in_domain=task.bidding_zone,
                 psr_type=None,
                 registered_resource=None,
@@ -145,7 +144,7 @@ class EntsoeDownloader(EnergyDownloader):
             raise ConnectionError("API call did not return requested data!")
 
         if not result:
-            raise MissingDataError("No energy generation data available! Skipping...")
+            raise MissingDataError("No energy data available! Skipping...")
 
         records = extract_records(result)  # turns into list of dicts
         records = add_timestamps(records)  # adds key 'timestamp' to each dict

--- a/rbc/energy/epias/downloader.py
+++ b/rbc/energy/epias/downloader.py
@@ -108,7 +108,8 @@ class EpiasDownloader(EnergyDownloader):
         """
         # get power-plants   # ['id', 'name', 'eic', 'shortName']
         start = task.date
-        end = (pd.Timestamp(start) + pd.Timedelta(days=1)).strftime("%Y-%m-%d")
+        end = (task.dt + pd.Timedelta(days=1)).strftime("%Y-%m-%d")
+
         df_pp = self.eptr.call("pp-list-for-date-range", start_date=start, end_date=end)
         if df_pp.empty:
             raise MissingDataError("No power plant data available! Skipping...")
@@ -118,13 +119,13 @@ class EpiasDownloader(EnergyDownloader):
         batches = np.array_split(df_pp["id"].values, num_batches)
 
         gen_data = [
-            self.eptr.call("rt-gen-bulk", date=task.date, pp_ids=b.tolist())
+            self.eptr.call("rt-gen-bulk", date=start, pp_ids=b.tolist())
             for b in batches
         ]
 
         df_gen = pd.concat(gen_data)
         if df_gen.empty:
-            raise MissingDataError("No energy generation data available! Skipping...")
+            raise MissingDataError("No energy data available! Skipping...")
 
         missing_cols = [c for c in EXPECTED_COLS if c not in df_gen.columns]
         if missing_cols:

--- a/rbc/energy/epias/downloader.py
+++ b/rbc/energy/epias/downloader.py
@@ -21,6 +21,7 @@ from rbc.energy.utils import (
     MissingDataError,
 )
 
+MIN_YEAR = 2013
 EXPECTED_COLS = [
     "date",
     "hour",
@@ -106,6 +107,11 @@ class EpiasDownloader(EnergyDownloader):
             DataStructureError: If the data structure changed and relevant columns are now
                 missing (this will cause the entire run to be killed).
         """
+        if task.year < MIN_YEAR:
+            raise MissingDataError(
+                f"No energy data for year {task.year} (it's before {MIN_YEAR}). Skipping..."
+            )
+
         # get power-plants   # ['id', 'name', 'eic', 'shortName']
         start = task.date
         end = (task.dt + pd.Timedelta(days=1)).strftime("%Y-%m-%d")

--- a/rbc/energy/ieso/downloader.py
+++ b/rbc/energy/ieso/downloader.py
@@ -97,23 +97,19 @@ class IesoDownloader(EnergyDownloader):
             DataStructureError: If the data structure changed and relevant columns are now
                 missing (this will cause the entire run to be killed).
         """
-        dt = pd.Period(task.date, freq="M")
-        year = dt.year
-        month = dt.month
-
-        if year < 2010:
+        if task.year < 2010:
             raise MissingDataError(
-                f"No data for year {year} (it's before 2010). Skipping..."
+                f"No energy data for year {task.year} (it's before 2010). Skipping..."
             )
 
-        if year < 2019 or (year == 2019 and month <= 4):
-            df = self._get_from_old_source(year, month)
+        if task.year < 2019 or (task.year == 2019 and task.month <= 4):
+            df = self._get_from_old_source(task.year, task.month)
         else:
-            df = self._get_from_new_source(year, month)
+            df = self._get_from_new_source(task.year, task.month)
 
         if df.empty:
             raise MissingDataError(
-                f"No energy generation data available for {year}-{month}. Skipping..."
+                f"No energy data available for {task.year}-{task.month}. Skipping..."
             )
 
         missing_cols = [c for c in EXPECTED_COLS if c not in df.columns]

--- a/rbc/energy/ieso/downloader.py
+++ b/rbc/energy/ieso/downloader.py
@@ -23,6 +23,7 @@ from rbc.energy.utils import (
 
 URL_NEW_BASE = "https://reports-public.ieso.ca/public/GenOutputCapabilityMonth"
 URL_OLD_BASE = "https://www.ieso.ca"
+MIN_YEAR = 2010
 EXPECTED_COLS = ["Delivery Date", "Generator", "Fuel Type", "Measurement"] + [
     f"Hour {i}" for i in range(1, 25)
 ]
@@ -97,9 +98,9 @@ class IesoDownloader(EnergyDownloader):
             DataStructureError: If the data structure changed and relevant columns are now
                 missing (this will cause the entire run to be killed).
         """
-        if task.year < 2010:
+        if task.year < MIN_YEAR:
             raise MissingDataError(
-                f"No energy data for year {task.year} (it's before 2010). Skipping..."
+                f"No energy data for year {task.year} (it's before {MIN_YEAR}). Skipping..."
             )
 
         if task.year < 2019 or (task.year == 2019 and task.month <= 4):

--- a/rbc/energy/utils.py
+++ b/rbc/energy/utils.py
@@ -10,7 +10,7 @@ import threading
 import time
 import urllib
 from abc import ABC, abstractmethod
-from dataclasses import dataclass, replace
+from dataclasses import dataclass, field, replace
 from pathlib import Path
 
 import pandas as pd
@@ -77,11 +77,24 @@ class DownloadTask:
         date (str | None): Date in the format YYYY-MM(-DD) to download data for.
         temporal_resolution (str): Temporal resolution of data. Defaults to "1h".
         bidding_zone (str | None): Optional bidding zone of data. Defaults to None.
+        identifier (str): Task identifier, set in __post_init__.
+        dt (pd.Timestamp): Task datetime, set in __post_init__.
+        year (int): Task year, set in __post_init__.
+        month (int): Task month, set in __post_init__.
+        _DATE_PATTERN (re.Pattern): Pattern for enforcing "date" format.
+        _TRES_PATTERN (re.Pattern): Pattern for enforcing "temporal_resolution" format.
     """
 
+    # attributes of the actual task
     date: str
     temporal_resolution: str = "1h"
     bidding_zone: str | None = None
+
+    # attributes to be defined in __post_init__
+    identifier: str = field(init=False, repr=False)
+    dt: pd.Timestamp = field(init=False, repr=False)
+    year: int = field(init=False, repr=False)
+    month: int = field(init=False, repr=False)
 
     # patterns for matching
     _DATE_PATTERN = re.compile(r"^\d{4}(-(0[1-9]|1[0-2])(-(0[1-9]|[12]\d|3[01]))?)?$")
@@ -93,35 +106,31 @@ class DownloadTask:
         Raises:
             ValueError: If provided date or temporal resolution are in the wrong format.
         """
-        # check that date matches pattern and is a valid calendar date
-        if not self._DATE_PATTERN.match(self.date):
-            raise ValueError(f"Invalid date / date format: '{self.date}'")
-        try:
-            pd.to_datetime(self.date)
-        except (ValueError, TypeError):
-            raise ValueError(f"Invalid calendar date: '{self.date}'")
-
-        # check that temporal resolution matches pattern
+        # perform validation checks (temporal resolution, date)
         if not self._TRES_PATTERN.match(self.temporal_resolution):
             raise ValueError(
                 f"Invalid temporal resolution: '{self.temporal_resolution}'"
             )
 
-    @property
-    def identifier(self) -> str:
-        """A task's unique string representation for checkpointing and logging.
+        if not self._DATE_PATTERN.match(self.date):
+            raise ValueError(f"Invalid date / date format: '{self.date}'")
 
-        Returns:
-            str: Unique string 'date=YYYY-MM(-DD)|temporal_resolution=1h(|bidding_zone=<bz>)'
-        """
-        parts = [
-            f"date={self.date}",
-            f"temporal_resolution={self.temporal_resolution}",
-        ]
+        try:
+            timestamp = pd.to_datetime(self.date)
+        except (ValueError, TypeError):
+            raise ValueError(f"Invalid calendar date: '{self.date}'")
+
+        # assign values
+        object.__setattr__(self, "dt", timestamp)
+        object.__setattr__(self, "year", timestamp.year)
+        object.__setattr__(self, "month", timestamp.month)
+
+        # build ID ('date=YYYY-MM(-DD)|temporal_resolution=1h(|bidding_zone=<bz>)')
+        parts = [f"date={self.date}", f"temporal_resolution={self.temporal_resolution}"]
         if self.bidding_zone:
             parts.append(f"bidding_zone={self.bidding_zone}")
 
-        return "|".join(parts)
+        object.__setattr__(self, "identifier", "|".join(parts))
 
     def update(self, **changes) -> "DownloadTask":
         """Update a key with provided changes.
@@ -143,12 +152,10 @@ class DownloadTask:
         Raises:
               ValueError: If any of the required fields are None.
         """
-        for field in fields:
-            value = getattr(self, field)
+        for f in fields:
+            value = getattr(self, f)
             if value is None or (isinstance(value, str) and not value.strip()):
-                raise ValueError(
-                    f"Required attribute '{field}' missing for task: {self}"
-                )
+                raise ValueError(f"Required attribute '{f}' missing for task: {self}")
 
 
 class EnergyDownloader(ABC):

--- a/scripts/energy/aeso_download.py
+++ b/scripts/energy/aeso_download.py
@@ -11,6 +11,7 @@ from loguru import logger
 
 from rbc.config.loader import load_config, parse_key_value_pairs
 from rbc.energy.aeso import AesoDownloader
+from rbc.energy.aeso.downloader import MIN_YEAR
 from rbc.utils import setup_logging
 
 SOURCE = "aeso"
@@ -28,9 +29,9 @@ def parse_arguments() -> Namespace:
         "--years",
         nargs="+",
         type=int,
-        default=list(range(2015, datetime.now().year + 1)),  # 5min: 2015-2023
+        default=list(range(MIN_YEAR, datetime.now().year + 1)),  # 5min: 2015-2023
         help=f"Years to download. Example: -y 2020 2021. "
-        f"Default: {list(range(2015, datetime.now().year + 1))}",
+        f"Default: {list(range(MIN_YEAR, datetime.now().year + 1))}",
     )
     parser.add_argument(
         "-tr",

--- a/scripts/energy/eat_download.py
+++ b/scripts/energy/eat_download.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python
+"""EAT DATA DOWNLOAD SCRIPT.
+
+Download data from EAT website for New Zealand.
+"""
+
+from argparse import ArgumentParser, Namespace
+from datetime import datetime
+
+from loguru import logger
+
+from rbc.config.loader import load_config, parse_key_value_pairs
+from rbc.energy.eat import EatDownloader
+from rbc.utils import setup_logging
+
+SOURCE = "eat"
+
+
+def parse_arguments() -> Namespace:
+    """Parse command line arguments.
+
+    Returns:
+        argparse.Namespace: Namespace parsed command line arguments.
+    """
+    parser = ArgumentParser(prog="EAT data download")
+    parser.add_argument(
+        "-y",
+        "--years",
+        nargs="+",
+        type=int,
+        default=list(range(1997, datetime.now().year + 1)),  # available years
+        help=f"Years to download. Example: -y 2020 2021. "
+        f"Default: {list(range(1997, datetime.now().year + 1))}",
+    )
+    parser.add_argument(
+        "--no-resume",
+        dest="resume",
+        action="store_false",
+        help="Do not resume download from a previous checkpoint.",
+    )
+    parser.set_defaults(resume=True)
+    parser.add_argument(
+        "-o",
+        "--cfg_options",
+        action="append",
+        help="Override YAML config values (supports nested keys). "
+        "Example: -o paths.dst_dir_raw=/your/path/",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    """Coordinating EAT data download."""
+    args = parse_arguments()
+    overrides = parse_key_value_pairs(args.cfg_options) if args.cfg_options else None
+
+    cfg = load_config(source=SOURCE, overrides=overrides)
+    setup_logging(output_dir=cfg.paths.dst_dir_raw)
+    logger.info(f"Flags for the '{SOURCE}' download:\n{args}")
+    logger.info(f"Config for the '{SOURCE}' download:\n{cfg}")
+
+    downloader = EatDownloader(
+        output_path=cfg.paths.dst_dir_raw,
+        years=args.years,
+        resume=args.resume,
+    )
+    downloader.download_data()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/energy/eat_download.py
+++ b/scripts/energy/eat_download.py
@@ -11,6 +11,7 @@ from loguru import logger
 
 from rbc.config.loader import load_config, parse_key_value_pairs
 from rbc.energy.eat import EatDownloader
+from rbc.energy.eat.downloader import MIN_YEAR
 from rbc.utils import setup_logging
 
 SOURCE = "eat"
@@ -28,9 +29,9 @@ def parse_arguments() -> Namespace:
         "--years",
         nargs="+",
         type=int,
-        default=list(range(1997, datetime.now().year + 1)),  # available years
+        default=list(range(MIN_YEAR, datetime.now().year + 1)),  # available years
         help=f"Years to download. Example: -y 2020 2021. "
-        f"Default: {list(range(1997, datetime.now().year + 1))}",
+        f"Default: {list(range(MIN_YEAR, datetime.now().year + 1))}",
     )
     parser.add_argument(
         "--no-resume",

--- a/scripts/energy/eia_download.py
+++ b/scripts/energy/eia_download.py
@@ -11,6 +11,7 @@ from loguru import logger
 
 from rbc.config.loader import load_config, parse_key_value_pairs
 from rbc.energy.eia import EiaDownloader
+from rbc.energy.eia.downloader import MIN_YEAR
 from rbc.utils import setup_logging
 
 SOURCE = "eia"
@@ -28,9 +29,9 @@ def parse_arguments() -> Namespace:
         "--years",
         nargs="+",
         type=int,
-        default=list(range(2019, datetime.now().year + 1)),  # available years
+        default=list(range(MIN_YEAR, datetime.now().year + 1)),  # available years
         help=f"Years to download. Example: -y 2020 2021. "
-        f"Default: {list(range(2019, datetime.now().year + 1))}",
+        f"Default: {list(range(MIN_YEAR, datetime.now().year + 1))}",
     )
     parser.add_argument(
         "--no-resume",

--- a/scripts/energy/epias_download.py
+++ b/scripts/energy/epias_download.py
@@ -11,6 +11,7 @@ from loguru import logger
 
 from rbc.config.loader import load_config, parse_key_value_pairs
 from rbc.energy.epias import EpiasDownloader
+from rbc.energy.epias.downloader import MIN_YEAR
 from rbc.utils import setup_logging
 
 SOURCE = "epias"
@@ -28,9 +29,9 @@ def parse_arguments() -> Namespace:
         "--years",
         nargs="+",
         type=int,
-        default=list(range(2013, datetime.now().year + 1)),  # available years
+        default=list(range(MIN_YEAR, datetime.now().year + 1)),  # available years
         help=f"Years to download. Example: -y 2020 2021. "
-        f"Default: {list(range(2013, datetime.now().year + 1))}",
+        f"Default: {list(range(MIN_YEAR, datetime.now().year + 1))}",
     )
     parser.add_argument(
         "--no-resume",

--- a/scripts/energy/ieso_download.py
+++ b/scripts/energy/ieso_download.py
@@ -11,6 +11,7 @@ from loguru import logger
 
 from rbc.config.loader import load_config, parse_key_value_pairs
 from rbc.energy.ieso import IesoDownloader
+from rbc.energy.ieso.downloader import MIN_YEAR
 from rbc.utils import setup_logging
 
 SOURCE = "ieso"
@@ -28,9 +29,9 @@ def parse_arguments() -> Namespace:
         "--years",
         nargs="+",
         type=int,
-        default=list(range(2010, datetime.now().year + 1)),  # available years
+        default=list(range(MIN_YEAR, datetime.now().year + 1)),  # available years
         help=f"Years to download. Example: -y 2020 2021. "
-        f"Default: {list(range(2010, datetime.now().year + 1))}",
+        f"Default: {list(range(MIN_YEAR, datetime.now().year + 1))}",
     )
     parser.add_argument(
         "--no-resume",

--- a/tests/config/conftest.py
+++ b/tests/config/conftest.py
@@ -20,6 +20,7 @@ def source_configs(tmp_path: Path) -> dict:
             "paths": {"dst_dir_raw": str(Path(tmp_path, "aeso"))},
             "access": {"api_key": "token"},
         },
+        "eat": {"paths": {"dst_dir_raw": str(Path(tmp_path, "eat"))}},
         "eia": {
             "paths": {"dst_dir_raw": str(Path(tmp_path, "eia"))},
             "access": {"api_key": "token"},

--- a/tests/energy/aeso/test_downloader.py
+++ b/tests/energy/aeso/test_downloader.py
@@ -282,7 +282,7 @@ def test_get_task_data_no_generation_data(
     mock_df = pd.DataFrame(columns=EXPECTED_COLS)
 
     with patch.object(downloader, "_load_zip", return_value=mock_df):
-        with pytest.raises(MissingDataError, match="No energy generation"):
+        with pytest.raises(MissingDataError, match="No energy data available"):
             downloader._get_task_data(task)
 
 

--- a/tests/energy/eat/test_downloader.py
+++ b/tests/energy/eat/test_downloader.py
@@ -82,9 +82,7 @@ def get_mock_df(specific_task: DownloadTask) -> pd.DataFrame:
         else:
             data[col] = "mock_value"
 
-    return pd.DataFrame(data, index=[0])[
-        EXPECTED_COLS
-    ]  # df follows EXPECTED_COLS order
+    return pd.DataFrame(data, index=[0])[EXPECTED_COLS]  # ensure correct order
 
 
 # ----------------------------------

--- a/tests/energy/eat/test_downloader.py
+++ b/tests/energy/eat/test_downloader.py
@@ -1,0 +1,244 @@
+# tests/energy/eat/test_downloader.py
+"""Tests for EAT energy data downloader."""
+
+import pickle
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+import pytest
+from requests import exceptions
+
+from rbc.energy.eat import EatDownloader
+from rbc.energy.eat.downloader import EXPECTED_COLS
+from rbc.energy.utils import DataStructureError, DownloadTask, MissingDataError
+
+
+# ----------------------------------
+# Fixtures
+# ----------------------------------
+@pytest.fixture
+def init_args(tmp_path: Path) -> dict:
+    """Creates a basic setup with a temporary directory.
+
+    Args:
+        tmp_path (Path): Path to the temporary directory.
+
+    Returns:
+        dict: Initialisation arguments.
+    """
+    return {
+        "output_path": tmp_path,
+        "years": [2020],
+        "resume": False,
+    }
+
+
+@pytest.fixture
+def downloader(init_args: dict) -> EatDownloader:
+    """Provides an EatDownloader instance with a mocked, positive return code response.
+
+    Args:
+        init_args (dict): Arguments used to initialize an EatDownloader instance.
+
+    Returns:
+        EatDownloader: EatDownloader instance.
+    """
+    with patch("rbc.energy.eat.downloader.requests.head") as mock_get:
+        mock_get.return_value = MagicMock(status_code=200)
+        return EatDownloader(**init_args)
+
+
+@pytest.fixture
+def task(init_args: dict) -> DownloadTask:
+    """Gets a task as 'date=YYYY-MM' from the init arguments.
+
+    Args:
+        init_args (dict): Arguments used to initialize an EatDownloader instance.
+
+    Returns:
+        DownloadTask: The metadata of a downloading task, here: date (YYYY-MM)
+    """
+    year = init_args["years"][0]
+    return DownloadTask(date=f"{year}-01", temporal_resolution="30min")
+
+
+def get_mock_df(specific_task: DownloadTask) -> pd.DataFrame:
+    """Gets a mock dataframe for a specific task.
+
+    Args:
+        specific_task (DownloadTask): The metadata of a downloading task, here: date (YYYY-MM)
+
+    Returns:
+        pandas.DataFrame: Mock dataframe.
+    """
+    data = {}
+
+    for col in EXPECTED_COLS:
+        if col == "trading_date":
+            data[col] = specific_task.date
+        elif col.startswith("tp"):
+            data[col] = "10"
+        else:
+            data[col] = "mock_value"
+
+    return pd.DataFrame(data, index=[0])[
+        EXPECTED_COLS
+    ]  # df follows EXPECTED_COLS order
+
+
+# ----------------------------------
+# Tests - Initialization
+# ----------------------------------
+def test_downloader_initialization(downloader: EatDownloader, init_args: dict) -> None:
+    """Happy path for class initialization.
+
+    Check that the EatDownloader sets up paths and checkpoint correctly.
+
+    Args:
+        downloader (EatDownloader): Instance of EatDownloader class.
+        init_args (dict): Arguments used to initialize an EatDownloader instance.
+    """
+    assert downloader.years == init_args["years"]
+    assert downloader.output_path == init_args["output_path"]
+    assert downloader.checkpoint_path == Path(init_args["output_path"], "status.pickle")
+    assert downloader.checkpoint == {}
+
+
+def test_downloader_initialization_invalid_url(init_args: dict) -> None:
+    """Failure path for class initialization with invalid URL.
+
+    Args:
+        init_args (dict): Arguments used to initialize an EatDownloader instance.
+    """
+    with patch("rbc.energy.eat.downloader.requests.head") as mock_head:
+        mock_head.return_value.raise_for_status.side_effect = exceptions.HTTPError(
+            "404"
+        )
+
+        with pytest.raises(ConnectionError, match="EAT endpoint"):
+            EatDownloader(**init_args)
+
+
+def test_download_data_resume(init_args: dict) -> None:
+    """Happy path for "download_data" method when resuming from checkpoint.
+
+    Args:
+        init_args (dict): Arguments used to initialize an EatDownloader instance.
+    """
+    args = init_args.copy()
+    y = args["years"][0]
+
+    # save a fake checkpoint file
+    checkpoint = {
+        DownloadTask(date=d, temporal_resolution="30min").identifier: 1
+        for d in pd.date_range(start=f"{y}-01", end=f"{y}-12", freq="MS")
+        .strftime("%Y-%m")
+        .tolist()
+    }
+    checkpoint_path = Path(args["output_path"], "status.pickle")
+    with open(checkpoint_path, "wb") as f:
+        pickle.dump(checkpoint, f)
+
+    args["resume"] = True
+
+    with patch("rbc.energy.eat.downloader.requests.head") as mock_head:
+        mock_head.return_value = MagicMock(status_code=200)
+        downloader = EatDownloader(**args)
+
+        with patch.object(downloader, "_download_task_data") as mock_dump:
+            mock_dump.return_value = 1
+            downloader.download_data()
+
+            assert mock_dump.call_count == 0
+            assert downloader.checkpoint == checkpoint
+
+
+# ----------------------------------
+# Tests - Data crawling logic
+# ----------------------------------
+def test_download_task_data(downloader: EatDownloader, task: DownloadTask) -> None:
+    """Happy path for "_download_task_data" method when resuming from checkpoint.
+
+    Args:
+        downloader (EatDownloader): Instance of EatDownloader class.
+        task (DownloadTask): The metadata of a downloading task, here: date (YYYY-MM)
+    """
+    mock_df = get_mock_df(task)
+
+    with patch.object(downloader, "_get_task_data", return_value=mock_df):
+        status = downloader._download_task_data(task)
+
+        assert status == 1
+        expected_file = downloader._build_task_path(task)
+        assert expected_file.is_file(), f"The CSV {expected_file} was not created!"
+
+        saved_df = pd.read_csv(expected_file)
+        assert saved_df.iloc[0]["tp1"] == int(mock_df.iloc[0]["tp1"])
+
+
+def test_get_task_data(downloader: EatDownloader, task: DownloadTask) -> None:
+    """Happy path for "_get_task_data" method.
+
+    Args:
+        downloader (EatDownloader): Instance of EatDownloader class.
+        task (DownloadTask): The metadata of a downloading task, here: date (YYYY-MM)
+    """
+    mock_df = get_mock_df(task)
+    with patch(
+        "rbc.energy.eat.downloader.load_df_from_file", return_value=mock_df
+    ) as mock_load:
+        df = downloader._get_task_data(task)
+
+    assert not df.empty
+    assert len(df) == 1
+    assert df.iloc[0]["trading_date"] == f"{task.date}"
+    assert df.iloc[0]["site_code"] == "mock_value"
+    assert df.iloc[0]["tp1"] == "10"
+    assert mock_load.call_count == 1
+
+
+def test_get_task_data_no_data_for_old_year(downloader: EatDownloader) -> None:
+    """Failure path for "_get_task_data" method when a task with year before 2010 is provided.
+
+    Args:
+        downloader (EatDownloader): Instance of EatDownloader class.
+    """
+    old_year_task = DownloadTask(date="1996-01")
+    mock_df = pd.DataFrame(columns=EXPECTED_COLS)
+
+    with patch("rbc.energy.eat.downloader.load_df_from_file", return_value=mock_df):
+        with pytest.raises(MissingDataError, match="No energy data for year"):
+            downloader._get_task_data(old_year_task)
+
+
+def test_get_task_data_no_generation_data(
+    downloader: EatDownloader, task: DownloadTask
+) -> None:
+    """Failure path for "_get_task_data" method when no generation data is available.
+
+    Args:
+        downloader (EatDownloader): Instance of EatDownloader class.
+        task (DownloadTask): The metadata of a downloading task, here: date (YYYY-MM)
+    """
+    mock_df = pd.DataFrame(columns=EXPECTED_COLS)
+
+    with patch("rbc.energy.eat.downloader.load_df_from_file", return_value=mock_df):
+        with pytest.raises(MissingDataError, match="No energy data available"):
+            downloader._get_task_data(task)
+
+
+def test_get_task_data_structure_changed(
+    downloader: EatDownloader, task: DownloadTask
+) -> None:
+    """Failure path for "_get_task_data" method when dataframe doesn't have all columns.
+
+    Args:
+        downloader (EatDownloader): Instance of EatDownloader class.
+        task (DownloadTask): The metadata of a downloading task, here: date (YYYY-MM)
+    """
+    mock_df = get_mock_df(task).drop(columns="trading_date")
+
+    with patch("rbc.energy.eat.downloader.load_df_from_file", return_value=mock_df):
+        with pytest.raises(DataStructureError, match="Missing columns"):
+            downloader._get_task_data(task)

--- a/tests/energy/eat/test_downloader.py
+++ b/tests/energy/eat/test_downloader.py
@@ -10,7 +10,7 @@ import pytest
 from requests import exceptions
 
 from rbc.energy.eat import EatDownloader
-from rbc.energy.eat.downloader import EXPECTED_COLS
+from rbc.energy.eat.downloader import EXPECTED_COLS, MIN_YEAR
 from rbc.energy.utils import DataStructureError, DownloadTask, MissingDataError
 
 
@@ -197,12 +197,12 @@ def test_get_task_data(downloader: EatDownloader, task: DownloadTask) -> None:
 
 
 def test_get_task_data_no_data_for_old_year(downloader: EatDownloader) -> None:
-    """Failure path for "_get_task_data" method when a task with year before 2010 is provided.
+    """Failure path for "_get_task_data" method when a task before MIN_YEAR is provided.
 
     Args:
         downloader (EatDownloader): Instance of EatDownloader class.
     """
-    old_year_task = DownloadTask(date="1996-01")
+    old_year_task = DownloadTask(date=f"{MIN_YEAR - 1}-01")
     mock_df = pd.DataFrame(columns=EXPECTED_COLS)
 
     with patch("rbc.energy.eat.downloader.load_df_from_file", return_value=mock_df):

--- a/tests/energy/eia/test_downloader.py
+++ b/tests/energy/eia/test_downloader.py
@@ -10,6 +10,7 @@ import pytest
 from requests import exceptions
 
 from rbc.energy.eia import EiaDownloader
+from rbc.energy.eia.downloader import EXPECTED_COLS, MIN_YEAR
 from rbc.energy.utils import (
     MAX_RATE_LIMIT_RETRIES,
     DataStructureError,
@@ -318,6 +319,20 @@ def test_get_task_data_incomplete_download(
 
         with pytest.raises(ConnectionError, match="Incomplete download"):
             downloader._get_task_data(task)
+
+
+def test_get_task_data_no_data_for_old_year(downloader: EiaDownloader) -> None:
+    """Failure path for "_get_task_data" method when a task before MIN_YEAR is provided.
+
+    Args:
+        downloader (EiaDownloader): Instance of EiaDownloader class.
+    """
+    old_year_task = DownloadTask(date=f"{MIN_YEAR - 1}-01")
+    mock_df = pd.DataFrame(columns=EXPECTED_COLS)
+
+    with patch("rbc.energy.eat.downloader.load_df_from_file", return_value=mock_df):
+        with pytest.raises(MissingDataError, match="No energy data for year"):
+            downloader._get_task_data(old_year_task)
 
 
 def test_get_task_data_no_generation_data(

--- a/tests/energy/eia/test_downloader.py
+++ b/tests/energy/eia/test_downloader.py
@@ -335,9 +335,7 @@ def test_get_task_data_no_generation_data(
     with patch("rbc.energy.eia.downloader.requests.get") as mock_get:
         mock_get.return_value = mock_response
 
-        with pytest.raises(
-            MissingDataError, match="No energy generation data available"
-        ):
+        with pytest.raises(MissingDataError, match="No energy data available"):
             downloader._get_task_data(task)
 
 

--- a/tests/energy/entsoe/test_downloader.py
+++ b/tests/energy/entsoe/test_downloader.py
@@ -228,7 +228,7 @@ def test_get_task_data_no_data_for_old_year(
     """
     old_year_task = task.update(date="1900-01-01")
 
-    with pytest.raises(MissingDataError, match="No data for year"):
+    with pytest.raises(MissingDataError, match="No energy data for year"):
         downloader._get_task_data(old_year_task)
 
 
@@ -282,9 +282,7 @@ def test_get_task_data_no_generation_data(
     ) as mock_api:
         mock_api.return_value.query_api.return_value = []
 
-        with pytest.raises(
-            MissingDataError, match="No energy generation data available"
-        ):
+        with pytest.raises(MissingDataError, match="No energy data available"):
             downloader._get_task_data(task)
 
 

--- a/tests/energy/epias/test_downloader.py
+++ b/tests/energy/epias/test_downloader.py
@@ -9,7 +9,7 @@ import pandas as pd
 import pytest
 
 from rbc.energy.epias import EpiasDownloader
-from rbc.energy.epias.downloader import EXPECTED_COLS
+from rbc.energy.epias.downloader import EXPECTED_COLS, MIN_YEAR
 from rbc.energy.utils import (
     DataStructureError,
     DownloadTask,
@@ -207,6 +207,20 @@ def test_get_task_data(downloader: EpiasDownloader, task: DownloadTask) -> None:
     assert not df.empty
     assert df.iloc[0]["date"] == task.date
     assert df.iloc[0]["total"] == 16.2
+
+
+def test_get_task_data_no_data_for_old_year(downloader: EpiasDownloader) -> None:
+    """Failure path for "_get_task_data" method when a task before MIN_YEAR is provided.
+
+    Args:
+        downloader (EpiasDownloader): Instance of EpiasDownloader class.
+    """
+    old_year_task = DownloadTask(date=f"{MIN_YEAR - 1}-01")
+    mock_df = pd.DataFrame(columns=EXPECTED_COLS)
+
+    with patch("rbc.energy.eat.downloader.load_df_from_file", return_value=mock_df):
+        with pytest.raises(MissingDataError, match="No energy data for year"):
+            downloader._get_task_data(old_year_task)
 
 
 @pytest.mark.parametrize(

--- a/tests/energy/ieso/test_downloader.py
+++ b/tests/energy/ieso/test_downloader.py
@@ -10,7 +10,12 @@ import pytest
 from requests import exceptions
 
 from rbc.energy.ieso import IesoDownloader
-from rbc.energy.ieso.downloader import EXPECTED_COLS, URL_NEW_BASE, URL_OLD_BASE
+from rbc.energy.ieso.downloader import (
+    EXPECTED_COLS,
+    MIN_YEAR,
+    URL_NEW_BASE,
+    URL_OLD_BASE,
+)
 from rbc.energy.utils import DataStructureError, DownloadTask, MissingDataError
 
 
@@ -213,12 +218,12 @@ def test_get_task_data(
 
 
 def test_get_task_data_no_data_for_old_year(downloader: IesoDownloader) -> None:
-    """Failure path for "_get_task_data" method when a task with year before 2010 is provided.
+    """Failure path for "_get_task_data" method when a task before MIN_YEAR is provided.
 
     Args:
         downloader (IesoDownloader): Instance of IesoDownloader class.
     """
-    old_year_task = DownloadTask(date="2009-01")
+    old_year_task = DownloadTask(date=f"{MIN_YEAR - 1}-01")
     mock_df = pd.DataFrame(columns=EXPECTED_COLS)
 
     with patch.object(downloader, "_get_from_old_source", return_value=mock_df):

--- a/tests/energy/ieso/test_downloader.py
+++ b/tests/energy/ieso/test_downloader.py
@@ -237,7 +237,7 @@ def test_get_task_data_no_data_for_old_year(downloader: IesoDownloader) -> None:
 
     with patch.object(downloader, "_get_from_old_source", return_value=mock_df):
         with patch.object(downloader, "_get_from_new_source", return_value=mock_df):
-            with pytest.raises(MissingDataError, match="No data for year"):
+            with pytest.raises(MissingDataError, match="No energy data for year"):
                 downloader._get_task_data(old_year_task)
 
 
@@ -254,9 +254,7 @@ def test_get_task_data_no_generation_data(
 
     with patch.object(downloader, "_get_from_old_source", return_value=mock_df):
         with patch.object(downloader, "_get_from_new_source", return_value=mock_df):
-            with pytest.raises(
-                MissingDataError, match="No energy generation data available"
-            ):
+            with pytest.raises(MissingDataError, match="No energy data available"):
                 downloader._get_task_data(task)
 
 

--- a/tests/energy/ieso/test_downloader.py
+++ b/tests/energy/ieso/test_downloader.py
@@ -163,7 +163,7 @@ def test_download_task_data(downloader: IesoDownloader, task: DownloadTask) -> N
         downloader (IesoDownloader): Instance of IesoDownloader class.
         task (DownloadTask): The metadata of a downloading task, here: date (YYYY-MM)
     """
-    mock_df = pd.DataFrame({"Hour 1": [16.2]})
+    mock_df = get_mock_df(task)
 
     with patch.object(downloader, "_get_task_data", return_value=mock_df):
         status = downloader._download_task_data(task)
@@ -173,7 +173,7 @@ def test_download_task_data(downloader: IesoDownloader, task: DownloadTask) -> N
         assert expected_file.is_file(), f"The CSV {expected_file} was not created!"
 
         saved_df = pd.read_csv(expected_file)
-        assert saved_df.iloc[0]["Hour 1"] == 16.2
+        assert saved_df.iloc[0]["Hour 1"] == int(mock_df.iloc[0]["Hour 1"])
 
 
 @pytest.mark.parametrize(

--- a/tests/energy/ieso/test_downloader.py
+++ b/tests/energy/ieso/test_downloader.py
@@ -86,20 +86,6 @@ def get_mock_df(specific_task: DownloadTask) -> pd.DataFrame:
     )
 
 
-def get_task_year_month(task: DownloadTask) -> tuple[int, int]:
-    """Return (year, month) from a monthly DownloadTask.
-
-    Args:
-        task (DownloadTask): The metadata of a downloading task, here: date (YYYY-MM)
-
-    Returns:
-        tuple[int, int]: Tuple containing (year, month).
-    """
-    assert task.date is not None
-    year, month = task.date.split("-")
-    return int(year), int(month)
-
-
 # ----------------------------------
 # Tests - Initialization
 # ----------------------------------
@@ -285,7 +271,6 @@ def test_get_from_new_source(downloader: IesoDownloader, task: DownloadTask) -> 
         downloader (IesoDownloader): Instance of IesoDownloader class.
         task (DownloadTask): The metadata of a downloading task, here: date (YYYY-MM)
     """
-    year, month = get_task_year_month(task)
     mock_df = pd.DataFrame(
         {"Measurement": ["Output", "Forecast", "Capability"], "Value": [10, 20, 30]}
     )
@@ -293,12 +278,10 @@ def test_get_from_new_source(downloader: IesoDownloader, task: DownloadTask) -> 
     with patch(
         "rbc.energy.ieso.downloader.load_df_from_file", return_value=mock_df
     ) as mock_load:
-        df = downloader._get_from_new_source(year=year, month=month)
+        df = downloader._get_from_new_source(year=task.year, month=task.month)
 
         # check correct URL was created
-        expected_url = (
-            f"{URL_NEW_BASE}/PUB_GenOutputCapabilityMonth_{year}{month:02d}.csv"
-        )
+        expected_url = f"{URL_NEW_BASE}/PUB_GenOutputCapabilityMonth_{task.year}{task.month:02d}.csv"
         mock_load.assert_called_with(expected_url, header=3, index_col=False)
 
         # check forecast data was filtered out
@@ -315,12 +298,11 @@ def test_get_from_new_source_missing_measurement(
         downloader (IesoDownloader): Instance of IesoDownloader class.
         task (DownloadTask): The metadata of a downloading task, here: date (YYYY-MM)
     """
-    year, month = get_task_year_month(task)
     mock_df = get_mock_df(task).drop(columns="Measurement")
 
     with patch("rbc.energy.ieso.downloader.load_df_from_file", return_value=mock_df):
         with pytest.raises(DataStructureError, match="'Measurement' column is missing"):
-            downloader._get_from_new_source(year=year, month=month)
+            downloader._get_from_new_source(year=task.year, month=task.month)
 
 
 @pytest.mark.parametrize(
@@ -340,17 +322,16 @@ def test_get_from_old_source(
         task (DownloadTask): The metadata of a downloading task, here: date (YYYY-MM)
         suffix (str): Expected suffix of URL.
     """
-    year, month = get_task_year_month(task)
     mock_df = pd.DataFrame(
         {
             "Delivery Date": pd.to_datetime(
-                [f"{task.date}-01", f"{year}-{month + 1:02d}-01"]
+                [f"{task.date}-01", f"{task.year}-{task.month + 1:02d}-01"]
             )
         }
     )
 
     with patch.object(downloader, "_load_yearly_excel", return_value=mock_df) as mock_f:
-        df = downloader._get_from_old_source(year=year, month=month)
+        df = downloader._get_from_old_source(year=task.year, month=task.month)
 
         # check correct URL was created
         expected_url = (
@@ -360,7 +341,7 @@ def test_get_from_old_source(
 
         # check all except current month were filtered out
         assert len(df) == 1
-        assert df["Delivery Date"].dt.month.iloc[0] == month
+        assert df["Delivery Date"].dt.month.iloc[0] == task.month
 
 
 def test_lru_cache_works(downloader: IesoDownloader, task: DownloadTask) -> None:
@@ -370,7 +351,6 @@ def test_lru_cache_works(downloader: IesoDownloader, task: DownloadTask) -> None
         downloader (IesoDownloader): Instance of IesoDownloader class.
         task (DownloadTask): The metadata of a downloading task, here: date (YYYY-MM)
     """
-    year, month = get_task_year_month(task)
     mock_df = pd.DataFrame(
         {"DATE": pd.to_datetime(f"{task.date}-01"), "HOUR": [1], "GEN_A": [10]}
     )
@@ -380,9 +360,9 @@ def test_lru_cache_works(downloader: IesoDownloader, task: DownloadTask) -> None
     with patch("rbc.energy.ieso.downloader.load_df_from_file") as mock_load:
         mock_load.side_effect = [mock_df, mock_df]
 
-        downloader._get_from_old_source(year=year, month=month)
-        downloader._get_from_old_source(year=year, month=month)
-        downloader._get_from_old_source(year=year, month=month)
+        downloader._get_from_old_source(year=task.year, month=task.month)
+        downloader._get_from_old_source(year=task.year, month=task.month)
+        downloader._get_from_old_source(year=task.year, month=task.month)
 
         # check method called 2x - both in _load_yearly_excel call in 1st _get_from_old_source
         assert mock_load.call_count == 2
@@ -397,13 +377,11 @@ def test_get_from_old_source_structure_changed(
         downloader (IesoDownloader): Instance of IesoDownloader class.
         task (DownloadTask): The metadata of a downloading task, here: date (YYYY-MM)
     """
-    year, month = get_task_year_month(task)
-
     with patch.object(downloader, "_load_yearly_excel") as mock_load:
         mock_load.return_value = pd.DataFrame({"Delivery Date": [f"{task.date}-01"]})
 
         with pytest.raises(DataStructureError, match="no longer datetimelike"):
-            downloader._get_from_old_source(year=year, month=month)
+            downloader._get_from_old_source(year=task.year, month=task.month)
 
 
 def test_load_yearly_excel(downloader: IesoDownloader, task: DownloadTask) -> None:

--- a/tests/energy/test_utils.py
+++ b/tests/energy/test_utils.py
@@ -379,6 +379,9 @@ def test_downloadtask_initialise(tres: str | None, bz: str | None) -> None:
     assert task.date == date
     assert task.temporal_resolution == exp_tres
     assert task.bidding_zone == exp_bz
+    assert task.dt == pd.Timestamp(date)
+    assert task.year == 2020
+    assert task.month == 1
 
     if bz is not None:
         assert (


### PR DESCRIPTION
# New data crawler for EAT (New Zealand) energy data

Code and tests for downloading data from [EA Te Mana Hiko](https://www.ea.govt.nz/data-and-insights/datasets/wholesale/generation/generation-output/) via the existing `load_df_from_url` functionality. This can function as an example for future data crawlers and encompasses:

- a config YAML file `configs/energy/eat.yaml` for source-related settings,
- a data downloader in `rbc/energy/eat/downloader.py`,
- a script for running the downloader in `scripts/energy/eat_download.py`,
- tests for the downloader in `tests/energy/eat/test_downloader.py`.
- updated documentation (`README.md` and `docs/data_sources.md` )
### Additional changes

- **DownloadTask helper class**: Make `dt` (datetime), `year`, and `month` class attributes
- **EIA, EPIAS**: check a task's `year` at the start of `_get_task_data` to ignore irrelevant tasks directly
- **AESO, EAT, EIA, EPIAS, IESO**: include `MIN_YEAR` as global parameter for use by `Downloader` class, scripts and tests
- **Docs**: excluded data sources for energy in `data_sources.md`

## New dependencies
/

## Related issues

- Closes #14

## Type of change

- [X] New feature (non-breaking change which adds functionality)

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules