### PR TITLE
Features/ons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -149,6 +149,7 @@ venv.bak/
 
 # General stuff
 outputs*/
+.DS_Store
 
 # Spyder project settings
 .spyderproject

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ The RenewBench-Crawler repository is structured as follows:
 │   │   ├── entsoe/               # ENTSO-e (EU)
 │   │   ├── epias/                # EPIAS (Turkey)
 │   │   ├── ieso/                 # IESO (Canada, Ontario)
+│   │   ├── ons/                  # ONS (Brazil)
 │   │   └── taipower/             # Taipower (Taiwan)
 │   └── weather/                # Weather data crawlers
 │       ├── barra/                # BARRA2 (Australia)

--- a/configs/energy/ons.yaml
+++ b/configs/energy/ons.yaml
@@ -1,0 +1,2 @@
+paths:
+  dst_dir_raw: /lsdf/raw/energy/ons/

--- a/docs/data_sources.md
+++ b/docs/data_sources.md
@@ -513,16 +513,26 @@ An energy data source is excluded if it fails to meet **any** of the following c
 3. Data based on actual historical observations (not purely simulated generation)
 4. Publicly accessible without restrictive publication prohibitions
 
-| Region       | Source  | Status                                                 | Resolution                             | Data availability | Source                                                                                              |
-|--------------| ------- |--------------------------------------------------------| -------------------------------------- | ----------------- |-----------------------------------------------------------------------------------------------------|
-| World        | IEA     | Spatial and temporal resolutions too low, inaccessible | per country; **yearly**                | 2000 – 2024       | [Platform](https://www.iea.org/data-and-statistics/data-tools/renewable-energy-progress-tracker)    |
-| World        | IRENA   | Spatial and temporal resolutions too low               | per country; **yearly**                | 2000 – 2024       | [Data hosting](https://www.irena.org/Data/Downloads/IRENASTAT)                                      |
-| India        | CEA     | Spatial and temporal resolutions too low               | per state (<=350,000 km²); **monthly** | 2019 – now        | [Dashboard](https://cea.nic.in/dashboard/?lang=en)                                                  |
-| Paraguay     | ANDE    | Spatial and temporal resolutions too low               | per country (~400,000 km²); **yearly** | 1996 – 2019       | [Report](https://ande.gov.py/documentos_contables/706/ande_-_compilacion_estadistica_1999-2019.pdf) |
-| Mexico       | CENACE  | Spatial resolution too low                             | per country (~2,000,000 km²); hourly   | 2016 – now        | [Platform](https://www.cenace.gob.mx/Paginas/SIM/Reportes/EnergiaGeneradaTipoTec.aspx)              |
-| South Africa | Eskom   | Spatial resolution too low                             | per country (~1,000,000 km²); hourly   | 2021 – now        | [Dashboard](https://www.eskom.co.za/dataportal/supply-side/station-build-up-for-the-last-7-days/)   |
-| South Korea  | KPX     | Spatial resolution too low                             | per country (~100,000 km²); 5 min      | 2022 – now        | [Website](https://www.eskom.co.za/dataportal/supply-side/station-build-up-for-the-last-7-days/)     |
-| Europe       | EMHIRES | Spatial resolution too low, simulated data!            | per country; hourly                    | 2006 – now        | [Dataset](https://new.kpx.or.kr/powerSource.es?mid=a10606030000&device=chart)                       |
+| Region          | Source      | Status                                                 | Resolution                            | Data availability | Source                                                                                                                    |
+|-----------------|-------------|--------------------------------------------------------|---------------------------------------|-------------------|---------------------------------------------------------------------------------------------------------------------------|
+| World           | IEA         | Spatial and temporal resolutions too low, inaccessible | Per country; **yearly**               | 2000 – 2024       | [Platform](https://www.iea.org/data-and-statistics/data-tools/renewable-energy-progress-tracker)                          |
+| World           | IRENA       | Spatial and temporal resolutions too low               | Per country; **yearly**               | 2000 – 2024       | [Data hosting](https://www.irena.org/Data/Downloads/IRENASTAT)                                                            |
+| India           | CEA         | Spatial and temporal resolutions too low               | Per state (<=350,000 km²); **monthly** | 2019 – now        | [Dashboard](https://cea.nic.in/dashboard/?lang=en)                                                                        |
+| Paraguay        | ANDE        | Spatial and temporal resolutions too low               | Per country (~400,000 km²); **yearly** | 1996 – 2019       | [Report](https://ande.gov.py/documentos_contables/706/ande_-_compilacion_estadistica_1999-2019.pdf)                       |
+| Mexico          | CENACE      | Spatial resolution too low                             | Per country (~2,000,000 km²); hourly  | 2016 – now        | [Platform](https://www.cenace.gob.mx/Paginas/SIM/Reportes/EnergiaGeneradaTipoTec.aspx)                                    |
+| South Africa    | Eskom       | Spatial resolution too low                             | Per country (~1,000,000 km²); hourly  | 2021 – now        | [Dashboard](https://www.eskom.co.za/dataportal/supply-side/station-build-up-for-the-last-7-days/)                         |
+| South Korea     | KPX         | Spatial resolution too low                             | Per country (~100,000 km²); 5 min     | 2022 – now        | [Website](https://www.eskom.co.za/dataportal/supply-side/station-build-up-for-the-last-7-days/)                           |
+| Europe          | EMHIRES     | Spatial resolution too low, simulated data!            | Per country; hourly                   | 2006 – now        | [Dataset](https://new.kpx.or.kr/powerSource.es?mid=a10606030000&device=chart)                                             |
+| Canada (Quebec) | hydroquebec | Spatial resolution too low, only hydro data            | Per state (~500 km²); hourly           | 2018 – now        | [Dataset](https://donnees.hydroquebec.com/explore/dataset/historique-production-consommation-proxy-horaire/information/)  |
+| Israel          | NOGA        | Unknown (site inaccessible from Europe / via VPN)      | Unknown                               | Unknown           | [Website](https://www.noga.co.il/)                                                                                        |
+
+### Regions lacking data
+- Africa: [All countries except South Africa](https://ember-energy.org/app/uploads/2024/10/African-Electricity-Data-Transparency.pdf)
+- Middle East: Saudi Arabia, Bahrain, Qatar
+- Asia: China, Indonesia, Philippines
+
+### Geopolitical exclusions (data trustworthiness)
+- Russia
 
 ## Weather
 

--- a/docs/data_sources.md
+++ b/docs/data_sources.md
@@ -16,7 +16,7 @@ RenewBench-Crawler package.
 | **Canada<br> (Alberta)** | AESO     | downloader &check; | hourly/5 min; per plant  | `box` API token   | [Website](https://www.aeso.ca/market/market-and-system-reporting/data-requests/historical-generation-data/), [Data hosting](https://aeso.app.box.com/s/qofgn9axnnw6uq3ip1goiq2ngb11txe5/folder/196731538687), <br> [API how-to](https://developer.box.com/guides/authentication/tokens/developer-tokens) (s. details!) |
 | **Canada<br> (Ontario)** | IESO     | downloader &check; | hourly; per plant        | public            | [Website](https://www.ieso.ca/power-data/data-directory)                                                                                                                                                                                                                                                               |
 | **Chile**                | CEN      | planned            |                          |                   |                                                                                                                                                                                                                                                                                                                        |
-| **Brazil**               | ONS      | planned            | hourly; per plant        | public            | [Website](https://dados.ons.org.br/dataset/geracao-usina-2), Data hosting on AWS S3                                                                                                                                                                                                                                    |
+| **Brazil**               | ONS      | downloader &check; | hourly; per plant        | public            | [Website](https://dados.ons.org.br/dataset/geracao-usina-2), Data hosting on AWS S3                                                                                                                                                                                                                                    |
 | **Uruguay**              | ADME     | planned            |                          |                   |                                                                                                                                                                                                                                                                                                                        |
 | **Australia**            | AEMO     | planned            |                          |                   |                                                                                                                                                                                                                                                                                                                        |
 | **New<br>Zealand**       | EAT      | downloader &check; | 30 min; per plant        | public            | [Website / Data hosting](https://www.ea.govt.nz/data-and-insights/datasets/wholesale/generation/generation-output/)                                                                                                                                                                                                    |
@@ -220,31 +220,31 @@ RenewBench-Crawler package.
 - Downloadable files: 1 `.csv` (or `.xlsx`) per year (before 2022), 1 `.csv` (or `.xlsx`) per
   month (from 2022 onwards)
 - Files saved as **raw**: 1 `.csv` per month
-- Columns saved as **raw**:
+- Columns saved as **raw**: (translated from Portuguese)
 
-  `din_instante` - reference timestamp (YYYY-MM-DD HH:MM:SS), hourly resolution
+  `datetime` - reference timestamp (YYYY-MM-DD HH:MM:SS), hourly resolution
 
-  `id_subsistema` - subsystem identifier (3-character code for Brazilian grid subsystem)
+  `subsystem_id` - subsystem identifier (3-character code for Brazilian grid subsystem)
 
-  `nom_subsistema` - name of the subsystem
+  `subsystem_name` - name of the subsystem
 
-  `id_estado` - state identifier (2-character code for Brazilian state)
+  `state_id` - state identifier (2-character code for Brazilian state)
 
-  `nom_estado` - name of the state where the plant is located
+  `state_name` - name of the state where the plant is located
 
-  `cod_modalidadeoperacao` - plant operation mode (e.g. type of operational dispatch)
+  `operation_mode` - plant operation mode (e.g. type of operational dispatch)
 
-  `nom_tipousina` - plant type (e.g. hydro, thermal, wind, solar)
+  `plant_type` - plant type (e.g. hydro, thermal, wind, solar)
 
-  `nom_tipocombustivel` - fuel type used by the plant
+  `fuel_type` - fuel type used by the plant
 
-  `nom_usina` - name of the power plant
+  `plant_name` - name of the power plant
 
-  `id_ons` - unique identifier assigned by ONS (National System Operator)
+  `ons_id` - unique identifier assigned by ONS (National System Operator)
 
-  `ceg` - unique generation project identifier assigned by ANEEL (Brazilian regulator)
+  `generation_project_code` - unique generation project identifier assigned by ANEEL (Brazilian regulator)
 
-  `val_geracao` - generation in MWmed (average MW over the time interval; equivalent to MWh for hourly data)
+  `generation_MWmed` - generation in MWmed (average MW over the time interval; equivalent to MWh for hourly data)
 
 </details>
 

--- a/docs/data_sources.md
+++ b/docs/data_sources.md
@@ -16,7 +16,7 @@ RenewBench-Crawler package.
 | **Canada<br> (Alberta)** | AESO     | downloader &check; | hourly/5 min; per plant  | `box` API token   | [Website](https://www.aeso.ca/market/market-and-system-reporting/data-requests/historical-generation-data/), [Data hosting](https://aeso.app.box.com/s/qofgn9axnnw6uq3ip1goiq2ngb11txe5/folder/196731538687), <br> [API how-to](https://developer.box.com/guides/authentication/tokens/developer-tokens) (s. details!) |
 | **Canada<br> (Ontario)** | IESO     | downloader &check; | hourly; per plant        | public            | [Website](https://www.ieso.ca/power-data/data-directory)                                                                                                                                                                                                                                                               |
 | **Chile**                | CEN      | planned            |                          |                   |                                                                                                                                                                                                                                                                                                                        |
-| **Brazil**               | ONS      | planned            |                          |                   |                                                                                                                                                                                                                                                                                                                        |
+| **Brazil**               | ONS      | planned            | hourly; per plant        | public            | [Website](https://dados.ons.org.br/dataset/geracao-usina-2), Data hosting on AWS S3                                                                                                                                                                                                                                    |
 | **Uruguay**              | ADME     | planned            |                          |                   |                                                                                                                                                                                                                                                                                                                        |
 | **Australia**            | AEMO     | planned            |                          |                   |                                                                                                                                                                                                                                                                                                                        |
 | **New<br>Zealand**       | EAT      | downloader &check; | 30 min; per plant        | public            | [Website / Data hosting](https://www.ea.govt.nz/data-and-insights/datasets/wholesale/generation/generation-output/)                                                                                                                                                                                                    |
@@ -80,7 +80,7 @@ RenewBench-Crawler package.
 
   `hour` – hour
 
-  `total` – total generation of the power plant (MWh)
+  `total` – total generation of the power plant in MWh
 
   `powerPlantName` – name of the power plant
 
@@ -185,7 +185,8 @@ RenewBench-Crawler package.
 - Spatial resolution: per plant
 - Temporal resolution: hourly
 - Available data timespan: 2010-01 to now
-- Downloadable files: 1 `.xlsx` per year (pre-April-2019), 1 `.csv` per month (post-April-2019)
+- Downloadable files: 1 `.xlsx` per year (before April-2019), 1 `.csv` per month
+  (from April-2019 onwards)
 - Files saved as **raw**: 1 `.csv` per month
 - Columns saved as **raw**:
 
@@ -196,7 +197,7 @@ RenewBench-Crawler package.
   `Fuel Type` – fuel type (not given in `.xlsx` so `=NaN`; to be filled in during processing)
 
   `Measurement` – type of measurement:
-  - `Output`: generation (MW)
+  - `Output`: generation in MW
   - `Capability`: available capacity
 
   `Hour 1`, `Hour 2`, …, `Hour 24` – ending hour intervals (i.e. `00:00 - 01:00` to `23:00 to
@@ -204,6 +205,48 @@ RenewBench-Crawler package.
 
 </details>
 
+
+<details>
+<summary><b>ONS (Brazil)</b></summary>
+
+**Access**
+- Website: [ONS generation data](https://dados.ons.org.br/dataset/geracao-usina-2)
+- Requirements: public, no authentication needed (CC Attribution License)
+
+**Download & data structure**
+- Spatial resolution: per plant
+- Temporal resolution: hourly
+- Available data timespan: 2000 to now
+- Downloadable files: 1 `.csv` (or `.xlsx`) per year (before 2022), 1 `.csv` (or `.xlsx`) per
+  month (from 2022 onwards)
+- Files saved as **raw**: 1 `.csv` per month
+- Columns saved as **raw**:
+
+  `din_instante` - reference timestamp (YYYY-MM-DD HH:MM:SS), hourly resolution
+
+  `id_subsistema` - subsystem identifier (3-character code for Brazilian grid subsystem)
+
+  `nom_subsistema` - name of the subsystem
+
+  `id_estado` - state identifier (2-character code for Brazilian state)
+
+  `nom_estado` - name of the state where the plant is located
+
+  `cod_modalidadeoperacao` - plant operation mode (e.g. type of operational dispatch)
+
+  `nom_tipousina` - plant type (e.g. hydro, thermal, wind, solar)
+
+  `nom_tipocombustivel` - fuel type used by the plant
+
+  `nom_usina` - name of the power plant
+
+  `id_ons` - unique identifier assigned by ONS (National System Operator)
+
+  `ceg` - unique generation project identifier assigned by ANEEL (Brazilian regulator)
+
+  `val_geracao` - generation in MWmed (average MW over the time interval; equivalent to MWh for hourly data)
+
+</details>
 
 <details>
 <summary><b>EAT (New Zealand)</b></summary>
@@ -235,7 +278,7 @@ RenewBench-Crawler package.
 
   `trading_date` – the date on which the injections occurred
 
-  `tp1`, `tp2`, …, `tp50` – generation values (in kWh) per trading period, starting at
+  `tp1`, `tp2`, …, `tp50` – generation values in kWh (!) per trading period, starting at
   midnight in half hour intervals. **NOTE:** Daylight saving is applied (46 TP = on
   the day saving starts, 50 TP = on the day it ends)
 

--- a/rbc/config/schema.py
+++ b/rbc/config/schema.py
@@ -194,6 +194,18 @@ class IesoConfig(PathValidation, BaseModel):
     paths: Paths
 
 
+class OnsConfig(PathValidation, BaseModel):
+    """Configuration schema for the ONS energy data source.
+
+    Attributes:
+        source (Literal): Name of the data source.
+        paths (Paths): Paths pydantic model for paths.
+    """
+
+    source: Literal["ons"] = "ons"
+    paths: Paths
+
+
 # ----------------------------------
 # Per-source schemas - WEATHER
 # ----------------------------------
@@ -257,6 +269,7 @@ SCHEMA_REGISTRY: dict[str, Type[BaseModel]] = {
     "entsoe": EntsoeConfig,
     "epias": EpiasConfig,
     "ieso": IesoConfig,
+    "ons": OnsConfig,
     "barra2": Barra2Config,
     "era5": Era5Config,
     "icon_dream_eu": IconDreamEuConfig,

--- a/rbc/energy/aeso/downloader.py
+++ b/rbc/energy/aeso/downloader.py
@@ -78,7 +78,9 @@ class AesoDownloader(EnergyDownloader):
             InvalidError: If provided temporal_resolutions are invalid (not 1h &/ 5min).
             ConnectionError: If the AESO box endpoint isn't reachable.
         """
-        super().__init__(output_path=output_path, years=years, resume=resume)
+        super().__init__(
+            output_path=output_path, years=years, start_year=MIN_YEAR, resume=resume
+        )
         self.temporal_resolutions = temporal_resolutions
 
         invalid_t_res = set(temporal_resolutions) - set(FOLDER_ID_DICT.keys())

--- a/rbc/energy/aeso/downloader.py
+++ b/rbc/energy/aeso/downloader.py
@@ -24,9 +24,10 @@ from rbc.energy.utils import (
     MissingDataError,
 )
 
+URL_ROOT = "https://api.box.com/2.0/folders/196731538687/items"
 URL_BASE = "https://aeso.app.box.com/s/qofgn9axnnw6uq3ip1goiq2ngb11txe5"
 BOXAPI = f"shared_link={URL_BASE}"
-ROOT_ID = "196731538687"
+
 FOLDER_ID_DICT = {"1h": "196178549071", "5min": "196706124680"}
 
 MIN_YEAR = 2015
@@ -78,40 +79,37 @@ class AesoDownloader(EnergyDownloader):
             ConnectionError: If the AESO box endpoint isn't reachable.
         """
         super().__init__(output_path=output_path, years=years, resume=resume)
-
         self.temporal_resolutions = temporal_resolutions
+
         invalid_t_res = set(temporal_resolutions) - set(FOLDER_ID_DICT.keys())
         if invalid_t_res:
             raise InvalidError(
                 f"Invalid temporal resolution(s): {sorted(invalid_t_res)}"
             )
 
-        logger.info(
-            f"AESO Downloader initialized for:"
-            f"\n- years:\t\t{years}"
-            f"\n- temporal resolutions:\t{temporal_resolutions}"
-        )
-
-        try:
-            requests.get(
-                f"https://api.box.com/2.0/folders/{ROOT_ID}/items",
+        self._check_connection(
+            lambda: requests.get(
+                URL_ROOT,
                 headers={
                     "Authorization": f"Bearer {token}",
                     "boxapi": BOXAPI,
                 },
                 params={"limit": 1},
                 timeout=10,
-            ).raise_for_status()
+            ),
+            "AESO",
+        )
 
-        except (requests.exceptions.HTTPError, requests.exceptions.Timeout) as e:
-            logger.error("Initialization AESO connectivity check failed!")
-            raise ConnectionError(f"AESO box cloud storage is unreachable: {e}")
-
-        # API setup
+        # API setup and source lookup
         auth = BoxDeveloperTokenAuth(token=token)
         self.client = BoxClient(auth=auth)
-
         self._source_lookup = self._build_source_lookup()
+
+        logger.info(
+            f"AESO Downloader initialized for:"
+            f"\n- years:\t\t{years}"
+            f"\n- temporal resolutions:\t{temporal_resolutions}"
+        )
 
     def download_data(self) -> None:
         """Parse data for all given years from AESO site and save to CSV."""

--- a/rbc/energy/aeso/downloader.py
+++ b/rbc/energy/aeso/downloader.py
@@ -28,6 +28,7 @@ URL_BASE = "https://aeso.app.box.com/s/qofgn9axnnw6uq3ip1goiq2ngb11txe5"
 BOXAPI = f"shared_link={URL_BASE}"
 ROOT_ID = "196731538687"
 FOLDER_ID_DICT = {"1h": "196178549071", "5min": "196706124680"}
+
 MIN_YEAR = 2015
 EXPECTED_COLS = [
     "Date (MST)",

--- a/rbc/energy/eat/downloader.py
+++ b/rbc/energy/eat/downloader.py
@@ -34,7 +34,7 @@ EXPECTED_COLS = [
         "Trading_date",
     ]
     + [f"TP{i}" for i in range(1, 51)]
-]  # make lower case because column capitalisation changes across the years in EAT data
+]  # make lower case because column capitalization changes across the years in EAT data
 
 
 class EatDownloader(EnergyDownloader):
@@ -58,14 +58,9 @@ class EatDownloader(EnergyDownloader):
             ConnectionError: If the base URL isn't reachable.
         """
         super().__init__(output_path=output_path, years=years, resume=resume)
+        self._check_connection(lambda: requests.head(URL_BASE, timeout=10), "EAT")
+
         logger.info(f"EAT Downloader initialized for:\n- years:\t\t{years}")
-
-        try:
-            requests.head(URL_BASE, timeout=10).raise_for_status()
-
-        except Exception as e:
-            logger.error("Initialization EAT connectivity check failed!")
-            raise ConnectionError(f"EAT endpoint is unreachable: {e}")
 
     def download_data(self) -> None:
         """Parse data for all given years from EAT site and save to CSV."""

--- a/rbc/energy/eat/downloader.py
+++ b/rbc/energy/eat/downloader.py
@@ -20,6 +20,7 @@ from rbc.energy.utils import (
 )
 
 URL_BASE = "https://emidatasets.blob.core.windows.net/publicdata/Datasets/Wholesale/Generation/Generation_MD"
+
 MIN_YEAR = 1997
 EXPECTED_COLS = [
     c.lower()
@@ -54,7 +55,7 @@ class EatDownloader(EnergyDownloader):
                 or start from scratch (False). Defaults to True.
 
         Raises:
-            ConnectionError: If the base URLs aren't reachable.
+            ConnectionError: If the base URL isn't reachable.
         """
         super().__init__(output_path=output_path, years=years, resume=resume)
         logger.info(f"EAT Downloader initialized for:\n- years:\t\t{years}")

--- a/rbc/energy/eat/downloader.py
+++ b/rbc/energy/eat/downloader.py
@@ -57,7 +57,9 @@ class EatDownloader(EnergyDownloader):
         Raises:
             ConnectionError: If the base URL isn't reachable.
         """
-        super().__init__(output_path=output_path, years=years, resume=resume)
+        super().__init__(
+            output_path=output_path, years=years, start_year=MIN_YEAR, resume=resume
+        )
         self._check_connection(lambda: requests.head(URL_BASE, timeout=10), "EAT")
 
         logger.info(f"EAT Downloader initialized for:\n- years:\t\t{years}")
@@ -92,11 +94,6 @@ class EatDownloader(EnergyDownloader):
             DataStructureError: If the data structure changed and relevant columns are now
                 missing (this will cause the entire run to be killed).
         """
-        if task.year < MIN_YEAR:
-            raise MissingDataError(
-                f"No energy data for year {task.year} (it's before {MIN_YEAR}). Skipping..."
-            )
-
         url = f"{URL_BASE}/{task.year}{str(task.month).zfill(2)}_Generation_MD.csv"
         df = load_df_from_file(url, index_col=False)
 

--- a/rbc/energy/eia/downloader.py
+++ b/rbc/energy/eia/downloader.py
@@ -18,13 +18,12 @@ from rbc.energy.utils import (
     DataStructureError,
     DownloadTask,
     EnergyDownloader,
-    InvalidError,
     MissingDataError,
     RateLimitError,
 )
 
 URL_ROOT = "https://api.eia.gov/v2/"
-URL = "https://api.eia.gov/v2/electricity/rto/fuel-type-data/data/"
+URL_BASE = f"{URL_ROOT}electricity/rto/fuel-type-data/data/"
 
 MIN_YEAR = 2019
 EXPECTED_COLS = [
@@ -66,18 +65,12 @@ class EiaDownloader(EnergyDownloader):
         """
         super().__init__(output_path=output_path, years=years, resume=resume)
         self.token = token
+        self._check_connection(
+            lambda: requests.get(URL_ROOT, params={"api_key": self.token}, timeout=10),
+            "EIA",
+        )
 
         logger.info(f"EIA Downloader initialized for:\n- years:\t\t{years}")
-
-        try:
-            response = requests.get(URL_ROOT, params={"api_key": self.token})
-            if response.status_code != 200:
-                logger.info(f"Failed: {response.json().get('error', {}).get('code')}")
-                raise InvalidError(f"Provided API token {token} incorrect.")
-
-        except Exception as e:
-            logger.info(f"Failed: {e}")
-            raise InvalidError(f"Provided API token {token} incorrect.")
 
     def download_data(self) -> None:
         """Parse data for all given years from EIA site and save to CSV."""
@@ -142,7 +135,7 @@ class EiaDownloader(EnergyDownloader):
 
         while True:
             try:
-                response = requests.get(URL, params=params, timeout=30)
+                response = requests.get(URL_BASE, params=params, timeout=30)
             except (exceptions.ConnectionError, exceptions.Timeout) as e:
                 raise type(e)(f"API request failed: {e}") from e  # dynamically reraise
 
@@ -177,7 +170,7 @@ class EiaDownloader(EnergyDownloader):
             except (requests.exceptions.JSONDecodeError, KeyError, ValueError) as e:
                 raise DataStructureError(
                     f"EIA structure change detected for '{task.identifier}'! "
-                    f"Failed parsing of data from {URL} with parameters {params}: "
+                    f"Failed parsing of data from {URL_BASE} with parameters {params}: "
                     f"{type(e).__name__}!"
                 )
 

--- a/rbc/energy/eia/downloader.py
+++ b/rbc/energy/eia/downloader.py
@@ -79,7 +79,7 @@ class EiaDownloader(EnergyDownloader):
             logger.info(f"Failed: {e}")
             raise InvalidError(f"Provided API token {token} incorrect.")
 
-    def download_data(self):
+    def download_data(self) -> None:
         """Parse data for all given years from EIA site and save to CSV."""
         tasks = [DownloadTask(date=d) for d in self._get_date_list()]
 

--- a/rbc/energy/eia/downloader.py
+++ b/rbc/energy/eia/downloader.py
@@ -63,7 +63,9 @@ class EiaDownloader(EnergyDownloader):
         Raises:
             InvalidError: If token is invalid or basic API call fails.
         """
-        super().__init__(output_path=output_path, years=years, resume=resume)
+        super().__init__(
+            output_path=output_path, years=years, start_year=MIN_YEAR, resume=resume
+        )
         self.token = token
         self._check_connection(
             lambda: requests.get(URL_ROOT, params={"api_key": self.token}, timeout=10),
@@ -108,11 +110,6 @@ class EiaDownloader(EnergyDownloader):
                 relevant columns to be missed (this will cause the entire run to be killed).
             MissingDataError: If the loaded dataframe is empty.
         """
-        if task.year < MIN_YEAR:
-            raise MissingDataError(
-                f"No energy data for year {task.year} (it's before {MIN_YEAR}). Skipping..."
-            )
-
         start = task.dt.strftime("%Y-%m-%dT00")
         end = pd.Period((task.dt + pd.Timedelta(days=1)), freq="D").strftime(
             "%Y-%m-%dT00"

--- a/rbc/energy/entsoe/downloader.py
+++ b/rbc/energy/entsoe/downloader.py
@@ -73,17 +73,17 @@ class EntsoeDownloader(EnergyDownloader):
             if bz not in ACTIVE_ZONES:
                 raise InvalidError(f"Bidding zone '{bz}' is not supported.")
 
-        logger.info(
-            f"Entsoe-E Downloader initialized for:"
-            f"\n- bidding zones:\t{bidding_zones}"
-            f"\n- years:\t\t{years}"
-        )
-
         set_config(security_token=token)
         if get_config().security_token is None:
             raise InvalidError(
                 f"Entsoe-apy failed to successfully configure token '{token}'!"
             )
+
+        logger.info(
+            f"Entsoe-E Downloader initialized for:"
+            f"\n- bidding zones:\t{bidding_zones}"
+            f"\n- years:\t\t{years}"
+        )
 
     def download_data(self) -> None:
         """Parse data for all given years and zones from ENTSO-E Platform and save to CSV."""

--- a/rbc/energy/entsoe/downloader.py
+++ b/rbc/energy/entsoe/downloader.py
@@ -14,7 +14,7 @@ from entsoe.query.decorators import ServiceUnavailableError
 from entsoe.utils import add_timestamps, extract_records
 from loguru import logger
 
-from rbc.energy.entsoe.mappings import ACTIVE_ZONES, ACTIVE_ZONES_METADATA
+from rbc.energy.entsoe.mappings import ACTIVE_ZONES, ACTIVE_ZONES_METADATA, MIN_YEAR
 from rbc.energy.utils import (
     WORKERS,
     DataStructureError,
@@ -66,7 +66,9 @@ class EntsoeDownloader(EnergyDownloader):
         Raises:
             InvalidError: If bidding zone is unsupported or token is invalid.
         """
-        super().__init__(output_path=output_path, years=years, resume=resume)
+        super().__init__(
+            output_path=output_path, years=years, start_year=MIN_YEAR, resume=resume
+        )
         self.bidding_zones = list(bidding_zones)
 
         for bz in self.bidding_zones:

--- a/rbc/energy/epias/downloader.py
+++ b/rbc/energy/epias/downloader.py
@@ -76,12 +76,12 @@ class EpiasDownloader(EnergyDownloader):
         """
         super().__init__(output_path=output_path, years=years, resume=resume)
 
-        logger.info(f"EPIAS Downloader initialized for:\n- years:\t\t{years}")
-
         try:
             self.eptr = EPTR2(username=username, password=password)
         except Exception:
             raise InvalidError("Provided username and password are incorrect.")
+
+        logger.info(f"EPIAS Downloader initialized for:\n- years:\t\t{years}")
 
     def download_data(self) -> None:
         """Parse data for all given years from EPIAS Platform and save to CSV."""

--- a/rbc/energy/epias/downloader.py
+++ b/rbc/energy/epias/downloader.py
@@ -83,7 +83,7 @@ class EpiasDownloader(EnergyDownloader):
         except Exception:
             raise InvalidError("Provided username and password are incorrect.")
 
-    def download_data(self):
+    def download_data(self) -> None:
         """Parse data for all given years from EPIAS Platform and save to CSV."""
         tasks = [DownloadTask(date=d) for d in self._get_date_list()]
 

--- a/rbc/energy/epias/downloader.py
+++ b/rbc/energy/epias/downloader.py
@@ -74,7 +74,9 @@ class EpiasDownloader(EnergyDownloader):
         Raises:
             InvalidError: If login credentials are incorrect.
         """
-        super().__init__(output_path=output_path, years=years, resume=resume)
+        super().__init__(
+            output_path=output_path, years=years, start_year=MIN_YEAR, resume=resume
+        )
 
         try:
             self.eptr = EPTR2(username=username, password=password)
@@ -107,11 +109,6 @@ class EpiasDownloader(EnergyDownloader):
             DataStructureError: If the data structure changed and relevant columns are now
                 missing (this will cause the entire run to be killed).
         """
-        if task.year < MIN_YEAR:
-            raise MissingDataError(
-                f"No energy data for year {task.year} (it's before {MIN_YEAR}). Skipping..."
-            )
-
         # get power-plants   # ['id', 'name', 'eic', 'shortName']
         start = task.date
         end = (task.dt + pd.Timedelta(days=1)).strftime("%Y-%m-%d")

--- a/rbc/energy/ieso/downloader.py
+++ b/rbc/energy/ieso/downloader.py
@@ -105,9 +105,9 @@ class IesoDownloader(EnergyDownloader):
             )
 
         if task.year < 2019 or (task.year == 2019 and task.month <= 4):
-            df = self._get_from_old_source(task.year, task.month)
+            df = self._get_from_old_source(task)
         else:
-            df = self._get_from_new_source(task.year, task.month)
+            df = self._get_from_new_source(task)
 
         if df.empty:
             raise MissingDataError(
@@ -124,12 +124,11 @@ class IesoDownloader(EnergyDownloader):
         return df
 
     @staticmethod
-    def _get_from_new_source(year: int, month: int) -> pd.DataFrame:
+    def _get_from_new_source(task: DownloadTask) -> pd.DataFrame:
         """Extract data from post-04-2019 (new) source for a given month.
 
         Args:
-            year (int): Year to extract data for.
-            month (int): Month to extract data for.
+            task (DownloadTask): The metadata of a downloading task, here: date (YYYY-MM)
 
         Returns:
             pd.DataFrame: Dataframe for a desired month.
@@ -137,7 +136,7 @@ class IesoDownloader(EnergyDownloader):
         Raises:
             DataStructureError: If downloaded data does not have the 'Measurement' column.
         """
-        url = f"{URL_NEW_BASE}/PUB_GenOutputCapabilityMonth_{year}{str(month).zfill(2)}.csv"
+        url = f"{URL_NEW_BASE}/PUB_GenOutputCapabilityMonth_{task.year}{str(task.month).zfill(2)}.csv"
         df = load_df_from_file(url, header=3, index_col=False)
 
         try:
@@ -149,12 +148,11 @@ class IesoDownloader(EnergyDownloader):
             )
         return df
 
-    def _get_from_old_source(self, year: int, month: int) -> pd.DataFrame:
+    def _get_from_old_source(self, task: DownloadTask) -> pd.DataFrame:
         """Extract data from pre-04-2019 (old) source for a given month using the year's Excel.
 
         Args:
-            year (int): Year to extract data for.
-            month (int): Month to extract data for.
+            task (DownloadTask): The metadata of a downloading task, here: date (YYYY-MM)
 
         Returns:
             pd.DataFrame: Dataframe for a desired month.
@@ -162,16 +160,16 @@ class IesoDownloader(EnergyDownloader):
         Raises:
             DataStructureError: If 'Delivery Date' column data is not datetime-like.
         """
-        url = f"{URL_OLD_BASE}/-/media/Files/IESO/Power-Data/data-directory/GOC-{year}"
-        url += "-Jan-April.xlsx" if year == 2019 else ".xlsx"
+        url = f"{URL_OLD_BASE}/-/media/Files/IESO/Power-Data/data-directory/GOC-{task.year}"
+        url += "-Jan-April.xlsx" if task.year == 2019 else ".xlsx"
 
         with self._download_lock:
             df_year = self._load_yearly_excel(url)
 
         # filter for the specific month
         try:
-            month_mask = (df_year["Delivery Date"].dt.year == year) & (
-                df_year["Delivery Date"].dt.month == month
+            month_mask = (df_year["Delivery Date"].dt.year == task.year) & (
+                df_year["Delivery Date"].dt.month == task.month
             )
         except AttributeError as e:
             raise DataStructureError(

--- a/rbc/energy/ieso/downloader.py
+++ b/rbc/energy/ieso/downloader.py
@@ -23,6 +23,7 @@ from rbc.energy.utils import (
 
 URL_NEW_BASE = "https://reports-public.ieso.ca/public/GenOutputCapabilityMonth"
 URL_OLD_BASE = "https://www.ieso.ca"
+
 MIN_YEAR = 2010
 EXPECTED_COLS = ["Delivery Date", "Generator", "Fuel Type", "Measurement"] + [
     f"Hour {i}" for i in range(1, 25)
@@ -134,7 +135,6 @@ class IesoDownloader(EnergyDownloader):
             pd.DataFrame: Dataframe for a desired month.
 
         Raises:
-            RETRY_ERRORS / InvalidError: If loading data from the URL fails.
             DataStructureError: If downloaded data does not have the 'Measurement' column.
         """
         url = f"{URL_NEW_BASE}/PUB_GenOutputCapabilityMonth_{year}{str(month).zfill(2)}.csv"
@@ -160,7 +160,7 @@ class IesoDownloader(EnergyDownloader):
             pd.DataFrame: Dataframe for a desired month.
 
         Raises:
-            DataStructureError: If downloaded data does not have the 'Measurement' column.
+            DataStructureError: If 'Delivery Date' column data is not datetime-like.
         """
         url = f"{URL_OLD_BASE}/-/media/Files/IESO/Power-Data/data-directory/GOC-{year}"
         url += "-Jan-April.xlsx" if year == 2019 else ".xlsx"
@@ -193,7 +193,6 @@ class IesoDownloader(EnergyDownloader):
             pd.DataFrame: Dataframe for the desired year.
 
         Raises:
-            RETRY_ERRORS / InvalidError: If loading data from the URL fails.
             DataStructureError: If downloaded data does not have capacity values.
         """
         # 1. get generation ('Output') data and standardize
@@ -231,7 +230,7 @@ class IesoDownloader(EnergyDownloader):
     # --------------------------------------------
     @staticmethod
     def standardize_old_data(df: pd.DataFrame, measurement_type: str) -> pd.DataFrame:
-        """Standardize old (pre-2019) dataframes to match the newer CSV format.
+        """Standardize old dataframes (before 04-2019) to match the newer CSV format.
 
         From:   DATE | HOUR | Unnamed: 2 | Generator 1 | Generator 2 | ...
         → to:   Delivery Date | Generator | Fuel Type | Measurement | Hour 1 | Hour 2 | ...

--- a/rbc/energy/ieso/downloader.py
+++ b/rbc/energy/ieso/downloader.py
@@ -54,7 +54,9 @@ class IesoDownloader(EnergyDownloader):
         Raises:
             ConnectionError: If the base URLs aren't reachable.
         """
-        super().__init__(output_path=output_path, years=years, resume=resume)
+        super().__init__(
+            output_path=output_path, years=years, start_year=MIN_YEAR, resume=resume
+        )
         self._download_lock = threading.Lock()
         self._check_connection(
             lambda: requests.head(URL_BASE_NEW, timeout=10), "IESO (new)"
@@ -97,11 +99,6 @@ class IesoDownloader(EnergyDownloader):
             DataStructureError: If the data structure changed and relevant columns are now
                 missing (this will cause the entire run to be killed).
         """
-        if task.year < MIN_YEAR:
-            raise MissingDataError(
-                f"No energy data for year {task.year} (it's before {MIN_YEAR}). Skipping..."
-            )
-
         if task.year < 2019 or (task.year == 2019 and task.month <= 4):
             df = self._get_from_old_source(task)
         else:

--- a/rbc/energy/ieso/downloader.py
+++ b/rbc/energy/ieso/downloader.py
@@ -21,8 +21,8 @@ from rbc.energy.utils import (
     load_df_from_file,
 )
 
-URL_NEW_BASE = "https://reports-public.ieso.ca/public/GenOutputCapabilityMonth"
-URL_OLD_BASE = "https://www.ieso.ca"
+URL_BASE_NEW = "https://reports-public.ieso.ca/public/GenOutputCapabilityMonth"
+URL_BASE_OLD = "https://www.ieso.ca"
 
 MIN_YEAR = 2010
 EXPECTED_COLS = ["Delivery Date", "Generator", "Fuel Type", "Measurement"] + [
@@ -56,16 +56,14 @@ class IesoDownloader(EnergyDownloader):
         """
         super().__init__(output_path=output_path, years=years, resume=resume)
         self._download_lock = threading.Lock()
+        self._check_connection(
+            lambda: requests.head(URL_BASE_NEW, timeout=10), "IESO (new)"
+        )
+        self._check_connection(
+            lambda: requests.head(URL_BASE_OLD, timeout=10), "IESO (old)"
+        )
 
         logger.info(f"IESO Downloader initialized for:\n- years:\t\t{years}")
-
-        try:
-            for url in [URL_NEW_BASE, URL_OLD_BASE]:
-                requests.head(url, timeout=10).raise_for_status()
-
-        except Exception as e:
-            logger.error("Initialization IESO connectivity check failed!")
-            raise ConnectionError(f"One or more IESO endpoints are unreachable: {e}")
 
     def download_data(self) -> None:
         """Parse data for all given years from IESO site and save to CSV."""
@@ -136,7 +134,7 @@ class IesoDownloader(EnergyDownloader):
         Raises:
             DataStructureError: If downloaded data does not have the 'Measurement' column.
         """
-        url = f"{URL_NEW_BASE}/PUB_GenOutputCapabilityMonth_{task.year}{str(task.month).zfill(2)}.csv"
+        url = f"{URL_BASE_NEW}/PUB_GenOutputCapabilityMonth_{task.year}{str(task.month).zfill(2)}.csv"
         df = load_df_from_file(url, header=3, index_col=False)
 
         try:
@@ -160,7 +158,7 @@ class IesoDownloader(EnergyDownloader):
         Raises:
             DataStructureError: If 'Delivery Date' column data is not datetime-like.
         """
-        url = f"{URL_OLD_BASE}/-/media/Files/IESO/Power-Data/data-directory/GOC-{task.year}"
+        url = f"{URL_BASE_OLD}/-/media/Files/IESO/Power-Data/data-directory/GOC-{task.year}"
         url += "-Jan-April.xlsx" if task.year == 2019 else ".xlsx"
 
         with self._download_lock:

--- a/rbc/energy/ons/__init__.py
+++ b/rbc/energy/ons/__init__.py
@@ -1,0 +1,3 @@
+from rbc.energy.ons.downloader import OnsDownloader
+
+__all__ = ["OnsDownloader"]

--- a/rbc/energy/ons/downloader.py
+++ b/rbc/energy/ons/downloader.py
@@ -24,7 +24,7 @@ from rbc.energy.utils import (
 URL_BASE = "https://ons-aws-prod-opendata.s3.amazonaws.com/dataset/geracao_usina_2_ho/"
 
 MIN_YEAR = 2000
-EXPECTED_COLS = {
+EXPECTED_COLS_MAPPING = {
     "din_instante": "datetime",
     "id_subsistema": "subsystem_id",
     "nom_subsistema": "subsystem_name",
@@ -91,7 +91,7 @@ class OnsDownloader(EnergyDownloader):
             task (DownloadTask): The metadata of a downloading task, here: date (YYYY-MM)
 
         Returns:
-            pd.DataFrame: Dataframe for specific date with the columns as per EXPECTED_COLS
+            pd.DataFrame: Dataframe for specific date with the columns as per EXPECTED_COLS_MAPPING
                 (English translated versions as column headers).
 
         Raises:
@@ -115,14 +115,14 @@ class OnsDownloader(EnergyDownloader):
                 f"No energy data available for {task.year}-{task.month}. Skipping..."
             )
 
-        missing_cols = [c for c in EXPECTED_COLS.keys() if c not in df.columns]
+        missing_cols = [c for c in EXPECTED_COLS_MAPPING.keys() if c not in df.columns]
         if missing_cols:
             raise DataStructureError(
                 f"ONS file structure change detected for '{task.identifier}'! "
                 f"Missing columns: {missing_cols}"
             )
 
-        df = df.rename(columns=EXPECTED_COLS)
+        df = df.rename(columns=EXPECTED_COLS_MAPPING)
         return df
 
     @staticmethod

--- a/rbc/energy/ons/downloader.py
+++ b/rbc/energy/ons/downloader.py
@@ -112,7 +112,7 @@ class OnsDownloader(EnergyDownloader):
                 f"No energy data available for {task.year}-{task.month}. Skipping..."
             )
 
-        missing_cols = [c for c in EXPECTED_COLS_MAPPING.keys() if c not in df.columns]
+        missing_cols = [c for c in EXPECTED_COLS_MAPPING if c not in df.columns]
         if missing_cols:
             raise DataStructureError(
                 f"ONS file structure change detected for '{task.identifier}'! "

--- a/rbc/energy/ons/downloader.py
+++ b/rbc/energy/ons/downloader.py
@@ -158,8 +158,9 @@ class OnsDownloader(EnergyDownloader):
         df_month = df_year[month_mask].copy()
         return df_month
 
-    @lru_cache(maxsize=1)
-    def _load_yearly_csv(self, url: str) -> pd.DataFrame:
+    @staticmethod
+    @lru_cache(maxsize=None)
+    def _load_yearly_csv(url: str) -> pd.DataFrame:
         """Downloads the yearly CSV and ensures datetime column has datetime-like values.
 
         Args:

--- a/rbc/energy/ons/downloader.py
+++ b/rbc/energy/ons/downloader.py
@@ -21,7 +21,6 @@ from rbc.energy.utils import (
     load_df_from_file,
 )
 
-# URL_HOMEPAGE = "https://dados.ons.org.br/dataset/geracao-usina-2"
 URL_BASE = "https://ons-aws-prod-opendata.s3.amazonaws.com/dataset/geracao_usina_2_ho/"
 
 MIN_YEAR = 2000
@@ -67,15 +66,9 @@ class OnsDownloader(EnergyDownloader):
         """
         super().__init__(output_path=output_path, years=years, resume=resume)
         self._download_lock = threading.Lock()
+        self._check_connection(lambda: requests.head(URL_BASE, timeout=10), "ONS")
 
         logger.info(f"ONS Downloader initialized for:\n- years:\t\t{years}")
-
-        try:
-            requests.head(URL_BASE, timeout=10).raise_for_status()
-
-        except Exception as e:
-            logger.error("Initialization ONS connectivity check failed!")
-            raise ConnectionError(f"ONS endpoint is unreachable: {e}")
 
     def download_data(self) -> None:
         """Parse data for all given years from ONS site and save to CSV."""

--- a/rbc/energy/ons/downloader.py
+++ b/rbc/energy/ons/downloader.py
@@ -147,9 +147,6 @@ class OnsDownloader(EnergyDownloader):
 
         Returns:
             pd.DataFrame: Dataframe for a desired month.
-
-        Raises:
-            DataStructureError: If 'din_instante' column data is not datetime-like.
         """
         url = f"{URL_BASE}GERACAO_USINA-2_{task.year}.csv"
 
@@ -157,15 +154,9 @@ class OnsDownloader(EnergyDownloader):
             df_year = self._load_yearly_csv(url)
 
         # filter for the specific month
-        try:
-            month_mask = (df_year["din_instante"].dt.year == task.year) & (
-                df_year["din_instante"].dt.month == task.month
-            )
-        except ValueError as e:
-            raise DataStructureError(
-                f"ONS file structure change detected in yearly csv '{url}'! "
-                f"'din_instante' is no longer datetimelike: {e}"
-            )
+        month_mask = (df_year["din_instante"].dt.year == task.year) & (
+            df_year["din_instante"].dt.month == task.month
+        )
 
         df_month = df_year[month_mask].copy()
         return df_month
@@ -181,7 +172,8 @@ class OnsDownloader(EnergyDownloader):
             pd.DataFrame: Dataframe for the desired year.
 
         Raises:
-            DataStructureError: If downloaded data does not have the 'din_instante' column.
+            DataStructureError: If downloaded data does not have the 'din_instante' column
+                or the data in the column cannot be converted to datetime-like values.
         """
         df = load_df_from_file(url, delimiter=";")
         try:
@@ -191,5 +183,9 @@ class OnsDownloader(EnergyDownloader):
                 f"ONS file structure change detected for '{url}'! "
                 f"Missing datetime column 'din_instante'"
             )
-
+        except ValueError as e:  # if to_datetime raises DateParseError
+            raise DataStructureError(
+                f"ONS file structure change detected for '{url}'! "
+                f"'din_instante' is no longer datetimelike: {e}"
+            )
         return df

--- a/rbc/energy/ons/downloader.py
+++ b/rbc/energy/ons/downloader.py
@@ -1,0 +1,203 @@
+"""ONS DATA DOWNLOADER.
+
+Access of ONS website and their CSV files using pandas' load functionality.
+"""
+
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from functools import lru_cache
+from pathlib import Path
+
+import pandas as pd
+import requests
+from loguru import logger
+
+from rbc.energy.utils import (
+    WORKERS,
+    DataStructureError,
+    DownloadTask,
+    EnergyDownloader,
+    MissingDataError,
+    load_df_from_file,
+)
+
+# URL_HOMEPAGE = "https://dados.ons.org.br/dataset/geracao-usina-2"
+URL_BASE = "https://ons-aws-prod-opendata.s3.amazonaws.com/dataset/geracao_usina_2_ho/"
+
+MIN_YEAR = 2000
+EXPECTED_COLS = {
+    "din_instante": "reference_datetime",
+    "id_subsistema": "subsystem_id",
+    "nom_subsistema": "subsystem_name",
+    "id_estado": "state_id",
+    "nom_estado": "state_name",
+    "cod_modalidadeoperacao": "operation_mode",
+    "nom_tipousina": "plant_type",
+    "nom_tipocombustivel": "fuel_type",
+    "nom_usina": "plant_name",
+    "id_ons": "ons_id",
+    "ceg": "generation_project_code",
+    "val_geracao": "generation_MWmed",
+}
+
+
+class OnsDownloader(EnergyDownloader):
+    """ONS data downloader.
+
+    Attributes:
+        _download_lock (threading.Lock): Lock for downloading yearly data once.
+    """
+
+    def __init__(
+        self,
+        output_path: Path,
+        years: list[int],
+        resume: bool = True,
+    ) -> None:
+        """Initializes the instance.
+
+        Args:
+            output_path (Path): Path to the output directory.
+            years (list[int]): List of years to get data for.
+            resume (bool, optional): Whether to resume from a previous download (True)
+                or start from scratch (False). Defaults to True.
+
+        Raises:
+            ConnectionError: If the base URL isn't reachable.
+        """
+        super().__init__(output_path=output_path, years=years, resume=resume)
+        self._download_lock = threading.Lock()
+
+        logger.info(f"ONS Downloader initialized for:\n- years:\t\t{years}")
+
+        try:
+            requests.head(URL_BASE, timeout=10).raise_for_status()
+
+        except Exception as e:
+            logger.error("Initialization ONS connectivity check failed!")
+            raise ConnectionError(f"ONS endpoint is unreachable: {e}")
+
+    def download_data(self) -> None:
+        """Parse data for all given years from ONS site and save to CSV."""
+        tasks = [DownloadTask(date=d) for d in self._get_month_list()]
+
+        logger.info(
+            f"Downloading tasks: {tasks[0].identifier} --- {tasks[-1].identifier}"
+        )
+        with ThreadPoolExecutor(max_workers=WORKERS) as executor:
+            executor.map(self._threading_wrapper, tasks)
+
+    def _get_task_data(self, task: DownloadTask) -> pd.DataFrame:  # type: ignore[override]
+        """Get ONS generation data per plant for one specific month.
+
+        ONS's data storing structure and method was changed in 2022 from
+        storing in yearly CSV and Excel files (old) to monthly CSV and Excel files (new).
+        The data structure itself (column headers) have remained the same throughout.
+
+        Args:
+            task (DownloadTask): The metadata of a downloading task, here: date (YYYY-MM)
+
+        Returns:
+            pd.DataFrame: Dataframe for specific date with the columns as per EXPECTED_COLS
+                (English translated versions as column headers).
+
+        Raises:
+            MissingDataError: If an earlier year was provided than data exists for or if the
+                dataframe is empty.
+            DataStructureError: If the data structure changed and relevant columns are now
+                missing (this will cause the entire run to be killed).
+        """
+        if task.year < MIN_YEAR:
+            raise MissingDataError(
+                f"No energy data for year {task.year} (it's before {MIN_YEAR}). Skipping..."
+            )
+
+        if task.year < 2022:
+            df = self._get_from_yearly_csv(task)
+        else:
+            df = self._get_from_monthly_csv(task.year, task.month)
+
+        if df.empty:
+            raise MissingDataError(
+                f"No energy data available for {task.year}-{task.month}. Skipping..."
+            )
+
+        missing_cols = [c for c in EXPECTED_COLS.keys() if c not in df.columns]
+        if missing_cols:
+            raise DataStructureError(
+                f"ONS file structure change detected for '{task.identifier}'! "
+                f"Missing columns: {missing_cols}"
+            )
+
+        df = df.rename(columns=EXPECTED_COLS)
+        return df
+
+    @staticmethod
+    def _get_from_monthly_csv(year: int, month: int) -> pd.DataFrame:
+        """Extract data from 2022 onwards for a given month.
+
+        Args:
+            year (int): Year to extract data for.
+            month (int): Month to extract data for.
+
+        Returns:
+            pd.DataFrame: Dataframe for a desired month.
+        """
+        url = f"{URL_BASE}GERACAO_USINA-2_{year}_{str(month).zfill(2)}.csv"
+        df = load_df_from_file(url, delimiter=";")
+        return df
+
+    def _get_from_yearly_csv(self, task: DownloadTask) -> pd.DataFrame:
+        """Extract data from before 2022 for a given month using the year's CSV.
+
+        Args:
+            task (DownloadTask): The metadata of a downloading task, here: date (YYYY-MM)
+
+        Returns:
+            pd.DataFrame: Dataframe for a desired month.
+
+        Raises:
+            DataStructureError: If 'din_instante' column data is not datetime-like.
+        """
+        url = f"{URL_BASE}GERACAO_USINA-2_{task.year}.csv"
+
+        with self._download_lock:
+            df_year = self._load_yearly_csv(url)
+
+        # filter for the specific month
+        try:
+            month_mask = (df_year["din_instante"].dt.year == task.year) & (
+                df_year["din_instante"].dt.month == task.month
+            )
+        except ValueError as e:
+            raise DataStructureError(
+                f"ONS file structure change detected in yearly csv '{url}'! "
+                f"'din_instante' is no longer datetimelike: {e}"
+            )
+
+        df_month = df_year[month_mask].copy()
+        return df_month
+
+    @lru_cache(maxsize=1)
+    def _load_yearly_csv(self, url: str) -> pd.DataFrame:
+        """Downloads the yearly CSV and ensures datetime column has datetime-like values.
+
+        Args:
+            url (str): URL to download data from.
+
+        Returns:
+            pd.DataFrame: Dataframe for the desired year.
+
+        Raises:
+            DataStructureError: If downloaded data does not have the 'din_instante' column.
+        """
+        df = load_df_from_file(url, delimiter=";")
+        try:
+            df["din_instante"] = pd.to_datetime(df["din_instante"])
+        except KeyError:
+            raise DataStructureError(
+                f"ONS file structure change detected for '{url}'! "
+                f"Missing datetime column 'din_instante'"
+            )
+
+        return df

--- a/rbc/energy/ons/downloader.py
+++ b/rbc/energy/ons/downloader.py
@@ -64,7 +64,9 @@ class OnsDownloader(EnergyDownloader):
         Raises:
             ConnectionError: If the base URL isn't reachable.
         """
-        super().__init__(output_path=output_path, years=years, resume=resume)
+        super().__init__(
+            output_path=output_path, years=years, start_year=MIN_YEAR, resume=resume
+        )
         self._download_lock = threading.Lock()
         self._check_connection(lambda: requests.head(URL_BASE, timeout=10), "ONS")
 
@@ -100,11 +102,6 @@ class OnsDownloader(EnergyDownloader):
             DataStructureError: If the data structure changed and relevant columns are now
                 missing (this will cause the entire run to be killed).
         """
-        if task.year < MIN_YEAR:
-            raise MissingDataError(
-                f"No energy data for year {task.year} (it's before {MIN_YEAR}). Skipping..."
-            )
-
         if task.year < 2022:
             df = self._get_from_yearly_csv(task)
         else:

--- a/rbc/energy/ons/downloader.py
+++ b/rbc/energy/ons/downloader.py
@@ -108,7 +108,7 @@ class OnsDownloader(EnergyDownloader):
         if task.year < 2022:
             df = self._get_from_yearly_csv(task)
         else:
-            df = self._get_from_monthly_csv(task.year, task.month)
+            df = self._get_from_monthly_csv(task)
 
         if df.empty:
             raise MissingDataError(
@@ -126,17 +126,16 @@ class OnsDownloader(EnergyDownloader):
         return df
 
     @staticmethod
-    def _get_from_monthly_csv(year: int, month: int) -> pd.DataFrame:
+    def _get_from_monthly_csv(task: DownloadTask) -> pd.DataFrame:
         """Extract data from 2022 onwards for a given month.
 
         Args:
-            year (int): Year to extract data for.
-            month (int): Month to extract data for.
+            task (DownloadTask): The metadata of a downloading task, here: date (YYYY-MM)
 
         Returns:
             pd.DataFrame: Dataframe for a desired month.
         """
-        url = f"{URL_BASE}GERACAO_USINA-2_{year}_{str(month).zfill(2)}.csv"
+        url = f"{URL_BASE}GERACAO_USINA-2_{task.year}_{str(task.month).zfill(2)}.csv"
         df = load_df_from_file(url, delimiter=";")
         return df
 

--- a/rbc/energy/ons/downloader.py
+++ b/rbc/energy/ons/downloader.py
@@ -26,7 +26,7 @@ URL_BASE = "https://ons-aws-prod-opendata.s3.amazonaws.com/dataset/geracao_usina
 
 MIN_YEAR = 2000
 EXPECTED_COLS = {
-    "din_instante": "reference_datetime",
+    "din_instante": "datetime",
     "id_subsistema": "subsystem_id",
     "nom_subsistema": "subsystem_name",
     "id_estado": "state_id",

--- a/rbc/energy/utils.py
+++ b/rbc/energy/utils.py
@@ -160,7 +160,12 @@ class DownloadTask:
 
 
 class EnergyDownloader(ABC):
-    """Abstract base class for parallelized daily energy downloader classes.
+    """Abstract base class for parallelized energy downloader classes.
+
+    This class coordinates and parallelizes the energy data crawling task execution.
+    Subclasses must all overwrite the abstract `_get_task_data` method.
+    Error catching in downloading, checkpoint loading/saving, and common attributes are
+    handled here.
 
     Attributes:
         RETRY_ERRORS (tuple): Tuple of exceptions that may be raised when retrying calls.
@@ -306,24 +311,20 @@ class EnergyDownloader(ABC):
         """Load checkpoint from checkpoint path depending on resume logic.
 
         Returns:
-            dict: Loaded checkpoint.
+            dict: Loaded checkpoint or empty dict (if no checkpoint exists).
         """
         if self.resume and self.checkpoint_path.is_file():
-            logger.info(f"Loading checkpoint from '{self.checkpoint_path}'")
+            logger.info(f"Resuming from checkpoint: '{self.checkpoint_path}'")
 
             try:
                 with open(self.checkpoint_path, "rb") as f:
                     return pickle.load(f)
             except (EOFError, pickle.UnpicklingError):
-                logger.warning(
-                    f"Checkpoint '{self.checkpoint_path}' is corrupted. Starting fresh."
-                )
+                logger.warning("Checkpoint file is corrupted. Starting fresh.")
                 return {}
-        else:
-            logger.info(
-                "No checkpoint loading (first run or resume=False). Starting fresh."
-            )
-            return {}
+
+        logger.info("No checkpoint (first run or resume=False). Starting fresh.")
+        return {}
 
     def _save_checkpoint(self) -> None:
         """Save checkpoint safely (ensure abrupt terminations don't corrupt the file)."""

--- a/rbc/energy/utils.py
+++ b/rbc/energy/utils.py
@@ -12,6 +12,7 @@ import urllib
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field, replace
 from pathlib import Path
+from typing import Callable
 
 import pandas as pd
 import requests
@@ -354,6 +355,46 @@ class EnergyDownloader(ABC):
     # --------------------------------------------
     # General helper methods
     # --------------------------------------------
+    @staticmethod
+    def _check_connection(
+        requests_func: Callable[[], requests.Response], source: str
+    ) -> None:
+        """Check API/URL connection to a remote endpoint with a generic wrapper using requests.
+
+        Args:
+            requests_func (Callable): Function to check the requests call response.
+            source (str): Name of the data source (for error messages).
+
+        Raises:
+            ConnectionError: If access to remote site failed or remote site is unreachable.
+        """
+        try:
+            response = requests_func()
+            response.raise_for_status()
+
+        except requests.exceptions.HTTPError as e:  # catch 4xx/5xx status codes
+            if response.content:
+                try:
+                    reason = (
+                        response.json().get("error", {}).get("code", "Unknown Error")
+                    )
+                except (requests.exceptions.JSONDecodeError, ValueError):
+                    reason = response.text[:100]  # fallback to raw text snippet
+                error_msg = f"status {response.status_code} ({reason})"
+            elif response.reason:
+                error_msg = f"status {response.status_code} ({response.reason})"
+            else:
+                error_msg = f"status {response.status_code} (Empty Response)"
+
+            logger.error(f"{source} API/URL request failed with {error_msg}")
+            raise ConnectionError(
+                f"{source} API/URL access failed with {error_msg}"
+            ) from e
+
+        except requests.exceptions.RequestException as e:  # catch connection/timeout/..
+            logger.error(f"{source} initialization connectivity check failed!")
+            raise ConnectionError(f"{source} API/URL unreachable: {e}") from e
+
     @staticmethod
     def _get_status_code(e: Exception) -> int | None:
         """Extracts HTTP status code from various library exceptions.

--- a/rbc/energy/utils.py
+++ b/rbc/energy/utils.py
@@ -170,32 +170,52 @@ class EnergyDownloader(ABC):
     Attributes:
         RETRY_ERRORS (tuple): Tuple of exceptions that may be raised when retrying calls.
         output_path (Path): Path to the output directory.
-        years (list[int]): List of years to get data for.
         resume (bool, optional): Whether to resume from a previous download (True) or
             start from scratch (False). Defaults to True.
         _lock (threading.Lock): Threading lock to ensure thread-safe checkpoint updates.
         checkpoint_path (Path): Path to the checkpoint file for resuming.
         checkpoint (dict): Dict of 0 and 1 values for resuming.
+        today (pd.Timestamp): Timestamp for today's date.
+        years (list[int]): List of years to get data for.
     """
 
     RETRY_ERRORS = RETRY_ERRORS
 
-    def __init__(self, output_path: Path, years: list[int], resume: bool = True):
+    def __init__(
+        self,
+        output_path: Path,
+        years: list[int],
+        start_year: int | None = None,
+        resume: bool = True,
+    ) -> None:
         """Initializes the instance.
 
         Args:
             output_path (Path): Path to the output directory.
             years (list[int]): List of years to get data for.
+            start_year (int | None): Earliest valid year for this data source. If provided,
+                years before this value are silently filtered out and a warning is logged.
             resume (bool, optional): Whether to resume from a previous download (True)
                 or start from scratch (False). Defaults to True.
         """
         self.output_path = output_path
-        self.years = years
         self.resume = resume
         self._lock = threading.Lock()
-
         self.checkpoint_path = Path(self.output_path, "status.pickle")
         self.checkpoint = self._load_checkpoint()
+        self.today = pd.Timestamp.now()
+
+        if start_year is not None:
+            filtered_years = [y for y in years if start_year <= y <= self.today.year]
+            invalid_years = [y for y in years if y not in filtered_years]
+            if invalid_years:
+                logger.info(
+                    f"Filtering out {len(invalid_years)} year(s) outside the valid range "
+                    f"[{start_year}, {self.today.year}]: {invalid_years}"
+                )
+            years = filtered_years
+
+        self.years = years
 
     def _threading_wrapper(self, task: DownloadTask) -> None:
         """Thread-safe wrapper for one download task (download and checkpoint reading/saving).
@@ -421,9 +441,9 @@ class EnergyDownloader(ABC):
         Returns:
             list[str]: List of all valid dates, formatted as YYYY-MM-DD.
         """
-        yesterday = (pd.Timestamp.now() - pd.Timedelta(days=1)).normalize()
-
+        yesterday = (self.today - pd.Timedelta(days=1)).normalize()
         all_dates = []
+
         for year in self.years:
             year_start = pd.Timestamp(f"{year}-01-01")
             year_end = pd.Timestamp(f"{year}-12-31")
@@ -440,7 +460,9 @@ class EnergyDownloader(ABC):
             )
 
         if not all_dates:
-            raise InvalidError(f"Provided years '{self.years}' lie in the future!")
+            raise InvalidError(
+                f"No valid dates for year(s) {self.years} (only up to {yesterday.date()})."
+            )
 
         return all_dates
 

--- a/scripts/energy/ons_download.py
+++ b/scripts/energy/ons_download.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python
+"""ONS DATA DOWNLOAD SCRIPT.
+
+Download data from ONS website for Brazil.
+"""
+
+from argparse import ArgumentParser, Namespace
+from datetime import datetime
+
+from loguru import logger
+
+from rbc.config.loader import load_config, parse_key_value_pairs
+from rbc.energy.ons import OnsDownloader
+from rbc.energy.ons.downloader import MIN_YEAR
+from rbc.utils import setup_logging
+
+SOURCE = "ons"
+
+
+def parse_arguments() -> Namespace:
+    """Parse command line arguments.
+
+    Returns:
+        argparse.Namespace: Namespace parsed command line arguments.
+    """
+    parser = ArgumentParser(prog="ONS data download")
+    parser.add_argument(
+        "-y",
+        "--years",
+        nargs="+",
+        type=int,
+        default=list(range(MIN_YEAR, datetime.now().year + 1)),  # available years
+        help=f"Years to download. Example: -y 2020 2021. "
+        f"Default: {list(range(MIN_YEAR, datetime.now().year + 1))}",
+    )
+    parser.add_argument(
+        "--no-resume",
+        dest="resume",
+        action="store_false",
+        help="Do not resume download from a previous checkpoint.",
+    )
+    parser.set_defaults(resume=True)
+    parser.add_argument(
+        "-o",
+        "--cfg_options",
+        action="append",
+        help="Override YAML config values (supports nested keys). "
+        "Example: -o paths.dst_dir_raw=/your/path/",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    """Coordinating ONS data download."""
+    args = parse_arguments()
+    overrides = parse_key_value_pairs(args.cfg_options) if args.cfg_options else None
+
+    cfg = load_config(source=SOURCE, overrides=overrides)
+    setup_logging(output_dir=cfg.paths.dst_dir_raw)
+    logger.info(f"Flags for the '{SOURCE}' download:\n{args}")
+    logger.info(f"Config for the '{SOURCE}' download:\n{cfg}")
+
+    downloader = OnsDownloader(
+        output_path=cfg.paths.dst_dir_raw,
+        years=args.years,
+        resume=args.resume,
+    )
+    downloader.download_data()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/config/conftest.py
+++ b/tests/config/conftest.py
@@ -34,6 +34,7 @@ def source_configs(tmp_path: Path) -> dict:
             "access": {"username": "name", "password": "pw"},
         },
         "ieso": {"paths": {"dst_dir_raw": str(Path(tmp_path, "ieso"))}},
+        "ons": {"paths": {"dst_dir_raw": str(Path(tmp_path, "ons"))}},
         "barra2": {
             "paths": {"dst_dir_raw": str(Path(tmp_path, "barra2"))},
         },

--- a/tests/energy/aeso/test_downloader.py
+++ b/tests/energy/aeso/test_downloader.py
@@ -154,18 +154,16 @@ def test_downloader_initialization_invalid_tres(init_args: dict) -> None:
         AesoDownloader(**args)
 
 
-def test_downloader_initialization_invalid_request(init_args: dict) -> None:
+def test_downloader_initialization_invalid_access(init_args: dict) -> None:
     """Failure path for class initialization with invalid request.
 
     Args:
         init_args (dict): Arguments used to initialize an AesoDownloader instance.
     """
     with patch("rbc.energy.aeso.downloader.requests.get") as mock_get:
-        mock_get.return_value.raise_for_status.side_effect = exceptions.HTTPError("404")
+        mock_get.return_value.raise_for_status.side_effect = exceptions.HTTPError(404)
 
-        with pytest.raises(
-            ConnectionError, match="AESO box cloud storage is unreachable"
-        ):
+        with pytest.raises(ConnectionError, match="AESO API/URL access failed"):
             AesoDownloader(**init_args)
 
 

--- a/tests/energy/aeso/test_downloader.py
+++ b/tests/energy/aeso/test_downloader.py
@@ -32,7 +32,7 @@ def init_args(tmp_path: Path) -> dict:
         tmp_path (Path): Path to the temporary directory.
 
     Returns:
-        dict: Initialisation arguments.
+        dict: initialization arguments.
     """
     return {
         "token": "fake_token",

--- a/tests/energy/eat/test_downloader.py
+++ b/tests/energy/eat/test_downloader.py
@@ -103,18 +103,16 @@ def test_downloader_initialization(downloader: EatDownloader, init_args: dict) -
     assert downloader.checkpoint == {}
 
 
-def test_downloader_initialization_invalid_url(init_args: dict) -> None:
+def test_downloader_initialization_invalid_access(init_args: dict) -> None:
     """Failure path for class initialization with invalid URL.
 
     Args:
         init_args (dict): Arguments used to initialize an EatDownloader instance.
     """
     with patch("rbc.energy.eat.downloader.requests.head") as mock_head:
-        mock_head.return_value.raise_for_status.side_effect = exceptions.HTTPError(
-            "404"
-        )
+        mock_head.return_value.raise_for_status.side_effect = exceptions.HTTPError(404)
 
-        with pytest.raises(ConnectionError, match="EAT endpoint"):
+        with pytest.raises(ConnectionError, match="EAT API/URL access failed"):
             EatDownloader(**init_args)
 
 

--- a/tests/energy/eat/test_downloader.py
+++ b/tests/energy/eat/test_downloader.py
@@ -10,7 +10,7 @@ import pytest
 from requests import exceptions
 
 from rbc.energy.eat import EatDownloader
-from rbc.energy.eat.downloader import EXPECTED_COLS, MIN_YEAR
+from rbc.energy.eat.downloader import EXPECTED_COLS
 from rbc.energy.utils import DataStructureError, DownloadTask, MissingDataError
 
 
@@ -25,7 +25,7 @@ def init_args(tmp_path: Path) -> dict:
         tmp_path (Path): Path to the temporary directory.
 
     Returns:
-        dict: Initialisation arguments.
+        dict: initialization arguments.
     """
     return {
         "output_path": tmp_path,
@@ -192,20 +192,6 @@ def test_get_task_data(downloader: EatDownloader, task: DownloadTask) -> None:
     assert df.iloc[0]["site_code"] == "mock_value"
     assert df.iloc[0]["tp1"] == "10"
     assert mock_load.call_count == 1
-
-
-def test_get_task_data_no_data_for_old_year(downloader: EatDownloader) -> None:
-    """Failure path for "_get_task_data" method when a task before MIN_YEAR is provided.
-
-    Args:
-        downloader (EatDownloader): Instance of EatDownloader class.
-    """
-    old_year_task = DownloadTask(date=f"{MIN_YEAR - 1}-01")
-    mock_df = pd.DataFrame(columns=EXPECTED_COLS)
-
-    with patch("rbc.energy.eat.downloader.load_df_from_file", return_value=mock_df):
-        with pytest.raises(MissingDataError, match="No energy data for year"):
-            downloader._get_task_data(old_year_task)
 
 
 def test_get_task_data_no_generation_data(

--- a/tests/energy/eia/test_downloader.py
+++ b/tests/energy/eia/test_downloader.py
@@ -15,7 +15,6 @@ from rbc.energy.utils import (
     MAX_RATE_LIMIT_RETRIES,
     DataStructureError,
     DownloadTask,
-    InvalidError,
     MissingDataError,
     RateLimitError,
 )
@@ -127,16 +126,16 @@ def test_downloader_initialization(downloader: EiaDownloader, init_args: dict) -
     assert downloader.checkpoint == {}
 
 
-def test_downloader_initialization_invalid_token(init_args: dict) -> None:
+def test_downloader_initialization_invalid_access(init_args: dict) -> None:
     """Failure path for class initialization with invalid token.
 
     Args:
         init_args (dict): Arguments used to initialize an EiaDownloader instance.
     """
     with patch("rbc.energy.eia.downloader.requests.get") as mock_get:
-        mock_get.return_value = MagicMock(status_code=400)
+        mock_get.return_value.raise_for_status.side_effect = exceptions.HTTPError(404)
 
-        with pytest.raises(InvalidError, match="incorrect"):
+        with pytest.raises(ConnectionError, match="EIA API/URL access failed"):
             EiaDownloader(**init_args)
 
 

--- a/tests/energy/eia/test_downloader.py
+++ b/tests/energy/eia/test_downloader.py
@@ -10,7 +10,6 @@ import pytest
 from requests import exceptions
 
 from rbc.energy.eia import EiaDownloader
-from rbc.energy.eia.downloader import EXPECTED_COLS, MIN_YEAR
 from rbc.energy.utils import (
     MAX_RATE_LIMIT_RETRIES,
     DataStructureError,
@@ -31,7 +30,7 @@ def init_args(tmp_path: Path) -> dict:
         tmp_path (Path): Path to the temporary directory.
 
     Returns:
-        dict: Initialisation arguments.
+        dict: initialization arguments.
     """
     return {
         "token": "fake_token",
@@ -318,20 +317,6 @@ def test_get_task_data_incomplete_download(
 
         with pytest.raises(ConnectionError, match="Incomplete download"):
             downloader._get_task_data(task)
-
-
-def test_get_task_data_no_data_for_old_year(downloader: EiaDownloader) -> None:
-    """Failure path for "_get_task_data" method when a task before MIN_YEAR is provided.
-
-    Args:
-        downloader (EiaDownloader): Instance of EiaDownloader class.
-    """
-    old_year_task = DownloadTask(date=f"{MIN_YEAR - 1}-01")
-    mock_df = pd.DataFrame(columns=EXPECTED_COLS)
-
-    with patch("rbc.energy.eat.downloader.load_df_from_file", return_value=mock_df):
-        with pytest.raises(MissingDataError, match="No energy data for year"):
-            downloader._get_task_data(old_year_task)
 
 
 def test_get_task_data_no_generation_data(

--- a/tests/energy/entsoe/test_downloader.py
+++ b/tests/energy/entsoe/test_downloader.py
@@ -29,7 +29,7 @@ def init_args(tmp_path: Path) -> dict:
         tmp_path (Path): Path to the temporary directory.
 
     Returns:
-        dict: Initialisation arguments.
+        dict: initialization arguments.
     """
     return {
         "token": "fake_token",

--- a/tests/energy/entsoe/test_downloader.py
+++ b/tests/energy/entsoe/test_downloader.py
@@ -105,7 +105,7 @@ def test_downloader_initialization(init_args: dict, bz: str, valid: bool) -> Non
         assert downloader.checkpoint == {}
 
 
-def test_downloader_initialization_invalid_config(init_args: dict) -> None:
+def test_downloader_initialization_invalid_credentials(init_args: dict) -> None:
     """Failure path for class initialization with invalid API configuration.
 
     Args:

--- a/tests/energy/epias/test_downloader.py
+++ b/tests/energy/epias/test_downloader.py
@@ -9,7 +9,7 @@ import pandas as pd
 import pytest
 
 from rbc.energy.epias import EpiasDownloader
-from rbc.energy.epias.downloader import EXPECTED_COLS, MIN_YEAR
+from rbc.energy.epias.downloader import EXPECTED_COLS
 from rbc.energy.utils import (
     DataStructureError,
     DownloadTask,
@@ -29,7 +29,7 @@ def init_args(tmp_path: Path) -> dict:
         tmp_path (Path): Path to the temporary directory.
 
     Returns:
-        dict: Initialisation arguments.
+        dict: initialization arguments.
     """
     return {
         "username": "fake_username",
@@ -207,20 +207,6 @@ def test_get_task_data(downloader: EpiasDownloader, task: DownloadTask) -> None:
     assert not df.empty
     assert df.iloc[0]["date"] == task.date
     assert df.iloc[0]["total"] == 16.2
-
-
-def test_get_task_data_no_data_for_old_year(downloader: EpiasDownloader) -> None:
-    """Failure path for "_get_task_data" method when a task before MIN_YEAR is provided.
-
-    Args:
-        downloader (EpiasDownloader): Instance of EpiasDownloader class.
-    """
-    old_year_task = DownloadTask(date=f"{MIN_YEAR - 1}-01")
-    mock_df = pd.DataFrame(columns=EXPECTED_COLS)
-
-    with patch("rbc.energy.eat.downloader.load_df_from_file", return_value=mock_df):
-        with pytest.raises(MissingDataError, match="No energy data for year"):
-            downloader._get_task_data(old_year_task)
 
 
 @pytest.mark.parametrize(

--- a/tests/energy/ieso/test_downloader.py
+++ b/tests/energy/ieso/test_downloader.py
@@ -283,7 +283,7 @@ def test_get_from_new_source(downloader: IesoDownloader, task: DownloadTask) -> 
     with patch(
         "rbc.energy.ieso.downloader.load_df_from_file", return_value=mock_df
     ) as mock_load:
-        df = downloader._get_from_new_source(year=task.year, month=task.month)
+        df = downloader._get_from_new_source(task=task)
 
         # check correct URL was created
         expected_url = f"{URL_NEW_BASE}/PUB_GenOutputCapabilityMonth_{task.year}{task.month:02d}.csv"
@@ -307,7 +307,7 @@ def test_get_from_new_source_missing_measurement(
 
     with patch("rbc.energy.ieso.downloader.load_df_from_file", return_value=mock_df):
         with pytest.raises(DataStructureError, match="'Measurement' column is missing"):
-            downloader._get_from_new_source(year=task.year, month=task.month)
+            downloader._get_from_new_source(task=task)
 
 
 @pytest.mark.parametrize(
@@ -336,7 +336,7 @@ def test_get_from_old_source(
     )
 
     with patch.object(downloader, "_load_yearly_excel", return_value=mock_df) as mock_f:
-        df = downloader._get_from_old_source(year=task.year, month=task.month)
+        df = downloader._get_from_old_source(task=task)
 
         # check correct URL was created
         expected_url = (
@@ -365,9 +365,9 @@ def test_lru_cache_works(downloader: IesoDownloader, task: DownloadTask) -> None
     with patch("rbc.energy.ieso.downloader.load_df_from_file") as mock_load:
         mock_load.side_effect = [mock_df, mock_df]
 
-        downloader._get_from_old_source(year=task.year, month=task.month)
-        downloader._get_from_old_source(year=task.year, month=task.month)
-        downloader._get_from_old_source(year=task.year, month=task.month)
+        downloader._get_from_old_source(task=task)
+        downloader._get_from_old_source(task=task)
+        downloader._get_from_old_source(task=task)
 
         # check method called 2x - both in _load_yearly_excel call in 1st _get_from_old_source
         assert mock_load.call_count == 2
@@ -386,7 +386,7 @@ def test_get_from_old_source_structure_changed(
         mock_load.return_value = pd.DataFrame({"Delivery Date": [f"{task.date}-01"]})
 
         with pytest.raises(DataStructureError, match="no longer datetimelike"):
-            downloader._get_from_old_source(year=task.year, month=task.month)
+            downloader._get_from_old_source(task=task)
 
 
 def test_load_yearly_excel(downloader: IesoDownloader, task: DownloadTask) -> None:

--- a/tests/energy/ieso/test_downloader.py
+++ b/tests/energy/ieso/test_downloader.py
@@ -12,7 +12,6 @@ from requests import exceptions
 from rbc.energy.ieso import IesoDownloader
 from rbc.energy.ieso.downloader import (
     EXPECTED_COLS,
-    MIN_YEAR,
     URL_BASE_NEW,
     URL_BASE_OLD,
 )
@@ -30,7 +29,7 @@ def init_args(tmp_path: Path) -> dict:
         tmp_path (Path): Path to the temporary directory.
 
     Returns:
-        dict: Initialisation arguments.
+        dict: initialization arguments.
     """
     return {
         "output_path": tmp_path,
@@ -213,21 +212,6 @@ def test_get_task_data(
     assert df.iloc[0]["Hour 1"] == "10"
     assert mock_old.call_count == expect_old
     assert mock_new.call_count == expect_new
-
-
-def test_get_task_data_no_data_for_old_year(downloader: IesoDownloader) -> None:
-    """Failure path for "_get_task_data" method when a task before MIN_YEAR is provided.
-
-    Args:
-        downloader (IesoDownloader): Instance of IesoDownloader class.
-    """
-    old_year_task = DownloadTask(date=f"{MIN_YEAR - 1}-01")
-    mock_df = pd.DataFrame(columns=EXPECTED_COLS)
-
-    with patch.object(downloader, "_get_from_old_source", return_value=mock_df):
-        with patch.object(downloader, "_get_from_new_source", return_value=mock_df):
-            with pytest.raises(MissingDataError, match="No energy data for year"):
-                downloader._get_task_data(old_year_task)
 
 
 def test_get_task_data_no_generation_data(

--- a/tests/energy/ieso/test_downloader.py
+++ b/tests/energy/ieso/test_downloader.py
@@ -13,8 +13,8 @@ from rbc.energy.ieso import IesoDownloader
 from rbc.energy.ieso.downloader import (
     EXPECTED_COLS,
     MIN_YEAR,
-    URL_NEW_BASE,
-    URL_OLD_BASE,
+    URL_BASE_NEW,
+    URL_BASE_OLD,
 )
 from rbc.energy.utils import DataStructureError, DownloadTask, MissingDataError
 
@@ -109,18 +109,16 @@ def test_downloader_initialization(downloader: IesoDownloader, init_args: dict) 
     assert downloader.checkpoint == {}
 
 
-def test_downloader_initialization_invalid_url(init_args: dict) -> None:
+def test_downloader_initialization_invalid_access(init_args: dict) -> None:
     """Failure path for class initialization with invalid URL.
 
     Args:
         init_args (dict): Arguments used to initialize an IesoDownloader instance.
     """
     with patch("rbc.energy.ieso.downloader.requests.head") as mock_head:
-        mock_head.return_value.raise_for_status.side_effect = exceptions.HTTPError(
-            "404"
-        )
+        mock_head.return_value.raise_for_status.side_effect = exceptions.HTTPError(404)
 
-        with pytest.raises(ConnectionError, match="One or more IESO endpoints"):
+        with pytest.raises(ConnectionError, match="API/URL access failed"):
             IesoDownloader(**init_args)
 
 
@@ -286,7 +284,7 @@ def test_get_from_new_source(downloader: IesoDownloader, task: DownloadTask) -> 
         df = downloader._get_from_new_source(task=task)
 
         # check correct URL was created
-        expected_url = f"{URL_NEW_BASE}/PUB_GenOutputCapabilityMonth_{task.year}{task.month:02d}.csv"
+        expected_url = f"{URL_BASE_NEW}/PUB_GenOutputCapabilityMonth_{task.year}{task.month:02d}.csv"
         mock_load.assert_called_with(expected_url, header=3, index_col=False)
 
         # check forecast data was filtered out
@@ -340,7 +338,7 @@ def test_get_from_old_source(
 
         # check correct URL was created
         expected_url = (
-            f"{URL_OLD_BASE}/-/media/Files/IESO/Power-Data/data-directory/GOC-{suffix}"
+            f"{URL_BASE_OLD}/-/media/Files/IESO/Power-Data/data-directory/GOC-{suffix}"
         )
         mock_f.assert_called_with(expected_url)
 

--- a/tests/energy/ieso/test_downloader.py
+++ b/tests/energy/ieso/test_downloader.py
@@ -374,7 +374,7 @@ def test_lru_cache_works(downloader: IesoDownloader, task: DownloadTask) -> None
 def test_get_from_old_source_structure_changed(
     downloader: IesoDownloader, task: DownloadTask
 ) -> None:
-    """Failure path for "_get_from_new_source" method when the URL is unavailable.
+    """Failure path for "_get_from_old_source" method when the dates aren't datetime-like.
 
     Args:
         downloader (IesoDownloader): Instance of IesoDownloader class.

--- a/tests/energy/ons/test_downloader.py
+++ b/tests/energy/ons/test_downloader.py
@@ -1,0 +1,388 @@
+# tests/energy/ons/test_downloader.py
+"""Tests for ONS energy data downloader."""
+
+import pickle
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+import pytest
+from requests import exceptions
+
+from rbc.energy.ons import OnsDownloader
+from rbc.energy.ons.downloader import EXPECTED_COLS, MIN_YEAR, URL_BASE
+from rbc.energy.utils import DataStructureError, DownloadTask, MissingDataError
+
+
+# ----------------------------------
+# Fixtures
+# ----------------------------------
+@pytest.fixture
+def init_args(tmp_path: Path) -> dict:
+    """Creates a basic setup with a temporary directory.
+
+    Args:
+        tmp_path (Path): Path to the temporary directory.
+
+    Returns:
+        dict: Initialisation arguments.
+    """
+    return {
+        "output_path": tmp_path,
+        "years": [2023],
+        "resume": False,
+    }
+
+
+@pytest.fixture
+def downloader(init_args: dict) -> OnsDownloader:
+    """Provides an OnsDownloader instance with a mocked, positive return code response.
+
+    Args:
+        init_args (dict): Arguments used to initialize an OnsDownloader instance.
+
+    Returns:
+        OnsDownloader: OnsDownloader instance.
+    """
+    with patch("rbc.energy.ons.downloader.requests.head") as mock_get:
+        mock_get.return_value = MagicMock(status_code=200)
+        return OnsDownloader(**init_args)
+
+
+@pytest.fixture
+def task(init_args: dict) -> DownloadTask:
+    """Gets a task as 'date=YYYY-MM' from the init arguments.
+
+    Args:
+        init_args (dict): Arguments used to initialize an OnsDownloader instance.
+
+    Returns:
+        DownloadTask: The metadata of a downloading task, here: date (YYYY-MM)
+    """
+    year = init_args["years"][0]
+    return DownloadTask(date=f"{year}-01")
+
+
+def get_mock_df(spec_task: DownloadTask) -> pd.DataFrame:
+    """Gets a mock dataframe for a specific task.
+
+    Args:
+        spec_task (DownloadTask): The metadata of a downloading task, here: date (YYYY-MM)
+
+    Returns:
+        pandas.DataFrame: Mock dataframe.
+    """
+    row: dict[str, object] = {c: ["A"] for c in EXPECTED_COLS.keys()}
+    row.update(
+        {
+            c: f"{spec_task.date}-01 00:00:00"
+            for c in EXPECTED_COLS.keys()
+            if "din_instante" in c
+        }
+    )
+    row.update({"val_geracao": 10.0})
+    return pd.DataFrame(row, index=[0])
+
+
+# ----------------------------------
+# Tests - Initialization
+# ----------------------------------
+def test_downloader_initialization(downloader: OnsDownloader, init_args: dict) -> None:
+    """Happy path for class initialization.
+
+    Check that the OnsDownloader sets up paths and checkpoint correctly.
+
+    Args:
+        downloader (OnsDownloader): Instance of OnsDownloader class.
+        init_args (dict): Arguments used to initialize an OnsDownloader instance.
+    """
+    assert downloader.years == init_args["years"]
+    assert downloader.output_path == init_args["output_path"]
+    assert downloader.checkpoint_path == Path(init_args["output_path"], "status.pickle")
+    assert downloader.checkpoint == {}
+
+
+def test_downloader_initialization_invalid_access(init_args: dict) -> None:
+    """Failure path for class initialization with invalid URL.
+
+    Args:
+        init_args (dict): Arguments used to initialize an OnsDownloader instance.
+    """
+    with patch("rbc.energy.ons.downloader.requests.head") as mock_head:
+        mock_head.return_value.raise_for_status.side_effect = exceptions.HTTPError(404)
+
+        with pytest.raises(ConnectionError, match="API/URL access failed"):
+            OnsDownloader(**init_args)
+
+
+def test_download_data_resume(init_args: dict) -> None:
+    """Happy path for "download_data" method when resuming from checkpoint.
+
+    Args:
+        init_args (dict): Arguments used to initialize an OnsDownloader instance.
+    """
+    args = init_args.copy()
+    y = args["years"][0]
+
+    # save a fake checkpoint file
+    checkpoint = {
+        DownloadTask(date=d).identifier: 1
+        for d in pd.date_range(start=f"{y}-01", end=f"{y}-12", freq="MS")
+        .strftime("%Y-%m")
+        .tolist()
+    }
+    checkpoint_path = Path(args["output_path"], "status.pickle")
+    with open(checkpoint_path, "wb") as f:
+        pickle.dump(checkpoint, f)
+
+    args["resume"] = True
+
+    with patch("rbc.energy.ons.downloader.requests.head") as mock_head:
+        mock_head.return_value = MagicMock(status_code=200)
+        downloader = OnsDownloader(**args)
+
+        with patch.object(downloader, "_download_task_data") as mock_dump:
+            mock_dump.return_value = 1
+            downloader.download_data()
+
+            assert mock_dump.call_count == 0
+            assert downloader.checkpoint == checkpoint
+
+
+# ----------------------------------
+# Tests - Data crawling logic
+# ----------------------------------
+def test_download_task_data(downloader: OnsDownloader, task: DownloadTask) -> None:
+    """Happy path for "_download_task_data" method when resuming from checkpoint.
+
+    Args:
+        downloader (OnsDownloader): Instance of OnsDownloader class.
+        task (DownloadTask): The metadata of a downloading task, here: date (YYYY-MM)
+    """
+    mock_df = get_mock_df(task)
+
+    with patch.object(downloader, "_get_task_data", return_value=mock_df):
+        status = downloader._download_task_data(task)
+
+        assert status == 1
+        expected_file = downloader._build_task_path(task)
+        assert expected_file.is_file(), f"The CSV {expected_file} was not created!"
+
+        saved_df = pd.read_csv(expected_file)
+        assert saved_df.iloc[0]["val_geracao"] == int(mock_df.iloc[0]["val_geracao"])
+
+
+@pytest.mark.parametrize(
+    "task, expect_old, expect_new",
+    [
+        (DownloadTask(date="2021-01"), 1, 0),  # last month routed to old source
+        (DownloadTask(date="2022-01"), 0, 1),  # first month routed to new source
+    ],
+)
+def test_get_task_data(
+    downloader: OnsDownloader, task: DownloadTask, expect_old: int, expect_new: int
+) -> None:
+    """Happy path for "_get_task_data" method.
+
+    Args:
+        downloader (OnsDownloader): Instance of OnsDownloader class.
+        task (DownloadTask): The metadata of a downloading task, here: date (YYYY-MM)
+        expect_old (int): Expected call count for _get_from_yearly_csv.
+        expect_new (int): Expected call count for _get_from_monthly_csv.
+    """
+    mock_df = get_mock_df(task)
+    with patch.object(
+        downloader, "_get_from_yearly_csv", return_value=mock_df
+    ) as mock_old:
+        with patch.object(
+            downloader, "_get_from_monthly_csv", return_value=mock_df
+        ) as mock_new:
+            df = downloader._get_task_data(task)
+
+    assert not df.empty
+    assert len(df) == 1
+    assert df.iloc[0]["datetime"] == f"{task.date}-01 00:00:00"
+    assert df.iloc[0]["plant_name"] == "A"
+    assert df.iloc[0]["generation_MWmed"] == 10.0
+    assert mock_old.call_count == expect_old
+    assert mock_new.call_count == expect_new
+
+
+def test_get_task_data_no_data_for_old_year(downloader: OnsDownloader) -> None:
+    """Failure path for "_get_task_data" method when a task before MIN_YEAR is provided.
+
+    Args:
+        downloader (OnsDownloader): Instance of OnsDownloader class.
+    """
+    old_year_task = DownloadTask(date=f"{MIN_YEAR - 1}-01")
+    mock_df = pd.DataFrame(columns=EXPECTED_COLS)
+
+    with patch.object(downloader, "_get_from_yearly_csv", return_value=mock_df):
+        with patch.object(downloader, "_get_from_monthly_csv", return_value=mock_df):
+            with pytest.raises(MissingDataError, match="No energy data for year"):
+                downloader._get_task_data(old_year_task)
+
+
+def test_get_task_data_no_generation_data(
+    downloader: OnsDownloader, task: DownloadTask
+) -> None:
+    """Failure path for "_get_task_data" method when no generation data is available.
+
+    Args:
+        downloader (OnsDownloader): Instance of OnsDownloader class.
+        task (DownloadTask): The metadata of a downloading task, here: date (YYYY-MM)
+    """
+    mock_df = pd.DataFrame(columns=EXPECTED_COLS)
+
+    with patch.object(downloader, "_get_from_yearly_csv", return_value=mock_df):
+        with patch.object(downloader, "_get_from_monthly_csv", return_value=mock_df):
+            with pytest.raises(MissingDataError, match="No energy data available"):
+                downloader._get_task_data(task)
+
+
+def test_get_task_data_structure_changed(
+    downloader: OnsDownloader, task: DownloadTask
+) -> None:
+    """Failure path for "_get_task_data" method when dataframe doesn't have all columns.
+
+    Args:
+        downloader (OnsDownloader): Instance of OnsDownloader class.
+        task (DownloadTask): The metadata of a downloading task, here: date (YYYY-MM)
+    """
+    mock_df = get_mock_df(task).drop(columns="val_geracao")
+
+    with patch.object(downloader, "_get_from_yearly_csv", return_value=mock_df):
+        with patch.object(downloader, "_get_from_monthly_csv", return_value=mock_df):
+            with pytest.raises(DataStructureError, match="Missing columns"):
+                downloader._get_task_data(task)
+
+
+# ----------------------------------
+# Tests - Data crawling helper methods
+# ----------------------------------
+def test_get_from_monthly_csv(downloader: OnsDownloader, task: DownloadTask) -> None:
+    """Happy path for "_get_from_monthly_csv" method, ensuring correct URL.
+
+    Args:
+        downloader (OnsDownloader): Instance of OnsDownloader class.
+        task (DownloadTask): The metadata of a downloading task, here: date (YYYY-MM)
+    """
+    mock_df = get_mock_df(task)
+
+    with patch(
+        "rbc.energy.ons.downloader.load_df_from_file", return_value=mock_df
+    ) as mock_load:
+        df = downloader._get_from_monthly_csv(task=task)
+
+        # check correct URL was created
+        expected_url = (
+            f"{URL_BASE}GERACAO_USINA-2_{task.year}_{str(task.month).zfill(2)}.csv"
+        )
+        mock_load.assert_called_with(expected_url, delimiter=";")
+
+        # check all columns were loaded
+        assert "val_geracao" in df.columns
+
+
+def test_get_from_yearly_csv(downloader: OnsDownloader) -> None:
+    """Happy path for "_get_from_yearly_csv" method, ensuring correct URL and month filter.
+
+    Args:
+        downloader (OnsDownloader): Instance of OnsDownloader class.
+    """
+    task = DownloadTask(date="2021-01")
+    mock_df = pd.DataFrame(
+        {
+            "din_instante": pd.to_datetime(
+                [
+                    f"{task.date}-01 00:00:00",
+                    f"{task.year}-{task.month + 1:02d}-01 00:00:00",
+                ]
+            )
+        }
+    )
+
+    with patch.object(downloader, "_load_yearly_csv", return_value=mock_df) as mock_f:
+        df = downloader._get_from_yearly_csv(task=task)
+
+        # check correct URL was created
+        expected_url = f"{URL_BASE}GERACAO_USINA-2_{task.year}.csv"
+        mock_f.assert_called_with(expected_url)
+
+        # check all except current month were filtered out
+        assert len(df) == 1
+        assert df["din_instante"].dt.month.iloc[0] == task.month
+
+
+def test_lru_cache_works(downloader: OnsDownloader, task: DownloadTask) -> None:
+    """Happy path for @lru_cache decorator for _load_yearly_csv method.
+
+    Args:
+        downloader (OnsDownloader): Instance of OnsDownloader class.
+        task (DownloadTask): The metadata of a downloading task, here: date (YYYY-MM)
+    """
+    mock_df = pd.DataFrame(
+        {
+            "din_instante": pd.to_datetime(f"{task.date}-01 00:00:00"),
+            "generation_MWmed": [10],
+        }
+    )
+
+    downloader._load_yearly_csv.cache_clear()
+
+    with patch("rbc.energy.ons.downloader.load_df_from_file") as mock_load:
+        mock_load.return_value = mock_df
+
+        downloader._get_from_yearly_csv(task=task)
+        downloader._get_from_yearly_csv(task=task)
+        downloader._get_from_yearly_csv(task=task)
+
+        assert mock_load.call_count == 1
+
+
+def test_load_yearly_csv(downloader: OnsDownloader, task: DownloadTask) -> None:
+    """Happy path for "_load_yearly_csv" method.
+
+    Args:
+        downloader (OnsDownloader): Instance of OnsDownloader class.
+        task (DownloadTask): The metadata of a downloading task, here: date (YYYY-MM)
+    """
+    downloader._load_yearly_csv.cache_clear()
+
+    with patch("rbc.energy.ons.downloader.load_df_from_file") as mock_load:
+        mock_load.return_value = get_mock_df(task)
+
+        df = downloader._load_yearly_csv(url="http://fake.csv")
+
+        assert mock_load.call_count == 1
+        assert df["din_instante"].iloc[0] == pd.Timestamp(f"{task.date}-01")
+
+
+@pytest.mark.parametrize(
+    "mock_df_dict, expected_match",
+    [
+        ({"din_instante": ["fake_date"]}, "no longer datetimelike"),  # catch ValueError
+        ({"val_geracao": [10]}, "Missing datetime column"),  # catch KeyError
+    ],
+)
+def test_load_yearly_csv_structure_changed(
+    downloader: OnsDownloader,
+    task: DownloadTask,
+    mock_df_dict: dict,
+    expected_match: str,
+) -> None:
+    """Failure path for "_load_yearly_csv" method when the dates aren't datetime-like.
+
+    Args:
+        downloader (OnsDownloader): Instance of OnsDownloader class.
+        task (DownloadTask): The metadata of a downloading task, here: date (YYYY-MM)
+        mock_df_dict (dict): Dictionary of mock dataframe columns.
+        expected_match (str): Expected match string.
+    """
+    downloader._load_yearly_csv.cache_clear()
+
+    with patch("rbc.energy.ons.downloader.load_df_from_file") as mock_load:
+        mock_load.return_value = pd.DataFrame(mock_df_dict)
+
+        with pytest.raises(DataStructureError, match=expected_match):
+            downloader._load_yearly_csv(url="http://fake.csv")

--- a/tests/energy/ons/test_downloader.py
+++ b/tests/energy/ons/test_downloader.py
@@ -10,7 +10,7 @@ import pytest
 from requests import exceptions
 
 from rbc.energy.ons import OnsDownloader
-from rbc.energy.ons.downloader import EXPECTED_COLS_MAPPING, MIN_YEAR, URL_BASE
+from rbc.energy.ons.downloader import EXPECTED_COLS_MAPPING, URL_BASE
 from rbc.energy.utils import DataStructureError, DownloadTask, MissingDataError
 
 
@@ -25,7 +25,7 @@ def init_args(tmp_path: Path) -> dict:
         tmp_path (Path): Path to the temporary directory.
 
     Returns:
-        dict: Initialisation arguments.
+        dict: initialization arguments.
     """
     return {
         "output_path": tmp_path,
@@ -206,21 +206,6 @@ def test_get_task_data(
     assert df.iloc[0]["generation_MWmed"] == 10.0
     assert mock_old.call_count == expect_old
     assert mock_new.call_count == expect_new
-
-
-def test_get_task_data_no_data_for_old_year(downloader: OnsDownloader) -> None:
-    """Failure path for "_get_task_data" method when a task before MIN_YEAR is provided.
-
-    Args:
-        downloader (OnsDownloader): Instance of OnsDownloader class.
-    """
-    old_year_task = DownloadTask(date=f"{MIN_YEAR - 1}-01")
-    mock_df = pd.DataFrame(columns=EXPECTED_COLS_MAPPING)
-
-    with patch.object(downloader, "_get_from_yearly_csv", return_value=mock_df):
-        with patch.object(downloader, "_get_from_monthly_csv", return_value=mock_df):
-            with pytest.raises(MissingDataError, match="No energy data for year"):
-                downloader._get_task_data(old_year_task)
 
 
 def test_get_task_data_no_generation_data(

--- a/tests/energy/ons/test_downloader.py
+++ b/tests/energy/ons/test_downloader.py
@@ -10,7 +10,7 @@ import pytest
 from requests import exceptions
 
 from rbc.energy.ons import OnsDownloader
-from rbc.energy.ons.downloader import EXPECTED_COLS, MIN_YEAR, URL_BASE
+from rbc.energy.ons.downloader import EXPECTED_COLS_MAPPING, MIN_YEAR, URL_BASE
 from rbc.energy.utils import DataStructureError, DownloadTask, MissingDataError
 
 
@@ -72,11 +72,11 @@ def get_mock_df(spec_task: DownloadTask) -> pd.DataFrame:
     Returns:
         pandas.DataFrame: Mock dataframe.
     """
-    row: dict[str, object] = {c: ["A"] for c in EXPECTED_COLS.keys()}
+    row: dict[str, object] = {c: ["A"] for c in EXPECTED_COLS_MAPPING.keys()}
     row.update(
         {
             c: f"{spec_task.date}-01 00:00:00"
-            for c in EXPECTED_COLS.keys()
+            for c in EXPECTED_COLS_MAPPING.keys()
             if "din_instante" in c
         }
     )
@@ -215,7 +215,7 @@ def test_get_task_data_no_data_for_old_year(downloader: OnsDownloader) -> None:
         downloader (OnsDownloader): Instance of OnsDownloader class.
     """
     old_year_task = DownloadTask(date=f"{MIN_YEAR - 1}-01")
-    mock_df = pd.DataFrame(columns=EXPECTED_COLS)
+    mock_df = pd.DataFrame(columns=EXPECTED_COLS_MAPPING)
 
     with patch.object(downloader, "_get_from_yearly_csv", return_value=mock_df):
         with patch.object(downloader, "_get_from_monthly_csv", return_value=mock_df):
@@ -232,7 +232,7 @@ def test_get_task_data_no_generation_data(
         downloader (OnsDownloader): Instance of OnsDownloader class.
         task (DownloadTask): The metadata of a downloading task, here: date (YYYY-MM)
     """
-    mock_df = pd.DataFrame(columns=EXPECTED_COLS)
+    mock_df = pd.DataFrame(columns=EXPECTED_COLS_MAPPING)
 
     with patch.object(downloader, "_get_from_yearly_csv", return_value=mock_df):
         with patch.object(downloader, "_get_from_monthly_csv", return_value=mock_df):

--- a/tests/energy/test_utils.py
+++ b/tests/energy/test_utils.py
@@ -303,7 +303,11 @@ class TestEnergyDownloaderConnection:
         [exceptions.ConnectionError(), exceptions.Timeout()],
     )
     def test_check_connection_network_error(self, side_effect) -> None:
-        """Failure path for _check_connection when endpoint is unreachable (NetworkError)."""
+        """Failure path for _check_connection when endpoint is unreachable (NetworkError).
+
+        Args:
+            side_effect (Exception): Exception to raise on NetworkError.
+        """
         mock_func = MagicMock(side_effect=side_effect)
 
         with pytest.raises(ConnectionError, match="unreachable"):

--- a/tests/energy/test_utils.py
+++ b/tests/energy/test_utils.py
@@ -75,469 +75,513 @@ def downloader(init_args: dict) -> EnergyDownloader:
 # ----------------------------------
 # Tests - EnergyDownloader
 # ----------------------------------
-def test_initialization(downloader: EnergyDownloader, init_args: dict) -> None:
-    """Happy path for EnergyDownloader initialization.
+class TestEnergyDownloaderInit:
+    """Tests for EnergyDownloader initialization and setup."""
 
-    Args:
-        downloader (EnergyDownloader): Instance of EnergyDownloader class.
-        init_args (dict): Arguments used to initialize an EnergyDownloader instance.
-    """
-    assert downloader.output_path == init_args["output_path"]
-    assert downloader.checkpoint_path == Path(init_args["output_path"], "status.pickle")
-    assert downloader.checkpoint == {}
-    assert downloader.years == init_args["years"]
+    def test_initialization(
+        self, downloader: EnergyDownloader, init_args: dict
+    ) -> None:
+        """Happy path for EnergyDownloader initialization.
 
+        Args:
+            downloader (EnergyDownloader): Instance of EnergyDownloader class.
+            init_args (dict): Arguments used to initialize an EnergyDownloader instance.
+        """
+        assert downloader.output_path == init_args["output_path"]
+        assert downloader.checkpoint_path == Path(
+            init_args["output_path"], "status.pickle"
+        )
+        assert downloader.checkpoint == {}
+        assert downloader.years == init_args["years"]
 
-def test_initialization_filter_invalid_years(tmp_path: Path) -> None:
-    """Happy path for EnergyDownloader initialization for year filtering.
+    def test_initialization_filter_invalid_years(self, tmp_path: Path) -> None:
+        """Happy path for EnergyDownloader initialization for year filtering.
 
-    Args:
-        tmp_path (Path): Path to temporary directory.
-    """
-    current_year = pd.Timestamp.now().year
-    min_year = current_year - 1
-    years = [min_year - 1, min_year, current_year, current_year + 1]
+        Args:
+            tmp_path (Path): Path to temporary directory.
+        """
+        current_year = pd.Timestamp.now().year
+        min_year = current_year - 1
+        years = [min_year - 1, min_year, current_year, current_year + 1]
 
-    downloader = MockDownloader(output_path=tmp_path, years=years, start_year=min_year)
+        downloader = MockDownloader(
+            output_path=tmp_path, years=years, start_year=min_year
+        )
 
-    assert downloader.years == [min_year, current_year]
-
-
-@pytest.mark.parametrize(
-    "task",
-    [TASK_DAY, TASK_DAY.update(bidding_zone="ZONE_A")],
-)
-def test_threading_wrapper(downloader: MockDownloader, task: DownloadTask) -> None:
-    """Happy path for _threading_wrapper (and, inherently, _download_task_data).
-
-    Args:
-        downloader (MockDownloader): Instance of the MockDownloader class.
-        task (DownloadTask): The metadata for a task to download data for.
-    """
-    with patch.object(downloader, "_download_task_data", return_value=1) as mock_dl:
-        with patch.object(downloader, "_save_checkpoint") as mock_save:
-            downloader._threading_wrapper(task)
-
-            assert downloader.checkpoint[task.identifier] == 1
-            mock_dl.assert_called_once_with(task=task)
-            mock_save.assert_called_once()
+        assert downloader.years == [min_year, current_year]
 
 
-def test_threading_wrapper_skip_existing_task(downloader: MockDownloader) -> None:
-    """Happy path for _threading_wrapper when task exists from previous run and is skipped.
+class TestEnergyDownloaderThreading:
+    """Tests for the threading wrapper and error catch logic."""
 
-    Args:
-        downloader (MockDownloader): Instance of the MockDownloader class.
-    """
-    downloader.checkpoint = {TASK_DAY.identifier: 1}
+    @pytest.mark.parametrize(
+        "task",
+        [TASK_DAY, TASK_DAY.update(bidding_zone="ZONE_A")],
+    )
+    def test_threading_wrapper(
+        self, downloader: MockDownloader, task: DownloadTask
+    ) -> None:
+        """Happy path for _threading_wrapper (and, inherently, _download_task_data).
 
-    with patch.object(downloader, "_download_task_data") as mock_dl:
-        with patch.object(downloader, "_save_checkpoint") as mock_save:
-            downloader._threading_wrapper(TASK_DAY)
-
-            mock_dl.assert_not_called()
-            mock_save.assert_not_called()
-
-
-@pytest.mark.parametrize(
-    "task, expected_error_status",
-    [
-        (TASK_DAY, 1),  # for EIA/EPIAS/...
-        (TASK_YESTERDAY, 0),
-        (TASK_DAY.update(bidding_zone="ZONE_A"), 1),  # for Entso-E
-        (TASK_YESTERDAY.update(bidding_zone="ZONE_A"), 0),
-    ],
-)
-@pytest.mark.parametrize(
-    "code, expected_status, expected_sleep_calls",
-    [
-        (None, 0, MAX_RETRIES - 1),
-        (300, 0, MAX_RETRIES - 1),
-        (404, 1, 0),
-        (400, 1, 0),
-    ],
-)
-def test_threading_error_catching(
-    downloader: MockDownloader,
-    task: DownloadTask,
-    expected_error_status: int,
-    code: int | None,
-    expected_status: int,
-    expected_sleep_calls: int,
-) -> None:
-    """Failure path suite for _threading_wrapper (and, inherently, _download_task_data).
-
-    This test suite ensures that the various different errors that can be raised by
-    _get_task_data and caught in _download_task_data are propagated correctly to
-    _threading_wrapper and result in the correct resume logic.
-
-    Args:
-        downloader (MockDownloader): Instance of the MockDownloader class.
-        task (DownloadTask): The metadata for a task to download data for.
-        expected_error_status (int): Expected MissingDataError status.
-        code (int | None): Status code for HTTPError logic.
-        expected_status (int): Expected status for resuming logic.
-        expected_sleep_calls (int): Expected number of times sleep is called.
-    """
-    downloader.checkpoint = {}
-
-    # 1. Test error requiring immediate exit (DataStructureError / RateLimitError -> exit)
-    with patch("os._exit", side_effect=SystemExit) as mock_exit:
-        with patch.object(downloader, "_get_task_data", side_effect=DataStructureError):
-            with pytest.raises(SystemExit):
+        Args:
+            downloader (MockDownloader): Instance of the MockDownloader class.
+            task (DownloadTask): The metadata for a task to download data for.
+        """
+        with patch.object(downloader, "_download_task_data", return_value=1) as mock_dl:
+            with patch.object(downloader, "_save_checkpoint") as mock_save:
                 downloader._threading_wrapper(task)
 
-    mock_exit.assert_called_once_with(1)  # assert outside "with"-block for correct exec
+                assert downloader.checkpoint[task.identifier] == 1
+                mock_dl.assert_called_once_with(task=task)
+                mock_save.assert_called_once()
 
-    # 2. Test missing data (MissingDataError -> status 0 = current year, status 1 = prior)
-    downloader.checkpoint = {}
-    with patch.object(downloader, "_get_task_data", side_effect=MissingDataError):
-        with patch.object(downloader, "_save_checkpoint") as mock_save:
-            downloader._threading_wrapper(task)
+    def test_threading_wrapper_skip_existing_task(
+        self, downloader: MockDownloader
+    ) -> None:
+        """Happy path for _threading_wrapper when task exists from previous run and is skipped.
 
-            assert downloader.checkpoint[task.identifier] == expected_error_status
-            mock_save.assert_called_once()
+        Args:
+            downloader (MockDownloader): Instance of the MockDownloader class.
+        """
+        downloader.checkpoint = {TASK_DAY.identifier: 1}
 
-    # 3. Test HTTPError - no code: (->0), retry: code=300 (->0), missing: code=404 (->1), client: code=400 (->1)
-    downloader.checkpoint = {}
-    with patch.object(
-        downloader, "_get_task_data", side_effect=exceptions.HTTPError("")
-    ):
-        with patch.object(downloader, "_get_status_code", return_value=code):
-            with patch("rbc.energy.utils.time.sleep") as mock_sleep:
-                with patch.object(downloader, "_save_checkpoint") as mock_save:
+        with patch.object(downloader, "_download_task_data") as mock_dl:
+            with patch.object(downloader, "_save_checkpoint") as mock_save:
+                downloader._threading_wrapper(TASK_DAY)
+
+                mock_dl.assert_not_called()
+                mock_save.assert_not_called()
+
+    @pytest.mark.parametrize(
+        "task, expected_error_status",
+        [
+            (TASK_DAY, 1),  # for EIA/EPIAS/...
+            (TASK_YESTERDAY, 0),
+            (TASK_DAY.update(bidding_zone="ZONE_A"), 1),  # for Entso-E
+            (TASK_YESTERDAY.update(bidding_zone="ZONE_A"), 0),
+        ],
+    )
+    @pytest.mark.parametrize(
+        "code, expected_status, expected_sleep_calls",
+        [
+            (None, 0, MAX_RETRIES - 1),
+            (300, 0, MAX_RETRIES - 1),
+            (404, 1, 0),
+            (400, 1, 0),
+        ],
+    )
+    def test_threading_error_catching(
+        self,
+        downloader: MockDownloader,
+        task: DownloadTask,
+        expected_error_status: int,
+        code: int | None,
+        expected_status: int,
+        expected_sleep_calls: int,
+    ) -> None:
+        """Failure path suite for _threading_wrapper (and, inherently, _download_task_data).
+
+        This test suite ensures that the various different errors that can be raised by
+        _get_task_data and caught in _download_task_data are propagated correctly to
+        _threading_wrapper and result in the correct resume logic.
+
+        Args:
+            downloader (MockDownloader): Instance of the MockDownloader class.
+            task (DownloadTask): The metadata for a task to download data for.
+            expected_error_status (int): Expected MissingDataError status.
+            code (int | None): Status code for HTTPError logic.
+            expected_status (int): Expected status for resuming logic.
+            expected_sleep_calls (int): Expected number of times sleep is called.
+        """
+        downloader.checkpoint = {}
+
+        # 1. Test error requiring immediate exit (DataStructureError / RateLimitError -> exit)
+        with patch("os._exit", side_effect=SystemExit) as mock_exit:
+            with patch.object(
+                downloader, "_get_task_data", side_effect=DataStructureError
+            ):
+                with pytest.raises(SystemExit):
                     downloader._threading_wrapper(task)
 
-                    assert downloader.checkpoint[task.identifier] == expected_status
-                    assert mock_sleep.call_count == expected_sleep_calls
-                    mock_save.assert_called_once()
+        mock_exit.assert_called_once_with(
+            1
+        )  # assert outside "with"-block for correct exec
 
-    # 4. Test other errors (that are not specifically handled in _download_task_data)
-    downloader.checkpoint = {}
-    with patch.object(downloader, "_get_task_data", side_effect=Exception):
-        with patch.object(downloader, "_save_checkpoint") as mock_save:
-            downloader._threading_wrapper(task)
+        # 2. Test missing data (MissingDataError -> status 0 = current year, status 1 = prior)
+        downloader.checkpoint = {}
+        with patch.object(downloader, "_get_task_data", side_effect=MissingDataError):
+            with patch.object(downloader, "_save_checkpoint") as mock_save:
+                downloader._threading_wrapper(task)
 
-            assert downloader.checkpoint[task.identifier] == 0
-            mock_save.assert_called_once()
+                assert downloader.checkpoint[task.identifier] == expected_error_status
+                mock_save.assert_called_once()
+
+        # 3. Test HTTPError
+        # no code: (->0), retry: code=300 (->0), missing: code=404 (->1), client: code=400 (->1)
+        downloader.checkpoint = {}
+        with patch.object(
+            downloader, "_get_task_data", side_effect=exceptions.HTTPError("")
+        ):
+            with patch.object(downloader, "_get_status_code", return_value=code):
+                with patch("rbc.energy.utils.time.sleep") as mock_sleep:
+                    with patch.object(downloader, "_save_checkpoint") as mock_save:
+                        downloader._threading_wrapper(task)
+
+                        assert downloader.checkpoint[task.identifier] == expected_status
+                        assert mock_sleep.call_count == expected_sleep_calls
+                        mock_save.assert_called_once()
+
+        # 4. Test other errors (that are not specifically handled in _download_task_data)
+        downloader.checkpoint = {}
+        with patch.object(downloader, "_get_task_data", side_effect=Exception):
+            with patch.object(downloader, "_save_checkpoint") as mock_save:
+                downloader._threading_wrapper(task)
+
+                assert downloader.checkpoint[task.identifier] == 0
+                mock_save.assert_called_once()
 
 
 # ----------------------------------
 # Tests - EnergyDownloader helper methods
 # ----------------------------------
-def test_check_connection_success() -> None:
-    """Happy path for _check_connection when endpoint returns 2xx."""
-    mock_response = MagicMock()
-    mock_response.raise_for_status.return_value = None
-    MockDownloader._check_connection(lambda: mock_response, "TEST")
+class TestEnergyDownloaderConnection:
+    """Tests for remote endpoint connectivity checking."""
 
-
-@pytest.mark.parametrize(
-    "has_content, has_reason, json_side_effect, expected_match",
-    [
-        (True, True, None, "status 401"),  # JSON body with error code
-        (True, False, exceptions.JSONDecodeError("", "", 0), "status 500"),  # uncodable
-        (True, False, ValueError(), "status 500"),  # invalid JSON payload
-        (False, True, None, "status 403"),  # no content body, but has reason
-        (False, False, None, "status 500"),  # empty response
-    ],
-)
-def test_check_connection_http_error(
-    has_content: bool,
-    has_reason: bool,
-    json_side_effect: Exception | None,
-    expected_match: str,
-) -> None:
-    """Failure path for _check_connection when there is a HTTPError.
-
-    Args:
-        has_content (bool): Whether the response has a content.
-        has_reason (bool): Whether the response has a reason.
-        json_side_effect (Exception | None): Exception to raise on .json() call.
-        expected_match (str): Expected returned status code.
-    """
-    mock_response = MagicMock()
-    mock_response.raise_for_status.side_effect = exceptions.HTTPError()
-    mock_response.status_code = int(expected_match.split()[1])
-    mock_response.content = b"data" if has_content else b""
-    mock_response.reason = "Some Reason" if has_reason else None
-
-    if json_side_effect:
-        mock_response.json.side_effect = json_side_effect
-        mock_response.text = "Error details here"
-    else:
-        mock_response.json.return_value = {"error": {"code": "ERROR"}}
-
-    with pytest.raises(ConnectionError, match=expected_match):
+    def test_check_connection_success(self) -> None:
+        """Happy path for _check_connection when endpoint returns 2xx."""
+        mock_response = MagicMock()
+        mock_response.raise_for_status.return_value = None
         MockDownloader._check_connection(lambda: mock_response, "TEST")
 
+    @pytest.mark.parametrize(
+        "has_content, has_reason, json_side_effect, expected_match",
+        [
+            (True, True, None, "status 401"),  # JSON body with error code
+            (
+                True,
+                False,
+                exceptions.JSONDecodeError("", "", 0),
+                "status 500",
+            ),  # uncodable
+            (True, False, ValueError(), "status 500"),  # invalid JSON payload
+            (False, True, None, "status 403"),  # no content body, but has reason
+            (False, False, None, "status 500"),  # empty response
+        ],
+    )
+    def test_check_connection_http_error(
+        self,
+        has_content: bool,
+        has_reason: bool,
+        json_side_effect: Exception | None,
+        expected_match: str,
+    ) -> None:
+        """Failure path for _check_connection when there is a HTTPError.
 
-@pytest.mark.parametrize(
-    "side_effect",
-    [exceptions.ConnectionError(), exceptions.Timeout()],
-)
-def test_check_connection_network_error(side_effect) -> None:
-    """Failure path for _check_connection when endpoint is unreachable (NetworkError)."""
-    mock_func = MagicMock(side_effect=side_effect)
+        Args:
+            has_content (bool): Whether the response has a content.
+            has_reason (bool): Whether the response has a reason.
+            json_side_effect (Exception | None): Exception to raise on .json() call.
+            expected_match (str): Expected returned status code.
+        """
+        mock_response = MagicMock()
+        mock_response.raise_for_status.side_effect = exceptions.HTTPError()
+        mock_response.status_code = int(expected_match.split()[1])
+        mock_response.content = b"data" if has_content else b""
+        mock_response.reason = "Some Reason" if has_reason else None
 
-    with pytest.raises(ConnectionError, match="unreachable"):
-        MockDownloader._check_connection(mock_func, "TEST")
-        mock_func.assert_called_once()
+        if json_side_effect:
+            mock_response.json.side_effect = json_side_effect
+            mock_response.text = "Error details here"
+        else:
+            mock_response.json.return_value = {"error": {"code": "ERROR"}}
 
+        with pytest.raises(ConnectionError, match=expected_match):
+            MockDownloader._check_connection(lambda: mock_response, "TEST")
 
-@pytest.mark.parametrize(
-    "error, expected_return",
-    [
-        (SimpleNamespace(response=SimpleNamespace(status_code=404)), 404),  # requests
-        (SimpleNamespace(code=503), 503),  # urllib
-        (Exception("No attributes"), None),
-    ],
-)
-def test_get_status_code(error: Exception, expected_return: str | None) -> None:
-    """Happy path for _get_status_code with different inputs.
+    @pytest.mark.parametrize(
+        "side_effect",
+        [exceptions.ConnectionError(), exceptions.Timeout()],
+    )
+    def test_check_connection_network_error(self, side_effect) -> None:
+        """Failure path for _check_connection when endpoint is unreachable (NetworkError)."""
+        mock_func = MagicMock(side_effect=side_effect)
 
-    Args:
-        error (Exception): Exception from which to get the status code (if it exists).
-        expected_return (str | None): Expected status code (None if error has no attributes).
-    """
-    assert MockDownloader._get_status_code(error) == expected_return
-
-
-@pytest.mark.parametrize(
-    "task, expected_csv",
-    [
-        (TASK_DAY, Path("1h", "2020-01-01.csv")),
-        (TASK_DAY.update(bidding_zone="A"), Path("1h", "A", "2020-01-01.csv")),
-        (TASK_DAY.update(temporal_resolution="5min"), Path("5min", "2020-01-01.csv")),
-    ],
-)
-def test_build_task_path(
-    downloader: MockDownloader, task: DownloadTask, expected_csv: Path
-) -> None:
-    """Happy path for _build_task_path when valid inputs are provided.
-
-    Args:
-        downloader (MockDownloader): Instance of the MockDownloader class.
-        task (DownloadTask): Valid DownloadTask for _build_task_path.
-        expected_csv (str): Expected csv path name.
-    """
-    path = downloader._build_task_path(task)
-    assert str(expected_csv) in str(path)
-
-
-@pytest.mark.parametrize(
-    "task",
-    [TASK_DAY, TASK_DAY.update(bidding_zone="ZONE_A")],
-)
-def test_save_checkpoint(
-    downloader: MockDownloader,
-    task: DownloadTask,
-) -> None:
-    """Happy path for _save_checkpoint with valid checkpoint setups.
-
-    Args:
-        downloader (MockDownloader): Instance of the MockDownloader class.
-        task (DownloadTask): The metadata for a task to download data for.
-    """
-    downloader.checkpoint = {task.identifier: 1}
-    downloader._save_checkpoint()
-
-    assert downloader.checkpoint_path.is_file()
-    with open(downloader.checkpoint_path, "rb") as f:
-        assert pickle.load(f) == downloader.checkpoint
+        with pytest.raises(ConnectionError, match="unreachable"):
+            MockDownloader._check_connection(mock_func, "TEST")
+            mock_func.assert_called_once()
 
 
-def test_load_checkpoint(downloader: MockDownloader) -> None:
-    """Happy path for _load_checkpoint.
+class TestEnergyDownloaderUtilities:
+    """Tests for miscellaneous helper methods."""
 
-    Args:
-        downloader (MockDownloader): Instance of the MockDownloader class.
-    """
-    assert downloader.resume is True
-    downloader.checkpoint = {"test": 1}
-    downloader._save_checkpoint()
+    @pytest.mark.parametrize(
+        "error, expected_return",
+        [
+            (SimpleNamespace(response=SimpleNamespace(status_code=404)), 404),  # requ
+            (SimpleNamespace(code=503), 503),  # urllib
+            (Exception("No attributes"), None),
+        ],
+    )
+    def test_get_status_code(
+        self, error: Exception, expected_return: str | None
+    ) -> None:
+        """Happy path for _get_status_code with different inputs.
 
-    result = downloader._load_checkpoint()
-    assert result == {"test": 1}
-
-
-def test_load_checkpoint_corrupted(downloader: MockDownloader) -> None:
-    """Failure path for _load_checkpoint when status.pickle is corrupted.
-
-    Args:
-        downloader (MockDownloader): Instance of the MockDownloader class.
-    """
-    path = Path(downloader.output_path, "status.pickle")
-    path.write_text("corrupted data")
-
-    result = downloader._load_checkpoint()
-    assert result == {}
+        Args:
+            error (Exception): Exception from which to get the status code (if it exists).
+            expected_return (str | None): Expected status code (None if error has no attributes).
+        """
+        assert MockDownloader._get_status_code(error) == expected_return
 
 
-def test_get_date_list_current_year(downloader: MockDownloader) -> None:
-    """Happy path for _get_date_list when current year is provided.
+class TestEnergyDownloaderCheckpoint:
+    """Tests for saving, loading, and handling checkpoints."""
 
-    Args:
-        downloader (MockDownloader): Instance of the MockDownloader class.
-    """
-    with patch.object(downloader, "today", pd.Timestamp("2025-02-01")):
-        downloader.years = [2025]
-        dates = downloader._get_date_list()
+    @pytest.mark.parametrize(
+        "task, expected_csv",
+        [
+            (TASK_DAY, Path("1h", "2020-01-01.csv")),
+            (TASK_DAY.update(bidding_zone="A"), Path("1h", "A", "2020-01-01.csv")),
+            (
+                TASK_DAY.update(temporal_resolution="5min"),
+                Path("5min", "2020-01-01.csv"),
+            ),
+        ],
+    )
+    def test_build_task_path(
+        self, downloader: MockDownloader, task: DownloadTask, expected_csv: Path
+    ) -> None:
+        """Happy path for _build_task_path when valid inputs are provided.
 
-        assert len(dates) == 31
-        assert dates[-1] == "2025-01-31"
+        Args:
+            downloader (MockDownloader): Instance of the MockDownloader class.
+            task (DownloadTask): Valid DownloadTask for _build_task_path.
+            expected_csv (str): Expected csv path name.
+        """
+        path = downloader._build_task_path(task)
+        assert str(expected_csv) in str(path)
+
+    @pytest.mark.parametrize(
+        "task",
+        [TASK_DAY, TASK_DAY.update(bidding_zone="ZONE_A")],
+    )
+    def test_save_checkpoint(
+        self,
+        downloader: MockDownloader,
+        task: DownloadTask,
+    ) -> None:
+        """Happy path for _save_checkpoint with valid checkpoint setups.
+
+        Args:
+            downloader (MockDownloader): Instance of the MockDownloader class.
+            task (DownloadTask): The metadata for a task to download data for.
+        """
+        downloader.checkpoint = {task.identifier: 1}
+        downloader._save_checkpoint()
+
+        assert downloader.checkpoint_path.is_file()
+        with open(downloader.checkpoint_path, "rb") as f:
+            assert pickle.load(f) == downloader.checkpoint
+
+    def test_load_checkpoint(self, downloader: MockDownloader) -> None:
+        """Happy path for _load_checkpoint.
+
+        Args:
+            downloader (MockDownloader): Instance of the MockDownloader class.
+        """
+        assert downloader.resume is True
+        downloader.checkpoint = {"test": 1}
+        downloader._save_checkpoint()
+
+        result = downloader._load_checkpoint()
+        assert result == {"test": 1}
+
+    def test_load_checkpoint_corrupted(self, downloader: MockDownloader) -> None:
+        """Failure path for _load_checkpoint when status.pickle is corrupted.
+
+        Args:
+            downloader (MockDownloader): Instance of the MockDownloader class.
+        """
+        path = Path(downloader.output_path, "status.pickle")
+        path.write_text("corrupted data")
+
+        result = downloader._load_checkpoint()
+        assert result == {}
 
 
-def test_get_date_list_future_years(downloader: MockDownloader) -> None:
-    """Happy path for _get_date_list when future years are provided.
+class TestEnergyDownloaderDatelist:
+    """Tests for date list creation methods."""
 
-    Args:
-        downloader (MockDownloader): Instance of the MockDownloader class.
-    """
-    downloader.years = [downloader.today.year + 1]
+    def test_get_date_list_current_year(self, downloader: MockDownloader) -> None:
+        """Happy path for _get_date_list when current year is provided.
 
-    with pytest.raises(InvalidError, match="No valid dates for year"):
-        downloader._get_date_list()
+        Args:
+            downloader (MockDownloader): Instance of the MockDownloader class.
+        """
+        with patch.object(downloader, "today", pd.Timestamp("2025-02-01")):
+            downloader.years = [2025]
+            dates = downloader._get_date_list()
 
+            assert len(dates) == 31
+            assert dates[-1] == "2025-01-31"
 
-def test_get_month_list_current_year(downloader: MockDownloader) -> None:
-    """Happy path for _get_month_list when current year is provided.
+    def test_get_date_list_future_years(self, downloader: MockDownloader) -> None:
+        """Happy path for _get_date_list when future years are provided.
 
-    Args:
-        downloader (MockDownloader): Instance of the MockDownloader class.
-    """
-    with patch.object(downloader, "today", pd.Timestamp("2025-02-01")):
-        downloader.years = [2025]
-        months = downloader._get_month_list()
+        Args:
+            downloader (MockDownloader): Instance of the MockDownloader class.
+        """
+        downloader.years = [downloader.today.year + 1]
 
-        assert len(months) == 1
-        assert months[-1] == "2025-01"
+        with pytest.raises(InvalidError, match="No valid dates for year"):
+            downloader._get_date_list()
 
+    def test_get_month_list_current_year(self, downloader: MockDownloader) -> None:
+        """Happy path for _get_month_list when current year is provided.
 
-def test_get_year_list_current_year(downloader: MockDownloader) -> None:
-    """Happy path for _get_year_list when current year is provided.
+        Args:
+            downloader (MockDownloader): Instance of the MockDownloader class.
+        """
+        with patch.object(downloader, "today", pd.Timestamp("2025-02-01")):
+            downloader.years = [2025]
+            months = downloader._get_month_list()
 
-    Args:
-        downloader (MockDownloader): Instance of the MockDownloader class.
-    """
-    with patch.object(downloader, "today", pd.Timestamp("2025-02-01")):
-        downloader.years = [2025]
-        years = downloader._get_year_list()
+            assert len(months) == 1
+            assert months[-1] == "2025-01"
 
-        assert len(years) == 1
-        assert years[-1] == "2025"
+    def test_get_year_list_current_year(self, downloader: MockDownloader) -> None:
+        """Happy path for _get_year_list when current year is provided.
+
+        Args:
+            downloader (MockDownloader): Instance of the MockDownloader class.
+        """
+        with patch.object(downloader, "today", pd.Timestamp("2025-02-01")):
+            downloader.years = [2025]
+            years = downloader._get_year_list()
+
+            assert len(years) == 1
+            assert years[-1] == "2025"
 
 
 # ----------------------------------
 # Tests - DownloadTask class
 # ----------------------------------
-@pytest.mark.parametrize(
-    "tres, bz",
-    [(None, None), ("5min", None), (None, "ZONE_A"), ("5min", "ZONE_A")],
-)
-def test_downloadtask_initialize(tres: str | None, bz: str | None) -> None:
-    """Happy path for initializing a DownloadTask instance.
+class TestDownloadTaskInit:
+    """Tests for DownloadTask initialization."""
 
-    Args:
-        tres (str): Valid temporal resolution.
-        bz (str): Valid bidding zone.
-    """
-    date = "2020-01-01"
-    all_args = {"date": date, "temporal_resolution": tres, "bidding_zone": bz}
-    args = {k: v for k, v in all_args.items() if v is not None}
-    task = DownloadTask(**args)
-
-    exp_tres = tres if tres is not None else "1h"
-    exp_bz = bz if bz is not None else None
-
-    assert task.date == date
-    assert task.temporal_resolution == exp_tres
-    assert task.bidding_zone == exp_bz
-    assert task.dt == pd.Timestamp(date)
-    assert task.year == 2020
-    assert task.month == 1
-
-    if bz is not None:
-        assert (
-            task.identifier
-            == f"date={date}|temporal_resolution={exp_tres}|bidding_zone={bz}"
-        )
-    else:
-        assert task.identifier == f"date={date}|temporal_resolution={exp_tres}"
-
-
-@pytest.mark.parametrize("invalid_date", ["20200101", "invalid", "", "2020-02-31"])
-def test_downloadtask_initialize_with_invalid_date(invalid_date: str) -> None:
-    """Failure path for initializing a DownloadTask instance.
-
-    Args:
-        invalid_date (str): Invalid date.
-    """
-    with pytest.raises(ValueError, match=r"Invalid.*date"):
-        DownloadTask(date=invalid_date)
-
-
-@pytest.mark.parametrize("invalid_tres", ["5days", "invalid", ""])
-def test_downloadtask_initialize_with_invalid_tres(invalid_tres: str) -> None:
-    """Failure path for initializing a DownloadTask instance.
-
-    Args:
-        invalid_tres (str): Invalid temporal resolution.
-    """
-    with pytest.raises(ValueError, match="Invalid temporal resolution"):
-        DownloadTask(date="2020-01-01", temporal_resolution=invalid_tres)
-
-
-def test_downloadtask_update() -> None:
-    """Happy path for DownloadTask method "update"."""
-    date = "2020-01-01"
-    task = DownloadTask(date=date)
-
-    new_date = "2020-02-01"
-    new_task = task.update(
-        date=new_date, temporal_resolution="10h", bidding_zone="ZONE_A"
+    @pytest.mark.parametrize(
+        "tres, bz",
+        [(None, None), ("5min", None), (None, "ZONE_A"), ("5min", "ZONE_A")],
     )
+    def test_downloadtask_initialize(self, tres: str | None, bz: str | None) -> None:
+        """Happy path for initializing a DownloadTask instance.
 
-    assert task is not new_task
-    assert task.date != new_date
-    assert task.bidding_zone is None
-    assert new_task.date == new_date
-    assert new_task.temporal_resolution == "10h"
-    assert new_task.bidding_zone == "ZONE_A"
+        Args:
+            tres (str): Valid temporal resolution.
+            bz (str): Valid bidding zone.
+        """
+        date = "2020-01-01"
+        all_args = {"date": date, "temporal_resolution": tres, "bidding_zone": bz}
+        args = {k: v for k, v in all_args.items() if v is not None}
+        task = DownloadTask(**args)
+
+        exp_tres = tres if tres is not None else "1h"
+        exp_bz = bz if bz is not None else None
+
+        assert task.date == date
+        assert task.temporal_resolution == exp_tres
+        assert task.bidding_zone == exp_bz
+        assert task.dt == pd.Timestamp(date)
+        assert task.year == 2020
+        assert task.month == 1
+
+        if bz is not None:
+            assert (
+                task.identifier
+                == f"date={date}|temporal_resolution={exp_tres}|bidding_zone={bz}"
+            )
+        else:
+            assert task.identifier == f"date={date}|temporal_resolution={exp_tres}"
+
+    @pytest.mark.parametrize("invalid_date", ["20200101", "invalid", "", "2020-02-31"])
+    def test_downloadtask_initialize_with_invalid_date(self, invalid_date: str) -> None:
+        """Failure path for initializing a DownloadTask instance.
+
+        Args:
+            invalid_date (str): Invalid date.
+        """
+        with pytest.raises(ValueError, match=r"Invalid.*date"):
+            DownloadTask(date=invalid_date)
+
+    @pytest.mark.parametrize("invalid_tres", ["5days", "invalid", ""])
+    def test_downloadtask_initialize_with_invalid_tres(self, invalid_tres: str) -> None:
+        """Failure path for initializing a DownloadTask instance.
+
+        Args:
+            invalid_tres (str): Invalid temporal resolution.
+        """
+        with pytest.raises(ValueError, match="Invalid temporal resolution"):
+            DownloadTask(date="2020-01-01", temporal_resolution=invalid_tres)
 
 
-def test_downloadtask_validate_required_fields() -> None:
-    """Happy path for DownloadTask's "validate_required_fields"."""
-    task = DownloadTask(date="2020-01-01", bidding_zone="ZONE_A")
-    task.validate_required_fields("date", "temporal_resolution", "bidding_zone")
+class TestDownloadTaskUpdate:
+    """Tests for DownloadTask state update."""
+
+    def test_downloadtask_update(self) -> None:
+        """Happy path for DownloadTask method "update"."""
+        date = "2020-01-01"
+        task = DownloadTask(date=date)
+
+        new_date = "2020-02-01"
+        new_task = task.update(
+            date=new_date, temporal_resolution="10h", bidding_zone="ZONE_A"
+        )
+
+        assert task is not new_task
+        assert task.date != new_date
+        assert task.bidding_zone is None
+        assert new_task.date == new_date
+        assert new_task.temporal_resolution == "10h"
+        assert new_task.bidding_zone == "ZONE_A"
 
 
-def test_downloadtask_validate_required_fields_value_missing() -> None:
-    """Failure path for DownloadTask's "validate_required_fields" when value is missing."""
-    task = DownloadTask(date="2020-01-01")
-    with pytest.raises(ValueError, match="Required attribute 'bidding_zone' missing"):
-        task.validate_required_fields("bidding_zone")
+class TestDownloadTaskValidation:
+    """Tests for DownloadTask's required fields validation."""
 
+    def test_downloadtask_validate_required_fields(self) -> None:
+        """Happy path for DownloadTask's "validate_required_fields"."""
+        task = DownloadTask(date="2020-01-01", bidding_zone="ZONE_A")
+        task.validate_required_fields("date", "temporal_resolution", "bidding_zone")
 
-@pytest.mark.parametrize("empty_bz", [None, "", "   "])
-def test_downloadtask_validate_required_fields_value_empty(
-    empty_bz: None | str,
-) -> None:
-    """Failure path for DownloadTask's "validate_required_fields" when exists but is empty.
+    def test_downloadtask_validate_required_fields_value_missing(self) -> None:
+        """Failure path for DownloadTask's "validate_required_fields" when value is missing."""
+        task = DownloadTask(date="2020-01-01")
+        with pytest.raises(
+            ValueError, match="Required attribute 'bidding_zone' missing"
+        ):
+            task.validate_required_fields("bidding_zone")
 
-    Args:
-        empty_bz (str): Empty definition of attribute 'bidding_zone'.
-    """
-    task = DownloadTask(date="2020-01-01", bidding_zone=empty_bz)
-    with pytest.raises(ValueError, match="Required attribute 'bidding_zone' missing"):
-        task.validate_required_fields("bidding_zone")
+    @pytest.mark.parametrize("empty_bz", [None, "", "   "])
+    def test_downloadtask_validate_required_fields_value_empty(
+        self,
+        empty_bz: None | str,
+    ) -> None:
+        """Failure path for DownloadTask's "validate_required_fields" when exists but is empty.
 
+        Args:
+            empty_bz (str): Empty definition of attribute 'bidding_zone'.
+        """
+        task = DownloadTask(date="2020-01-01", bidding_zone=empty_bz)
+        with pytest.raises(
+            ValueError, match="Required attribute 'bidding_zone' missing"
+        ):
+            task.validate_required_fields("bidding_zone")
 
-def test_downloadtask_validate_required_fields_field_not_an_attribute() -> None:
-    """Failure path for DownloadTask's "validate_required_fields" for non-existent attribute."""
-    task = DownloadTask(date="2020-01-01")
-    with pytest.raises(AttributeError):
-        task.validate_required_fields("invalid")
+    def test_downloadtask_validate_required_fields_field_not_an_attribute(self) -> None:
+        """Failure path for DownloadTask's "validate_required_fields" for missing attribute."""
+        task = DownloadTask(date="2020-01-01")
+        with pytest.raises(AttributeError):
+            task.validate_required_fields("invalid")
 
 
 # ----------------------------------

--- a/tests/energy/test_utils.py
+++ b/tests/energy/test_utils.py
@@ -50,11 +50,12 @@ def init_args(tmp_path: Path) -> dict:
         tmp_path (Path): Path to the temporary directory.
 
     Returns:
-        dict: Initialisation arguments.
+        dict: initialization arguments.
     """
     return {
         "output_path": tmp_path,
         "years": [2020],
+        "start_year": 2015,
     }
 
 
@@ -68,9 +69,7 @@ def downloader(init_args: dict) -> EnergyDownloader:
     Returns:
         EnergyDownloader: Instance of the mock EnergyDownloader child class.
     """
-    return MockDownloader(
-        output_path=init_args["output_path"], years=init_args["years"]
-    )
+    return MockDownloader(**init_args)
 
 
 # ----------------------------------
@@ -83,10 +82,25 @@ def test_initialization(downloader: EnergyDownloader, init_args: dict) -> None:
         downloader (EnergyDownloader): Instance of EnergyDownloader class.
         init_args (dict): Arguments used to initialize an EnergyDownloader instance.
     """
-    assert downloader.years == init_args["years"]
     assert downloader.output_path == init_args["output_path"]
     assert downloader.checkpoint_path == Path(init_args["output_path"], "status.pickle")
     assert downloader.checkpoint == {}
+    assert downloader.years == init_args["years"]
+
+
+def test_initialization_filter_invalid_years(tmp_path: Path) -> None:
+    """Happy path for EnergyDownloader initialization for year filtering.
+
+    Args:
+        tmp_path (Path): Path to temporary directory.
+    """
+    current_year = pd.Timestamp.now().year
+    min_year = current_year - 1
+    years = [min_year - 1, min_year, current_year, current_year + 1]
+
+    downloader = MockDownloader(output_path=tmp_path, years=years, start_year=min_year)
+
+    assert downloader.years == [min_year, current_year]
 
 
 @pytest.mark.parametrize(
@@ -366,7 +380,7 @@ def test_get_date_list_current_year(downloader: MockDownloader) -> None:
     Args:
         downloader (MockDownloader): Instance of the MockDownloader class.
     """
-    with patch("pandas.Timestamp.now", return_value=pd.Timestamp("2025-02-01")):
+    with patch.object(downloader, "today", pd.Timestamp("2025-02-01")):
         downloader.years = [2025]
         dates = downloader._get_date_list()
 
@@ -380,9 +394,9 @@ def test_get_date_list_future_years(downloader: MockDownloader) -> None:
     Args:
         downloader (MockDownloader): Instance of the MockDownloader class.
     """
-    downloader.years = [pd.Timestamp.now().year + 1]
+    downloader.years = [downloader.today.year + 1]
 
-    with pytest.raises(InvalidError, match="lie in the future"):
+    with pytest.raises(InvalidError, match="No valid dates for year"):
         downloader._get_date_list()
 
 
@@ -392,7 +406,7 @@ def test_get_month_list_current_year(downloader: MockDownloader) -> None:
     Args:
         downloader (MockDownloader): Instance of the MockDownloader class.
     """
-    with patch("pandas.Timestamp.now", return_value=pd.Timestamp("2025-02-01")):
+    with patch.object(downloader, "today", pd.Timestamp("2025-02-01")):
         downloader.years = [2025]
         months = downloader._get_month_list()
 
@@ -406,7 +420,7 @@ def test_get_year_list_current_year(downloader: MockDownloader) -> None:
     Args:
         downloader (MockDownloader): Instance of the MockDownloader class.
     """
-    with patch("pandas.Timestamp.now", return_value=pd.Timestamp("2025-02-01")):
+    with patch.object(downloader, "today", pd.Timestamp("2025-02-01")):
         downloader.years = [2025]
         years = downloader._get_year_list()
 
@@ -421,8 +435,8 @@ def test_get_year_list_current_year(downloader: MockDownloader) -> None:
     "tres, bz",
     [(None, None), ("5min", None), (None, "ZONE_A"), ("5min", "ZONE_A")],
 )
-def test_downloadtask_initialise(tres: str | None, bz: str | None) -> None:
-    """Happy path for initialising a DownloadTask instance.
+def test_downloadtask_initialize(tres: str | None, bz: str | None) -> None:
+    """Happy path for initializing a DownloadTask instance.
 
     Args:
         tres (str): Valid temporal resolution.
@@ -453,8 +467,8 @@ def test_downloadtask_initialise(tres: str | None, bz: str | None) -> None:
 
 
 @pytest.mark.parametrize("invalid_date", ["20200101", "invalid", "", "2020-02-31"])
-def test_downloadtask_initialise_with_invalid_date(invalid_date: str) -> None:
-    """Failure path for initialising a DownloadTask instance.
+def test_downloadtask_initialize_with_invalid_date(invalid_date: str) -> None:
+    """Failure path for initializing a DownloadTask instance.
 
     Args:
         invalid_date (str): Invalid date.
@@ -464,8 +478,8 @@ def test_downloadtask_initialise_with_invalid_date(invalid_date: str) -> None:
 
 
 @pytest.mark.parametrize("invalid_tres", ["5days", "invalid", ""])
-def test_downloadtask_initialise_with_invalid_tres(invalid_tres: str) -> None:
-    """Failure path for initialising a DownloadTask instance.
+def test_downloadtask_initialize_with_invalid_tres(invalid_tres: str) -> None:
+    """Failure path for initializing a DownloadTask instance.
 
     Args:
         invalid_tres (str): Invalid temporal resolution.

--- a/tests/energy/test_utils.py
+++ b/tests/energy/test_utils.py
@@ -4,7 +4,7 @@
 import pickle
 from pathlib import Path
 from types import SimpleNamespace
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pandas as pd
 import pytest
@@ -211,6 +211,66 @@ def test_threading_error_catching(
 # ----------------------------------
 # Tests - EnergyDownloader helper methods
 # ----------------------------------
+def test_check_connection_success() -> None:
+    """Happy path for _check_connection when endpoint returns 2xx."""
+    mock_response = MagicMock()
+    mock_response.raise_for_status.return_value = None
+    MockDownloader._check_connection(lambda: mock_response, "TEST")
+
+
+@pytest.mark.parametrize(
+    "has_content, has_reason, json_side_effect, expected_match",
+    [
+        (True, True, None, "status 401"),  # JSON body with error code
+        (True, False, exceptions.JSONDecodeError("", "", 0), "status 500"),  # uncodable
+        (True, False, ValueError(), "status 500"),  # invalid JSON payload
+        (False, True, None, "status 403"),  # no content body, but has reason
+        (False, False, None, "status 500"),  # empty response
+    ],
+)
+def test_check_connection_http_error(
+    has_content: bool,
+    has_reason: bool,
+    json_side_effect: Exception | None,
+    expected_match: str,
+) -> None:
+    """Failure path for _check_connection when there is a HTTPError.
+
+    Args:
+        has_content (bool): Whether the response has a content.
+        has_reason (bool): Whether the response has a reason.
+        json_side_effect (Exception | None): Exception to raise on .json() call.
+        expected_match (str): Expected returned status code.
+    """
+    mock_response = MagicMock()
+    mock_response.raise_for_status.side_effect = exceptions.HTTPError()
+    mock_response.status_code = int(expected_match.split()[1])
+    mock_response.content = b"data" if has_content else b""
+    mock_response.reason = "Some Reason" if has_reason else None
+
+    if json_side_effect:
+        mock_response.json.side_effect = json_side_effect
+        mock_response.text = "Error details here"
+    else:
+        mock_response.json.return_value = {"error": {"code": "ERROR"}}
+
+    with pytest.raises(ConnectionError, match=expected_match):
+        MockDownloader._check_connection(lambda: mock_response, "TEST")
+
+
+@pytest.mark.parametrize(
+    "side_effect",
+    [exceptions.ConnectionError(), exceptions.Timeout()],
+)
+def test_check_connection_network_error(side_effect) -> None:
+    """Failure path for _check_connection when endpoint is unreachable (NetworkError)."""
+    mock_func = MagicMock(side_effect=side_effect)
+
+    with pytest.raises(ConnectionError, match="unreachable"):
+        MockDownloader._check_connection(mock_func, "TEST")
+        mock_func.assert_called_once()
+
+
 @pytest.mark.parametrize(
     "error, expected_return",
     [


### PR DESCRIPTION
# New data crawler for ONS (Brazil) energy data

Code and tests for downloading data from [ONS](https://dados.ons.org.br/dataset/geracao-usina-2) via the existing `load_df_from_url` functionality. This can function as an example for future data crawlers and encompasses:

- a config YAML file `configs/energy/ons.yaml` for source-related settings,
- a data downloader in `rbc/energy/ons/downloader.py`,
- a script for running the downloader in `scripts/energy/ons_download.py`,
- tests for the downloader in `tests/energy/ons/test_downloader.py`.
- updated documentation (`README.md` and `docs/data_sources.md`)

### Additional changes

- **EnergyDownloader**: generalise connectivity checks through new helper function `_check_connection`
- **All energy downloaders**: Clean up and consolidate logic (i.e. always use `task` as argument, not `year`/`month`)

## New dependencies
/

## Related issues

- Closes #21

## Type of change

- [X] New feature (non-breaking change which adds functionality)

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules