### PR TITLE
Features/adme

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ The RenewBench-Crawler repository is structured as follows:
 │   │   ├── loader.py             # Load and validate configs
 │   │   └── schema.py             # Pydantic config models and registry
 │   ├── energy/                 # Energy data crawlers
+│   │   ├── adme/                 # ADME (Uruguay)
 │   │   ├── aeso/                 # AESO (Canada, Alberta)
 │   │   ├── eat/                  # EA Te Mana Hiko (New Zealand)
 │   │   ├── eia/                  # EIA (US)

--- a/configs/energy/adme.yaml
+++ b/configs/energy/adme.yaml
@@ -1,0 +1,2 @@
+paths:
+  dst_dir_raw: /lsdf/raw/energy/adme/

--- a/docs/data_sources.md
+++ b/docs/data_sources.md
@@ -17,7 +17,7 @@ RenewBench-Crawler package.
 | **Canada<br> (Ontario)** | IESO     | downloader &check; | hourly; per plant        | public            | [Website](https://www.ieso.ca/power-data/data-directory)                                                                                                                                                                                                                                                               |
 | **Chile**                | CEN      | planned            |                          |                   |                                                                                                                                                                                                                                                                                                                        |
 | **Brazil**               | ONS      | downloader &check; | hourly; per plant        | public            | [Website](https://dados.ons.org.br/dataset/geracao-usina-2), Data hosting on AWS S3                                                                                                                                                                                                                                    |
-| **Uruguay**              | ADME     | planned            |                          |                   |                                                                                                                                                                                                                                                                                                                        |
+| **Uruguay**              | ADME     | downloader &check; | hourly; per plant        | public            | [Website](https://www.adme.com.uy/controlpanel.php), Data hosting [old](https://www.adme.com.uy/gpf_historico.php) / [new](https://www.adme.com.uy/panelControl/gpf.php)                                                                                                                                               |
 | **Australia**            | AEMO     | planned            |                          |                   |                                                                                                                                                                                                                                                                                                                        |
 | **New<br>Zealand**       | EAT      | downloader &check; | 30 min; per plant        | public            | [Website / Data hosting](https://www.ea.govt.nz/data-and-insights/datasets/wholesale/generation/generation-output/)                                                                                                                                                                                                    |
 | **Japan**                | REI      | planned            | hourly; per region       |                   |                                                                                                                                                                                                                                                                                                                        |
@@ -41,7 +41,7 @@ RenewBench-Crawler package.
 - Files saved as **raw**: 1 `.csv` per day and bidding zone
 - Columns saved as **raw**:
 
-  `timestamp` – timestamp start in UTC-aware (`+00:00`)
+  `timestamp` – timestamp start in UTC-aware ISO 8601 (`YYYY-MM-DDTHH:MM:SS+00:00`)
 
   `Unit_Name` – name of the generating unit
 
@@ -76,7 +76,7 @@ RenewBench-Crawler package.
 - Files saved as **raw**: 1 `.csv` per day
 - Columns saved as **raw**:
 
-  `date` – timestamp start in UTC-aware (`+03:00`)
+  `date` – timestamp start in UTC-aware ISO 8601 (`YYYY-MM-DDTHH:MM:SS+03:00`)
 
   `hour` – hour
 
@@ -105,7 +105,7 @@ RenewBench-Crawler package.
 - Files saved as **raw**: 1 `.csv` per day
 - Columns saved as **raw**:
 
-  `period` - timestamp start in UTC
+  `period` - timestamp start in UTC naive ISO 8601 (`YYYY-MM-DDTHH`)
 
   `respondent` - abbreviation for respondent (company) name
 
@@ -146,7 +146,7 @@ RenewBench-Crawler package.
 - Files saved as **raw**: 1 `.csv` per month
 - Columns saved as **raw**:
 
-  `Date (MST)` - timestamp start in Mountain Standard Time
+  `Date (MST)` - timestamp start in Mountain Standard Time in local format (`YYYY-MM-DD HH:MM:SS`)
 
   `Date (MPT)` - timestamp start in Mountain Prevailing Time (i.e. MST or MDT, as appropriate)
 
@@ -190,7 +190,7 @@ RenewBench-Crawler package.
 - Files saved as **raw**: 1 `.csv` per month
 - Columns saved as **raw**:
 
-  `Delivery Date` – date in local format (probably ET)
+  `Delivery Date` – date in local format (`YYYY-MM-DD`)
 
   `Generator` – generator name
 
@@ -222,7 +222,7 @@ RenewBench-Crawler package.
 - Files saved as **raw**: 1 `.csv` per month
 - Columns saved as **raw**: (translated from Portuguese)
 
-  `datetime` - reference timestamp (YYYY-MM-DD HH:MM:SS), hourly resolution
+  `datetime` - timestamp start in local format (`YYYY-MM-DD HH:MM:SS`)
 
   `subsystem_id` - subsystem identifier (3-character code for Brazilian grid subsystem)
 
@@ -247,6 +247,37 @@ RenewBench-Crawler package.
   `generation_MWmed` - generation in MWmed (average MW over the time interval; equivalent to MWh for hourly data)
 
 </details>
+
+
+<details>
+<summary><b>ADME (Uruguay)</b></summary>
+
+**Access**
+- Website: [ADME Website](https://www.adme.com.uy/controlpanel.php), generation data hosting
+  [archive (= "old")](https://www.adme.com.uy/gpf_historico.php) and [current (= "new")](https://www.adme.com.uy/panelControl/gpf.php)
+- Requirements: public, no authentication needed
+
+**Download & data structure**
+- Spatial resolution: per plant
+- Temporal resolution: hourly
+- Available data timespan: 2009 to now
+- Downloadable files: 1 `.xlsx` per year (before 2019), 1 `.csv` (or `.xlsx`) per
+  month (from 2019 onwards)
+- Files saved as **raw**: 1 `.csv` per month
+- Columns saved as **raw**: (only structural column (= time) translated from Spanish)
+
+  `(/, Fecha)` – timestamp end (!) in local format (`DD-MM-YYYY HH:MM`)
+
+  `(Hidráulico, <unit_name>)`, `(Biomasa, <unit_name>)`, `(Térmico, <unit_name>)`,
+  `(Eólico, <unit_name>)`, `(Solar, <unit_name>)` - generation per plant and source
+
+> **PLEASE NOTE:**
+>
+> The times are stored in an End-of-Interval format that will require conversion! Also,
+> the data is stored with a MultiIndex (double) column header!
+
+</details>
+
 
 <details>
 <summary><b>EAT (New Zealand)</b></summary>
@@ -276,7 +307,7 @@ RenewBench-Crawler package.
 
   `tech_code` – the plant technology
 
-  `trading_date` – the date on which the injections occurred
+  `trading_date` – the date on which the injections occurred (YYYY-MM-DD)
 
   `tp1`, `tp2`, …, `tp50` – generation values in kWh (!) per trading period, starting at
   midnight in half hour intervals. **NOTE:** Daylight saving is applied (46 TP = on
@@ -308,7 +339,7 @@ RenewBench-Crawler package.
 - Files saved as **raw**: 1 `.csv` per snapshot timestamp
 - Columns saved as **raw**:
 
-  `datetime` – timestamp in UTC-aware fixed-offset ISO 8601 (`+08:00`)
+  `datetime` – timestamp start in UTC-aware ISO 8601 (`YYYY-MM-DDTHH:MM:SS+08:00`)
 
   `fueltype` – fuel type (e.g. `COAL`, `GAS`, `NUCLEAR`, `HYDRO`, `PV`)
 

--- a/docs/data_sources.md
+++ b/docs/data_sources.md
@@ -43,21 +43,21 @@ RenewBench-Crawler package.
 
   `timestamp` – timestamp start in UTC-aware ISO 8601 (`YYYY-MM-DDTHH:MM:SS+00:00`)
 
-  `Unit_Name` – name of the generating unit
+  `time_series.mkt_psrtype.power_system_resources.name` – name of the generating unit
 
-  `Unit_Code` – unique identifier (mRID) of the generating unit
+  `time_series.mkt_psrtype.power_system_resources.m_rid.value` – unique identifier (mRID) of the generating unit
 
-  `PSR_Type` – PSR code of fuel category
+  `time_series.mkt_psrtype.psr_type` – PSR code of fuel category
 
-  `Capacity` – nominal capacity of the generating unit
+  `time_series.mkt_psrtype.power_system_resources.nominal_p` – nominal capacity of the generating unit
 
-  `Generation_MW` – actual generation in MW
+  `time_series.period.point.quantity` – actual generation in MW
 
-  `Consumption_MW` – consumption in MW (if the unit is consuming, else `NaN`)
+  `time_series.period.point.secondary_quantity` – consumption in MW (if the unit is consuming, else `NaN`)
 
-  `Measurement_Unit` – physical unit of the reported quantities (usually `MAW`)
+  `time_series.quantity_measure_unit_name` – physical unit of the reported quantities (usually `MAW`)
 
-  `Temporal_Resolution` – string describing the time step (e.g. `PT15M`, `PT60M`)
+  `time_series.period.resolution` – string describing the time step (e.g. `PT15M`, `PT60M`)
 
 </details>
 

--- a/docs/data_sources.md
+++ b/docs/data_sources.md
@@ -220,31 +220,31 @@ RenewBench-Crawler package.
 - Downloadable files: 1 `.csv` (or `.xlsx`) per year (before 2022), 1 `.csv` (or `.xlsx`) per
   month (from 2022 onwards)
 - Files saved as **raw**: 1 `.csv` per month
-- Columns saved as **raw**: (translated from Portuguese)
+- Columns saved as **raw**:
 
-  `datetime` - timestamp start in local format (`YYYY-MM-DD HH:MM:SS`)
+  `din_instante` - timestamp start in local format (`YYYY-MM-DD HH:MM:SS`)
 
-  `subsystem_id` - subsystem identifier (3-character code for Brazilian grid subsystem)
+  `id_subsistema` - subsystem identifier (3-character code for Brazilian grid subsystem)
 
-  `subsystem_name` - name of the subsystem
+  `nom_subsistema` - name of the subsystem
 
-  `state_id` - state identifier (2-character code for Brazilian state)
+  `id_estado` - state identifier (2-character code for Brazilian state)
 
-  `state_name` - name of the state where the plant is located
+  `nom_estado` - name of the state where the plant is located
 
-  `operation_mode` - plant operation mode (e.g. type of operational dispatch)
+  `cod_modalidadeoperacao` - plant operation mode (e.g. type of operational dispatch)
 
-  `plant_type` - plant type (e.g. hydro, thermal, wind, solar)
+  `nom_tipousina` - plant type (e.g. hydro, thermal, wind, solar)
 
-  `fuel_type` - fuel type used by the plant
+  `nom_tipocombustivel` - fuel type used by the plant
 
-  `plant_name` - name of the power plant
+  `nom_usina` - name of the power plant
 
-  `ons_id` - unique identifier assigned by ONS (National System Operator)
+  `id_ons` - unique identifier assigned by ONS (National System Operator)
 
-  `generation_project_code` - unique generation project identifier assigned by ANEEL (Brazilian regulator)
+  `ceg` - unique generation project identifier assigned by ANEEL (Brazilian regulator)
 
-  `generation_MWmed` - generation in MWmed (average MW over the time interval; equivalent to MWh for hourly data)
+  `val_geracao` - generation in MWmed (average MW over the time interval; equivalent to MWh for hourly data)
 
 </details>
 
@@ -264,12 +264,12 @@ RenewBench-Crawler package.
 - Downloadable files: 1 `.xlsx` per year (before 2019), 1 `.csv` (or `.xlsx`) per
   month (from 2019 onwards)
 - Files saved as **raw**: 1 `.csv` per month
-- Columns saved as **raw**: (only structural column (= time) translated from Spanish)
+- Columns saved as **raw**:
 
   `(/, Fecha)` – timestamp end (!) in local format (`DD-MM-YYYY HH:MM`)
 
   `(Hidráulico, <unit_name>)`, `(Biomasa, <unit_name>)`, `(Térmico, <unit_name>)`,
-  `(Eólico, <unit_name>)`, `(Solar, <unit_name>)` - generation per plant and source
+  `(Eólico, <unit_name>)`, `(Solar, <unit_name>)` - generation per plant and source in MWh
 
 > **PLEASE NOTE:**
 >

--- a/rbc/config/schema.py
+++ b/rbc/config/schema.py
@@ -114,6 +114,18 @@ class AccessValidation:
 # ----------------------------------
 # Per-source schemas - ENERGY
 # ----------------------------------
+class AdmeConfig(PathValidation, BaseModel):
+    """Configuration schema for the ADME energy data source.
+
+    Attributes:
+        source (Literal): Name of the data source.
+        paths (Paths): Paths pydantic model for paths.
+    """
+
+    source: Literal["adme"] = "adme"
+    paths: Paths
+
+
 class AesoConfig(PathValidation, AccessValidation, BaseModel):
     """Configuration schema for the AESO energy data source.
 
@@ -263,6 +275,7 @@ class Barra2Config(PathValidation, BaseModel):
 # Schema registry
 # ----------------------------------
 SCHEMA_REGISTRY: dict[str, Type[BaseModel]] = {
+    "adme": AdmeConfig,
     "aeso": AesoConfig,
     "eat": EatConfig,
     "eia": EiaConfig,

--- a/rbc/energy/adme/__init__.py
+++ b/rbc/energy/adme/__init__.py
@@ -1,0 +1,3 @@
+from rbc.energy.adme.downloader import AdmeDownloader
+
+__all__ = ["AdmeDownloader"]

--- a/rbc/energy/adme/downloader.py
+++ b/rbc/energy/adme/downloader.py
@@ -92,6 +92,10 @@ class AdmeDownloader(EnergyDownloader):
         storing in yearly Excel files (old) to monthly CSV and Excel files (new).
         When older data is requested, the structure is changed to mirror the columns
         in the newer data and stored per month as well.
+        ADME follows an End-of-Interval timestamp convention, meaning values for an hour
+        are saved on the dot of the next hour (i.e. "01:00" = data from 0-1 AM, not 1-2 AM).
+        This means for each month, data starts with hour 1 of Day 1 and hour 0 of Day 1
+        of the next month (i.e. start = "01-01-2018 01:00", end = "01-02-2018 00:00").
 
         Args:
             task (DownloadTask): The metadata of a downloading task, here: date (YYYY-MM)
@@ -144,30 +148,8 @@ class AdmeDownloader(EnergyDownloader):
         url = f"{URL_BASE_NEW}anod={task.year}&mesd={month}&periodo=1&fuente=0&tipo=1"
         df = load_df_from_file(url, ".csv", delimiter=";", header=[0, 1])
 
-        # filter to exclude irrelevant timestamps (i.e. hour 0 of day 1 of next month)
-        try:
-            df = self._redefine_time_column(df)
-            df[TIME_COL] = pd.to_datetime(df[TIME_COL], dayfirst=True)
-            month_mask = (df[TIME_COL].dt.year == task.year) & (
-                df[TIME_COL].dt.month == task.month
-            )
-            df = df[month_mask].copy()
-
-        except KeyError:
-            raise DataStructureError(
-                f"ADME file structure change detected in new csv '{url}'! "
-                f"Missing datetime column 'Fecha'"
-            )
-        except (
-            ValueError,
-            AttributeError,
-        ) as e:  # if to_datetime raises DateParseError
-            raise DataStructureError(
-                f"ADME file structure change detected in new csv '{url}'! "
-                f"'Fecha' is no longer datetimelike: {e}"
-            )
-
-        # filter to exclude anything beyond the required columns
+        # filter to exclude anything beyond the required columns (i.e. imported energy)
+        df = self._redefine_time_column(df)
         cutoff = next(
             (i for i, c in enumerate(df.columns) if c[0] not in EXPECTED_COLS_MAPPING),
             None,
@@ -177,6 +159,9 @@ class AdmeDownloader(EnergyDownloader):
 
     def _get_from_old_source(self, task: DownloadTask) -> pd.DataFrame:
         """Extract data from pre-2019 (old) source for a given month using the year's Excel.
+
+        To ensure ADME's End-of-Interval timestamp convention is adhered to, specific
+        masking is implemented. This ensures monthly data is stored as previously described.
 
         Args:
             task (DownloadTask): The metadata of a downloading task, here: date (YYYY-MM)
@@ -192,18 +177,22 @@ class AdmeDownloader(EnergyDownloader):
         with self._download_lock:
             df_year = self._load_yearly_excel(url)
 
-        # filter for the specific month
-        try:
-            month_mask = (df_year[TIME_COL].dt.year == task.year) & (
-                df_year[TIME_COL].dt.month == task.month
-            )
-        except AttributeError as e:
-            raise DataStructureError(
-                f"ADME file structure change detected in old excel '{url}'! "
-                f"'Fecha' is no longer datetimelike: {e}"
-            )
-
+        # filter for the specific month (taking the End-of-Interval convention into account!)
+        next_month = pd.Period(task.date, freq="M") + 1
+        month_mask = (
+            (df_year[TIME_COL].dt.year == task.year)
+            & (df_year[TIME_COL].dt.month == task.month)
+            & (~((df_year[TIME_COL].dt.day == 1) & (df_year[TIME_COL].dt.hour == 0)))
+        ) | (
+            (df_year[TIME_COL].dt.year == next_month.year)
+            & (df_year[TIME_COL].dt.month == next_month.month)
+            & (df_year[TIME_COL].dt.day == 1)
+            & (df_year[TIME_COL].dt.hour == 0)
+        )
         df_month = df_year[month_mask].copy()
+
+        # revert to original time format to be consistent with source and new (post-2019 CSVs)
+        df_month[TIME_COL] = df_month[TIME_COL].dt.strftime("%d-%m-%Y %H:%M")
         return df_month
 
     @lru_cache(maxsize=None)
@@ -217,8 +206,9 @@ class AdmeDownloader(EnergyDownloader):
             pd.DataFrame: Dataframe for the desired year.
 
         Raises:
-            DataStructureError: If downloaded data does not have required sheets or sheet
-                loading does not work as expected.
+            DataStructureError: If downloaded data does not have all required sheets, sheet
+                loading does not work as expected, or the 'Fecha' column data is not
+                datetime-like.
         """
         # 1. load excel once to then extract relevant sheets
         xlsx_file = load_excel_from_file(url)
@@ -267,7 +257,14 @@ class AdmeDownloader(EnergyDownloader):
 
         # 4. ensure df structure is as required for _get_from_old_source processing
         df = self._redefine_time_column(df)
-        df[TIME_COL] = pd.to_datetime(df[TIME_COL], dayfirst=True)
+        try:
+            df[TIME_COL] = pd.to_datetime(df[TIME_COL], dayfirst=True)
+
+        except ValueError as e:  # if to_datetime raises DateParseError
+            raise DataStructureError(
+                f"ADME file structure change detected for '{url}'! "
+                f"'Fecha' is no longer datetimelike: {e}"
+            )
 
         col_order = list(EXPECTED_COLS_MAPPING)
         df = df[

--- a/rbc/energy/adme/downloader.py
+++ b/rbc/energy/adme/downloader.py
@@ -1,0 +1,302 @@
+"""ADME DATA DOWNLOADER.
+
+Access ADME website and their Excel/CSV files using requests and pandas load.
+"""
+
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from functools import lru_cache
+from pathlib import Path
+
+import pandas as pd
+import requests
+from loguru import logger
+
+from rbc.energy.utils import (
+    WORKERS,
+    DataStructureError,
+    DownloadTask,
+    EnergyDownloader,
+    MissingDataError,
+    load_df_from_file,
+    load_excel_from_file,
+)
+
+URL_ROOT_NEW = "https://www.adme.com.uy/panelControl/gpf.php"
+URL_BASE_NEW = "https://www.adme.com.uy/panelControl/gpf_excel.php?"
+URL_ROOT_OLD = "https://www.adme.com.uy/gpf_historico.php"
+URL_BASE_OLD = "https://www.adme.com.uy/db-docs/Docs_secciones/nid_1418/"
+
+MIN_YEAR = 2009
+EXPECTED_COLS_MAPPING = {
+    "Fecha": "Datetime",
+    "Hidráulico": "Hydro",
+    "Biomasa": "Biomass",
+    "Térmico": "Thermal",
+    "Eólico": "Wind",
+    "Solar": "Solar",
+}
+
+EXPECTED_SHEETS = ("GPF", "Eólica", "Solar", "Térmica", "Biomasa")
+TIME_COL = ("Fecha", "/")
+
+
+class AdmeDownloader(EnergyDownloader):
+    """ADME data downloader.
+
+    Attributes:
+        _download_lock (threading.Lock): Lock for downloading yearly data once.
+    """
+
+    def __init__(
+        self,
+        output_path: Path,
+        years: list[int],
+        resume: bool = True,
+    ):
+        """Initializes the instance.
+
+        Args:
+            output_path (Path): Path to the output directory.
+            years (list[int]): List of years to get data for.
+            resume (bool, optional): Whether to resume from a previous download (True)
+                or start from scratch (False). Defaults to True.
+        """
+        super().__init__(
+            output_path=output_path, years=years, start_year=MIN_YEAR, resume=resume
+        )
+        self._download_lock = threading.Lock()
+        self._check_connection(
+            lambda: requests.head(URL_ROOT_NEW, timeout=10), "ADME (new)"
+        )
+        self._check_connection(
+            lambda: requests.head(URL_ROOT_OLD, timeout=10), "ADME (old)"
+        )
+
+        logger.info(f"ADME Downloader initialized for:\n- years:\t\t{years}")
+
+    def download_data(self) -> None:
+        """Parse data for all given years from ADME site and save to CSV."""
+        tasks = [DownloadTask(date=d) for d in self._get_month_list()]
+
+        logger.info(
+            f"Downloading tasks: {tasks[0].identifier} --- {tasks[-1].identifier}"
+        )
+        with ThreadPoolExecutor(max_workers=WORKERS) as executor:
+            executor.map(self._threading_wrapper, tasks)
+
+    def _get_task_data(self, task: DownloadTask) -> pd.DataFrame:  # type: ignore[override]
+        """Get ADME generation data per plant for one specific month.
+
+        ADME's data storing structure and method was changed in 2019 from
+        storing in yearly Excel files (old) to monthly CSV and Excel files (new).
+        When older data is requested, the structure is changed to mirror the columns
+        in the newer data and stored per month as well.
+
+        Args:
+            task (DownloadTask): The metadata of a downloading task, here: date (YYYY-MM)
+
+        Returns:
+            pd.DataFrame: Dataframe for specific date with the columns as per EXPECTED_COLS_MAPPING
+                (English translated versions as column headers).
+
+        Raises:
+            MissingDataError: If an earlier year was provided than data exists for or if the
+                dataframe is empty.
+            DataStructureError: If the data structure changed and relevant columns are now
+                missing (this will cause the entire run to be killed).
+        """
+        if task.year < 2019:
+            df = self._get_from_old_source(task)
+        else:
+            df = self._get_from_new_source(task)
+
+        if df.empty:
+            raise MissingDataError(
+                f"No energy data available for {task.year}-{task.month}. Skipping..."
+            )
+
+        missing_cols = [
+            c for c in EXPECTED_COLS_MAPPING if c not in df.columns.get_level_values(0)
+        ]
+        if missing_cols:
+            raise DataStructureError(
+                f"ADME file structure change detected for '{task.identifier}'! "
+                f"Missing columns: {missing_cols}"
+            )
+
+        # translate double column headers to English
+        df.columns = pd.MultiIndex.from_tuples(
+            [(EXPECTED_COLS_MAPPING.get(c[0], c[0]), c[1]) for c in df.columns]
+        )
+        return df
+
+    def _get_from_new_source(self, task: DownloadTask) -> pd.DataFrame:
+        """Extract data from 2019 onwards (new) source for a given month.
+
+        Args:
+            task (DownloadTask): The metadata of a downloading task, here: date (YYYY-MM)
+
+        Returns:
+            pd.DataFrame: Dataframe for a desired month.
+        """
+        month = str(task.month).zfill(2)
+        url = f"{URL_BASE_NEW}anod={task.year}&mesd={month}&periodo=1&fuente=0&tipo=1"
+        df = load_df_from_file(url, ".csv", delimiter=";", header=[0, 1])
+
+        # filter to exclude irrelevant timestamps (i.e. hour 0 of day 1 of next month)
+        try:
+            df = self._redefine_time_column(df)
+            df[TIME_COL] = pd.to_datetime(df[TIME_COL], dayfirst=True)
+            month_mask = (df[TIME_COL].dt.year == task.year) & (
+                df[TIME_COL].dt.month == task.month
+            )
+            df = df[month_mask].copy()
+
+        except KeyError:
+            raise DataStructureError(
+                f"ADME file structure change detected in new csv '{url}'! "
+                f"Missing datetime column 'Fecha'"
+            )
+        except (
+            ValueError,
+            AttributeError,
+        ) as e:  # if to_datetime raises DateParseError
+            raise DataStructureError(
+                f"ADME file structure change detected in new csv '{url}'! "
+                f"'Fecha' is no longer datetimelike: {e}"
+            )
+
+        # filter to exclude anything beyond the required columns
+        cutoff = next(
+            (i for i, c in enumerate(df.columns) if c[0] not in EXPECTED_COLS_MAPPING),
+            None,
+        )
+        df = df.iloc[:, :cutoff]
+        return df
+
+    def _get_from_old_source(self, task: DownloadTask) -> pd.DataFrame:
+        """Extract data from pre-2019 (old) source for a given month using the year's Excel.
+
+        Args:
+            task (DownloadTask): The metadata of a downloading task, here: date (YYYY-MM)
+
+        Returns:
+            pd.DataFrame: Dataframe for a desired month.
+
+        Raises:
+            DataStructureError: If the TIME_COL ("fecha"-based) data is not datetime-like.
+        """
+        url = f"{URL_BASE_OLD}gpf_{task.year}.xlsx"
+
+        with self._download_lock:
+            df_year = self._load_yearly_excel(url)
+
+        # filter for the specific month
+        try:
+            month_mask = (df_year[TIME_COL].dt.year == task.year) & (
+                df_year[TIME_COL].dt.month == task.month
+            )
+        except AttributeError as e:
+            raise DataStructureError(
+                f"ADME file structure change detected in old excel '{url}'! "
+                f"'Fecha' is no longer datetimelike: {e}"
+            )
+
+        df_month = df_year[month_mask].copy()
+        return df_month
+
+    @lru_cache(maxsize=None)
+    def _load_yearly_excel(self, url: str) -> pd.DataFrame:
+        """Downloads the yearly Excel and concatenates into a standardized df once.
+
+        Args:
+            url (str): URL to download data from.
+
+        Returns:
+            pd.DataFrame: Dataframe for the desired year.
+
+        Raises:
+            DataStructureError: If downloaded data does not have required sheets or sheet
+                loading does not work as expected.
+        """
+        # 1. load excel once to then extract relevant sheets
+        xlsx_file = load_excel_from_file(url)
+
+        if not set(EXPECTED_SHEETS).issubset(set(xlsx_file.sheet_names)):
+            raise DataStructureError(
+                f"ADME file structure change detected in old excel '{url}'! "
+                f"Not all required sheets '{EXPECTED_SHEETS}' exist!"
+            )
+
+        # 2. get relevant sheets
+        df_dict = {}
+
+        for sheet in EXPECTED_SHEETS:
+            try:
+                # get df per fuel type (wind, solar, etc)
+                df = pd.read_excel(xlsx_file, sheet_name=sheet, header=3)
+
+                # special case: extract df for hydro from general "GPF" sheet
+                if sheet == "GPF":
+                    cutoff = next(
+                        (i for i, c in enumerate(df.columns) if c in EXPECTED_SHEETS),
+                        None,
+                    )
+                    df = df.iloc[:, :cutoff]
+
+                # define key for storing df as the fuel type
+                fuel_type = {
+                    "GPF": "Hidráulico",
+                    "Eólica": "Eólico",
+                    "Térmica": "Térmico",
+                }.get(sheet, sheet)
+
+                df = df.set_index("Fecha")
+                df_dict[fuel_type] = df
+
+            except Exception as e:
+                raise DataStructureError(
+                    f"ADME file structure change detected in old excel '{url}'! "
+                    f"Sheet {sheet} does not contain loadable data: {e}"
+                )
+
+        # 3. concatenate all dataframes into one
+        df = pd.concat(df_dict, axis=1)
+        df = df.reset_index()
+
+        # 4. ensure df structure is as required for _get_from_old_source processing
+        df = self._redefine_time_column(df)
+        df[TIME_COL] = pd.to_datetime(df[TIME_COL], dayfirst=True)
+
+        col_order = list(EXPECTED_COLS_MAPPING)
+        df = df[
+            sorted(
+                df.columns,
+                key=lambda c: (
+                    col_order.index(c[0]) if c[0] in col_order else len(col_order)
+                ),
+            )
+        ]
+        return df
+
+    # --------------------------------------------
+    # Helper methods
+    # --------------------------------------------
+    @staticmethod
+    def _redefine_time_column(df: pd.DataFrame) -> pd.DataFrame:
+        """Redefine the timestamp ("Fecha") double column header, aligning naming throughout.
+
+        Args:
+            df (pd.DataFrame): Dataframe with "Fecha" double column to be renamed.
+
+        Returns:
+            pd.DataFrame: adapted Dataframe.
+        """
+        df.columns = pd.MultiIndex.from_tuples(
+            [
+                TIME_COL if (c[0] == "Fecha" or c == ("/", "Fecha")) else c
+                for c in df.columns
+            ]
+        )
+        return df

--- a/rbc/energy/adme/downloader.py
+++ b/rbc/energy/adme/downloader.py
@@ -189,8 +189,9 @@ class AdmeDownloader(EnergyDownloader):
         df_month[TIME_COL] = df_month[TIME_COL].dt.strftime("%d-%m-%Y %H:%M")
         return df_month
 
+    @staticmethod
     @lru_cache(maxsize=None)
-    def _load_yearly_excel(self, url: str) -> pd.DataFrame:
+    def _load_yearly_excel(url: str) -> pd.DataFrame:
         """Downloads the yearly Excel and concatenates into a standardized df once.
 
         Args:

--- a/rbc/energy/adme/downloader.py
+++ b/rbc/energy/adme/downloader.py
@@ -28,17 +28,9 @@ URL_ROOT_OLD = "https://www.adme.com.uy/gpf_historico.php"
 URL_BASE_OLD = "https://www.adme.com.uy/db-docs/Docs_secciones/nid_1418/"
 
 MIN_YEAR = 2009
-EXPECTED_COLS_MAPPING = {
-    "Fecha": "Datetime",
-    "Hidráulico": "Hydro",
-    "Biomasa": "Biomass",
-    "Térmico": "Thermal",
-    "Eólico": "Wind",
-    "Solar": "Solar",
-}
-
-EXPECTED_SHEETS = ("GPF", "Eólica", "Solar", "Térmica", "Biomasa")
-TIME_COL = ("Fecha", "/")
+EXPECTED_COLS = ["/", "Hidráulico", "Biomasa", "Térmico", "Eólico", "Solar"]
+TIME_COL = ("/", "Fecha")
+EXPECTED_OLD_SHEETS = ("GPF", "Eólica", "Solar", "Térmica", "Biomasa")
 
 
 class AdmeDownloader(EnergyDownloader):
@@ -101,8 +93,7 @@ class AdmeDownloader(EnergyDownloader):
             task (DownloadTask): The metadata of a downloading task, here: date (YYYY-MM)
 
         Returns:
-            pd.DataFrame: Dataframe for specific date with the columns as per EXPECTED_COLS_MAPPING
-                (English translated versions as column headers).
+            pd.DataFrame: Dataframe for specific date with the columns as per EXPECTED_COLS.
 
         Raises:
             MissingDataError: If an earlier year was provided than data exists for or if the
@@ -121,7 +112,7 @@ class AdmeDownloader(EnergyDownloader):
             )
 
         missing_cols = [
-            c for c in EXPECTED_COLS_MAPPING if c not in df.columns.get_level_values(0)
+            c for c in EXPECTED_COLS if c not in df.columns.get_level_values(0)
         ]
         if missing_cols:
             raise DataStructureError(
@@ -129,13 +120,10 @@ class AdmeDownloader(EnergyDownloader):
                 f"Missing columns: {missing_cols}"
             )
 
-        # translate double column headers to English
-        df.columns = pd.MultiIndex.from_tuples(
-            [(EXPECTED_COLS_MAPPING.get(c[0], c[0]), c[1]) for c in df.columns]
-        )
         return df
 
-    def _get_from_new_source(self, task: DownloadTask) -> pd.DataFrame:
+    @staticmethod
+    def _get_from_new_source(task: DownloadTask) -> pd.DataFrame:
         """Extract data from 2019 onwards (new) source for a given month.
 
         Args:
@@ -143,18 +131,24 @@ class AdmeDownloader(EnergyDownloader):
 
         Returns:
             pd.DataFrame: Dataframe for a desired month.
+
+        Raises:
+            DataStructureError: If the data structure changed and relevant columns are now
+                missing (this will cause the entire run to be killed).
         """
         month = str(task.month).zfill(2)
         url = f"{URL_BASE_NEW}anod={task.year}&mesd={month}&periodo=1&fuente=0&tipo=1"
         df = load_df_from_file(url, ".csv", delimiter=";", header=[0, 1])
 
         # filter to exclude anything beyond the required columns (i.e. imported energy)
-        df = self._redefine_time_column(df)
-        cutoff = next(
-            (i for i, c in enumerate(df.columns) if c[0] not in EXPECTED_COLS_MAPPING),
-            None,
-        )
-        df = df.iloc[:, :cutoff]
+        try:
+            df = df.loc[:, EXPECTED_COLS]
+        except KeyError as e:
+            raise DataStructureError(
+                f"ADME structure change detected for '{task.identifier}'! "
+                f"Relevant columns are missing: {e}"
+            )
+
         return df
 
     def _get_from_old_source(self, task: DownloadTask) -> pd.DataFrame:
@@ -213,16 +207,16 @@ class AdmeDownloader(EnergyDownloader):
         # 1. load excel once to then extract relevant sheets
         xlsx_file = load_excel_from_file(url)
 
-        if not set(EXPECTED_SHEETS).issubset(set(xlsx_file.sheet_names)):
+        if not set(EXPECTED_OLD_SHEETS).issubset(set(xlsx_file.sheet_names)):
             raise DataStructureError(
                 f"ADME file structure change detected in old excel '{url}'! "
-                f"Not all required sheets '{EXPECTED_SHEETS}' exist!"
+                f"Not all required sheets '{EXPECTED_OLD_SHEETS}' exist!"
             )
 
         # 2. get relevant sheets
         df_dict = {}
 
-        for sheet in EXPECTED_SHEETS:
+        for sheet in EXPECTED_OLD_SHEETS:
             try:
                 # get df per fuel type (wind, solar, etc)
                 df = pd.read_excel(xlsx_file, sheet_name=sheet, header=3)
@@ -230,7 +224,11 @@ class AdmeDownloader(EnergyDownloader):
                 # special case: extract df for hydro from general "GPF" sheet
                 if sheet == "GPF":
                     cutoff = next(
-                        (i for i, c in enumerate(df.columns) if c in EXPECTED_SHEETS),
+                        (
+                            i
+                            for i, c in enumerate(df.columns)
+                            if c in EXPECTED_OLD_SHEETS
+                        ),
                         None,
                     )
                     df = df.iloc[:, :cutoff]
@@ -256,8 +254,11 @@ class AdmeDownloader(EnergyDownloader):
         df = df.reset_index()
 
         # 4. ensure df structure is as required for _get_from_old_source processing
-        df = self._redefine_time_column(df)
         try:
+            # format the datetime column header and column values
+            df.columns = pd.MultiIndex.from_tuples(
+                [TIME_COL if c[0] == "Fecha" else c for c in df.columns]
+            )
             df[TIME_COL] = pd.to_datetime(df[TIME_COL], dayfirst=True)
 
         except ValueError as e:  # if to_datetime raises DateParseError
@@ -266,34 +267,15 @@ class AdmeDownloader(EnergyDownloader):
                 f"'Fecha' is no longer datetimelike: {e}"
             )
 
-        col_order = list(EXPECTED_COLS_MAPPING)
+        # sort cols to match new source dfs (cols not in EXPECTED_COLS will be at end)
         df = df[
             sorted(
                 df.columns,
                 key=lambda c: (
-                    col_order.index(c[0]) if c[0] in col_order else len(col_order)
+                    EXPECTED_COLS.index(c[0])
+                    if c[0] in EXPECTED_COLS
+                    else len(EXPECTED_COLS)
                 ),
             )
         ]
-        return df
-
-    # --------------------------------------------
-    # Helper methods
-    # --------------------------------------------
-    @staticmethod
-    def _redefine_time_column(df: pd.DataFrame) -> pd.DataFrame:
-        """Redefine the timestamp ("Fecha") double column header, aligning naming throughout.
-
-        Args:
-            df (pd.DataFrame): Dataframe with "Fecha" double column to be renamed.
-
-        Returns:
-            pd.DataFrame: adapted Dataframe.
-        """
-        df.columns = pd.MultiIndex.from_tuples(
-            [
-                TIME_COL if (c[0] == "Fecha" or c == ("/", "Fecha")) else c
-                for c in df.columns
-            ]
-        )
         return df

--- a/rbc/energy/entsoe/downloader.py
+++ b/rbc/energy/entsoe/downloader.py
@@ -25,17 +25,17 @@ from rbc.energy.utils import (
     write_df_to_csv,
 )
 
-EXPECTED_COLS_MAPPING = {
-    "timestamp": "timestamp",
-    "time_series.mkt_psrtype.power_system_resources.name": "Unit_Name",
-    "time_series.mkt_psrtype.power_system_resources.m_rid.value": "Unit_Code",
-    "time_series.mkt_psrtype.psr_type": "PSR_Type",
-    "time_series.mkt_psrtype.power_system_resources.nominal_p": "Capacity",
-    "time_series.period.point.quantity": "Generation_MW",
-    "time_series.period.point.secondary_quantity": "Consumption_MW",
-    "time_series.quantity_measure_unit_name": "Measurement_Unit",
-    "time_series.period.resolution": "Temporal_Resolution",
-}
+EXPECTED_COLS = [
+    "timestamp",
+    "time_series.mkt_psrtype.power_system_resources.name",  # Unit name
+    "time_series.mkt_psrtype.power_system_resources.m_rid.value",  # Unit code
+    "time_series.mkt_psrtype.psr_type",  # PSR type (= fuel type)
+    "time_series.mkt_psrtype.power_system_resources.nominal_p",  # Capacity
+    "time_series.period.point.quantity",  # Generation in MW
+    "time_series.period.point.secondary_quantity",  # Consumption in MW
+    "time_series.quantity_measure_unit_name",  # Measurement unit
+    "time_series.period.resolution",  # Temporal resolution
+]
 
 
 class EntsoeDownloader(EnergyDownloader):
@@ -154,20 +154,27 @@ class EntsoeDownloader(EnergyDownloader):
 
         try:
             # Columns names are made to match those on the Entso-E Transparency Platform
-            df = df.loc[:, list(EXPECTED_COLS_MAPPING.keys())].rename(
-                columns=EXPECTED_COLS_MAPPING
-            )
+            df = df.loc[:, EXPECTED_COLS]
         except KeyError as e:
             raise DataStructureError(
                 f"Entsoe-E structure change detected for '{task.identifier}'! "
                 f"Relevant columns are missing: {e}"
             )
 
-        # Drop rows that have no PSR_Type and neither Unit_Name nor Unit_Code values
-        df = df.dropna(subset=["PSR_Type"])
-        df = df.dropna(subset=["Unit_Name", "Unit_Code"], how="all")
+        # Drop rows that have no PSR type and neither Unit Name nor Unit Code values
+        df = df.dropna(subset=["time_series.mkt_psrtype.psr_type"])
+        df = df.dropna(
+            subset=[
+                "time_series.mkt_psrtype.power_system_resources.name",
+                "time_series.mkt_psrtype.power_system_resources.m_rid.value",
+            ],
+            how="all",
+        )
 
-        df = df.sort_values(by=["timestamp", "Unit_Name"], ascending=[True, True])
+        df = df.sort_values(
+            by=["timestamp", "time_series.mkt_psrtype.power_system_resources.name"],
+            ascending=[True, True],
+        )
         return df
 
     def _save_task_data(self, task: DownloadTask, df: pd.DataFrame) -> None:
@@ -180,13 +187,15 @@ class EntsoeDownloader(EnergyDownloader):
             task (DownloadTask): The metadata for the task that was downloaded.
             df (pd.DataFrame): Downloaded dataframe for the task.
         """
-        df_full = df.dropna(subset=["Temporal_Resolution"])
+        df_full = df.dropna(subset=["time_series.period.resolution"])
         if len(df_full) != len(df):
             logger.warning(
                 "Some rows are missing temporal resolution values! Removing those rows."
             )
 
-        for t_res, df_t_res in df_full.groupby("Temporal_Resolution", sort=True):
+        for t_res, df_t_res in df_full.groupby(
+            "time_series.period.resolution", sort=True
+        ):
             updated_task = task.update(
                 temporal_resolution=self._normalize_temporal_resolution(str(t_res))
             )

--- a/rbc/energy/ieso/downloader.py
+++ b/rbc/energy/ieso/downloader.py
@@ -19,6 +19,7 @@ from rbc.energy.utils import (
     EnergyDownloader,
     MissingDataError,
     load_df_from_file,
+    load_excel_from_file,
 )
 
 URL_BASE_NEW = "https://reports-public.ieso.ca/public/GenOutputCapabilityMonth"
@@ -188,8 +189,11 @@ class IesoDownloader(EnergyDownloader):
         Raises:
             DataStructureError: If downloaded data does not have capacity values.
         """
-        # 1. get generation ('Output') data and standardize
-        df_gen = load_df_from_file(url, sheet_name="Output")
+        # 1. load excel once to then extract relevant sheets
+        xlsx_file = load_excel_from_file(url)
+
+        # 2. get generation ('Output') data and standardize
+        df_gen = pd.read_excel(xlsx_file, sheet_name="Output")
         df_gen = self.standardize_old_data(df_gen, "Output")
 
         # 2. get capacity ('Capability') data and standardize
@@ -200,7 +204,7 @@ class IesoDownloader(EnergyDownloader):
             "Capability",  # for 2010-2013 and 2019
         ]:
             try:
-                df_cap = load_df_from_file(url, sheet_name=sheet)
+                df_cap = pd.read_excel(xlsx_file, sheet_name=sheet)
                 break
             except ValueError:  # continue to next one if sheet does not exist
                 continue

--- a/rbc/energy/ons/downloader.py
+++ b/rbc/energy/ons/downloader.py
@@ -24,20 +24,20 @@ from rbc.energy.utils import (
 URL_BASE = "https://ons-aws-prod-opendata.s3.amazonaws.com/dataset/geracao_usina_2_ho/"
 
 MIN_YEAR = 2000
-EXPECTED_COLS_MAPPING = {
-    "din_instante": "datetime",
-    "id_subsistema": "subsystem_id",
-    "nom_subsistema": "subsystem_name",
-    "id_estado": "state_id",
-    "nom_estado": "state_name",
-    "cod_modalidadeoperacao": "operation_mode",
-    "nom_tipousina": "plant_type",
-    "nom_tipocombustivel": "fuel_type",
-    "nom_usina": "plant_name",
-    "id_ons": "ons_id",
-    "ceg": "generation_project_code",
-    "val_geracao": "generation_MWmed",
-}
+EXPECTED_COLS = [
+    "din_instante",
+    "id_subsistema",
+    "nom_subsistema",
+    "id_estado",
+    "nom_estado",
+    "cod_modalidadeoperacao",
+    "nom_tipousina",
+    "nom_tipocombustivel",
+    "nom_usina",
+    "id_ons",
+    "ceg",
+    "val_geracao",
+]
 
 
 class OnsDownloader(EnergyDownloader):
@@ -93,8 +93,7 @@ class OnsDownloader(EnergyDownloader):
             task (DownloadTask): The metadata of a downloading task, here: date (YYYY-MM)
 
         Returns:
-            pd.DataFrame: Dataframe for specific date with the columns as per EXPECTED_COLS_MAPPING
-                (English translated versions as column headers).
+            pd.DataFrame: Dataframe for specific date with the columns as per EXPECTED_COLS.
 
         Raises:
             MissingDataError: If an earlier year was provided than data exists for or if the
@@ -112,14 +111,13 @@ class OnsDownloader(EnergyDownloader):
                 f"No energy data available for {task.year}-{task.month}. Skipping..."
             )
 
-        missing_cols = [c for c in EXPECTED_COLS_MAPPING if c not in df.columns]
+        missing_cols = [c for c in EXPECTED_COLS if c not in df.columns]
         if missing_cols:
             raise DataStructureError(
                 f"ONS file structure change detected for '{task.identifier}'! "
                 f"Missing columns: {missing_cols}"
             )
 
-        df = df.rename(columns=EXPECTED_COLS_MAPPING)
         return df
 
     @staticmethod

--- a/rbc/energy/utils.py
+++ b/rbc/energy/utils.py
@@ -9,10 +9,11 @@ import re
 import threading
 import time
 import urllib
+import zipfile
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field, replace
 from pathlib import Path
-from typing import Callable
+from typing import Callable, Literal
 
 import pandas as pd
 import requests
@@ -500,13 +501,16 @@ def write_df_to_csv(df: pd.DataFrame, file_path: Path, index: bool = False) -> N
     logger.info(f"Successfully wrote dataframe to '{file_path}'")
 
 
-def load_df_from_file(file_path: Path | str, **args) -> pd.DataFrame:
+def load_df_from_file(
+    file_path: Path | str, file_type: Literal[".csv", ".xlsx"] | None = None, **args
+) -> pd.DataFrame:
     """Load pandas dataframe from a file such as an Excel or csv (file or URL directly).
 
     Args:
         file_path (Path | str): Path to the Excel file.
+        file_type (str | None): Manual file type definition for loading. Defaults to None.
         args (optional): Additional arguments to be passed to pandas loading
-        function, i.e. sheet_name for an Excel or index_col for a CSV.
+            function, i.e. sheet_name for an Excel or index_col for a CSV.
 
     Returns:
         pd.DataFrame: Pandas dataframe extracted from the provided file.
@@ -516,11 +520,13 @@ def load_df_from_file(file_path: Path | str, **args) -> pd.DataFrame:
             doesn't exist, if invalid arguments (args) were provided for loading with pandas.
         RETRY_ERRORS: If the file is a URL that is inaccessible for some reason.
     """
+    suffix = file_type or Path(file_path).suffix
+
     try:
-        if Path(file_path).suffix == ".xlsx":
+        if suffix == ".xlsx":
             df = pd.read_excel(str(file_path), **args)
 
-        elif Path(file_path).suffix == ".csv":
+        elif suffix == ".csv":
             df = pd.read_csv(str(file_path), **args)
 
         else:
@@ -539,3 +545,35 @@ def load_df_from_file(file_path: Path | str, **args) -> pd.DataFrame:
 
     logger.info(f"Successfully loaded dataframe from '{file_path}'")
     return df
+
+
+def load_excel_from_file(file_path: Path | str) -> pd.ExcelFile:
+    """Load an Excel file from the provided URL.
+
+    Args:
+        file_path (str): URL to download data from.
+
+    Returns:
+        pd.ExcelFile: Excel file extracted from the provided URL.
+
+    Raises:
+        InvalidError: If the file isn't an xlsx, if the file doesn't exist
+        RETRY_ERRORS: If the file is a URL that is inaccessible for some reason.
+    """
+    if Path(file_path).suffix != ".xlsx":
+        raise InvalidError(f"Invalid extension in '{file_path}' - not an xlsx!")
+
+    try:
+        xlsx_file = pd.ExcelFile(file_path)
+
+    except FileNotFoundError:
+        raise InvalidError(f"Invalid path - file '{file_path}' does not exist!")
+
+    except zipfile.BadZipFile:
+        raise InvalidError(f"Invalid file content - '{file_path}' is not a valid xlsx!")
+
+    except RETRY_ERRORS:  # these can occur when the file is a URL!
+        raise
+
+    logger.info(f"Successfully loaded excel from '{file_path}'")
+    return xlsx_file

--- a/scripts/energy/adme_download.py
+++ b/scripts/energy/adme_download.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python
+"""ADME DATA DOWNLOAD SCRIPT.
+
+Download data from ADME website for Uruguay.
+"""
+
+from argparse import ArgumentParser, Namespace
+from datetime import datetime
+
+from loguru import logger
+
+from rbc.config.loader import load_config, parse_key_value_pairs
+from rbc.energy.adme import AdmeDownloader
+from rbc.energy.adme.downloader import MIN_YEAR
+from rbc.utils import setup_logging
+
+SOURCE = "adme"
+
+
+def parse_arguments() -> Namespace:
+    """Parse command line arguments.
+
+    Returns:
+        argparse.Namespace: Namespace with parsed command line arguments.
+    """
+    parser = ArgumentParser(prog="ADME data download")
+    parser.add_argument(
+        "-y",
+        "--years",
+        nargs="+",
+        type=int,
+        default=list(range(MIN_YEAR, datetime.now().year + 1)),
+        help=f"Years to download. Example: -y 2020 2021. "
+        f"Default: {list(range(MIN_YEAR, datetime.now().year + 1))}",
+    )
+    parser.add_argument(
+        "--no-resume",
+        dest="resume",
+        action="store_false",
+        help="Do not resume download from a previous checkpoint.",
+    )
+    parser.set_defaults(resume=True)
+    parser.add_argument(
+        "-o",
+        "--cfg_options",
+        action="append",
+        help="Override YAML config values (supports nested keys). "
+        "Example: -o paths.dst_dir_raw=/your/path/",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    """Coordinating ADME data download."""
+    args = parse_arguments()
+    overrides = parse_key_value_pairs(args.cfg_options) if args.cfg_options else None
+
+    cfg = load_config(source=SOURCE, overrides=overrides)
+    setup_logging(output_dir=cfg.paths.dst_dir_raw)
+    logger.info(f"Flags for the '{SOURCE}' download:\n{args}")
+    logger.info(f"Config for the '{SOURCE}' download:\n{cfg}")
+
+    downloader = AdmeDownloader(
+        output_path=cfg.paths.dst_dir_raw,
+        years=args.years,
+        resume=args.resume,
+    )
+    downloader.download_data()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/config/conftest.py
+++ b/tests/config/conftest.py
@@ -16,6 +16,7 @@ def source_configs(tmp_path: Path) -> dict:
         dict: Dictionary of example source config dicts.
     """
     return {
+        "adme": {"paths": {"dst_dir_raw": str(Path(tmp_path, "adme"))}},
         "aeso": {
             "paths": {"dst_dir_raw": str(Path(tmp_path, "aeso"))},
             "access": {"api_key": "token"},

--- a/tests/energy/adme/test_downloader.py
+++ b/tests/energy/adme/test_downloader.py
@@ -141,7 +141,7 @@ def test_downloader_initialization_invalid_access(init_args: dict) -> None:
         with pytest.raises(ConnectionError, match="API/URL access failed"):
             AdmeDownloader(**init_args)
 
-            assert mock_head.call_count == 2
+        assert mock_head.call_count == 2
 
 
 def test_download_data_resume(init_args: dict) -> None:

--- a/tests/energy/adme/test_downloader.py
+++ b/tests/energy/adme/test_downloader.py
@@ -1,0 +1,420 @@
+"""Tests for ADME energy data downloader."""
+
+import pickle
+from pathlib import Path
+from typing import Generator
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+import pytest
+from requests import exceptions
+
+from rbc.energy.adme import AdmeDownloader
+from rbc.energy.adme.downloader import (
+    EXPECTED_COLS,
+    EXPECTED_OLD_SHEETS,
+    TIME_COL,
+    URL_BASE_NEW,
+    URL_BASE_OLD,
+)
+from rbc.energy.utils import DataStructureError, DownloadTask, MissingDataError
+
+
+# ----------------------------------
+# Fixtures
+# ----------------------------------
+@pytest.fixture
+def init_args(tmp_path: Path) -> dict:
+    """Creates a basic setup with a temporary directory.
+
+    Args:
+        tmp_path (Path): Path to the temporary directory.
+
+    Returns:
+        dict: initialization arguments.
+    """
+    return {
+        "output_path": tmp_path,
+        "years": [2020],
+        "resume": False,
+    }
+
+
+@pytest.fixture
+def downloader(init_args: dict) -> AdmeDownloader:
+    """Provides an AdmeDownloader instance with mocked connectivity checks.
+
+    Args:
+        init_args (dict): Arguments used to initialize an AdmeDownloader instance.
+
+    Returns:
+        AdmeDownloader: AdmeDownloader instance.
+    """
+    with patch("rbc.energy.adme.downloader.requests.head") as mock_head:
+        mock_head.return_value = MagicMock(status_code=200)
+        return AdmeDownloader(**init_args)
+
+
+@pytest.fixture
+def task(init_args: dict) -> DownloadTask:
+    """Gets a monthly task as 'date=YYYY-MM' from the init arguments.
+
+    Args:
+        init_args (dict): Arguments used to initialize an AdmeDownloader instance.
+
+    Returns:
+        DownloadTask: The metadata of a downloading task, here: date (YYYY-MM)
+    """
+    year = init_args["years"][0]
+    return DownloadTask(date=f"{year}-01")
+
+
+def get_mock_df(
+    spec_task: DownloadTask,
+    columns: list[tuple[str, str]] | None = None,
+    n_rows: int = 1,
+) -> pd.DataFrame:
+    """Gets a mock dataframe (with MultiIndex column headers) for a specific task.
+
+    Args:
+        spec_task (DownloadTask): The metadata of a downloading task, here: date (YYYY-MM)
+        columns (list[tuple[str, str]], optional): The dataframe columns as tuples.
+            Defaults to None, in which case all required columns are used.
+        n_rows (int, optional): The number of dataframe rows. Defaults to 1.
+
+    Returns:
+        pandas.DataFrame: Mock dataframe.
+    """
+    if columns is None:
+        columns = [TIME_COL] + [(c, "A") for c in EXPECTED_COLS if c != "/"]
+
+    idx = pd.MultiIndex.from_tuples(columns)
+    data: dict[tuple[str, str], list] = {c: list(range(1, n_rows + 1)) for c in idx}
+
+    # check if columns contain datetime elements, redefine data values
+    for col in columns:
+        if col == TIME_COL:
+            n_rows = n_rows if n_rows <= 23 else 23  # can't exceed 24 hours of the day
+            dates = [
+                f"01-{str(spec_task.month).zfill(2)}-{spec_task.year} {str(i).zfill(2)}:00"
+                for i in range(1, n_rows + 1)
+            ]
+            data[col] = dates
+
+    return pd.DataFrame(data)
+
+
+@pytest.fixture(autouse=True)
+def clear_cache() -> Generator[None, None, None]:
+    """Clear lru_cache after each test to avoid cache pollution."""
+    yield
+    AdmeDownloader._load_yearly_excel.cache_clear()
+
+
+# ----------------------------------
+# Tests - Initialization
+# ----------------------------------
+def test_downloader_initialization(downloader: AdmeDownloader, init_args: dict) -> None:
+    """Happy path for class initialization.
+
+    Check that the AdmeDownloader sets up paths and checkpoint correctly.
+
+    Args:
+        downloader (AdmeDownloader): Instance of AdmeDownloader class.
+        init_args (dict): Arguments used to initialize an AdmeDownloader instance.
+    """
+    assert downloader.years == init_args["years"]
+    assert downloader.output_path == init_args["output_path"]
+    assert downloader.checkpoint_path == Path(init_args["output_path"], "status.pickle")
+    assert downloader.checkpoint == {}
+
+
+def test_downloader_initialization_invalid_access(init_args: dict) -> None:
+    """Failure path for class initialization with invalid URL(s).
+
+    Args:
+        init_args (dict): Arguments used to initialize an AdmeDownloader instance.
+    """
+    with patch("rbc.energy.adme.downloader.requests.head") as mock_head:
+        mock_head.return_value.raise_for_status.side_effect = exceptions.HTTPError(404)
+
+        with pytest.raises(ConnectionError, match="API/URL access failed"):
+            AdmeDownloader(**init_args)
+
+            assert mock_head.call_count == 2
+
+
+def test_download_data_resume(init_args: dict) -> None:
+    """Happy path for "download_data" when resuming from checkpoint.
+
+    If all monthly tasks are already marked as done in the checkpoint, the
+    downloader should not attempt any downloads.
+
+    Args:
+        init_args (dict): Arguments used to initialize an AdmeDownloader instance.
+    """
+    args = init_args.copy()
+
+    # create a fake checkpoint with all months of the year completed
+    checkpoint = {
+        DownloadTask(date=d).identifier: 1
+        for y in args["years"]
+        for d in pd.date_range(start=f"{y}-01", end=f"{y}-12", freq="MS")
+        .strftime("%Y-%m")
+        .tolist()
+    }
+    checkpoint_path = Path(args["output_path"], "status.pickle")
+    with open(checkpoint_path, "wb") as f:
+        pickle.dump(checkpoint, f)
+
+    args["resume"] = True
+
+    with patch("rbc.energy.adme.downloader.requests.head") as mock_head:
+        mock_head.return_value = MagicMock(status_code=200)
+        downloader = AdmeDownloader(**args)
+
+        with patch.object(downloader, "_download_task_data") as mock_dump:
+            mock_dump.return_value = 1
+            downloader.download_data()
+
+            assert mock_dump.call_count == 0
+            assert downloader.checkpoint == checkpoint
+
+
+# ----------------------------------
+# Tests - Data crawling logic
+# ----------------------------------
+def test_download_task_data(downloader: AdmeDownloader, task: DownloadTask) -> None:
+    """Happy path for "_download_task_data" method.
+
+    Args:
+        downloader (AdmeDownloader): Instance of AdmeDownloader class.
+        task (DownloadTask): The metadata of a downloading task, here: date (YYYY-MM)
+    """
+    mock_df = get_mock_df(task)
+
+    with patch.object(downloader, "_get_task_data", return_value=mock_df):
+        status = downloader._download_task_data(task)
+
+    assert status == 1
+    expected_file = downloader._build_task_path(task)
+    assert expected_file.is_file(), f"The CSV {expected_file} was not created!"
+
+
+@pytest.mark.parametrize(
+    "task, expect_old, expect_new",
+    [
+        (DownloadTask(date="2018-01"), 1, 0),  # routed to old source
+        (DownloadTask(date="2019-01"), 0, 1),  # routed to new source
+    ],
+)
+def test_get_task_data(
+    downloader: AdmeDownloader,
+    task: DownloadTask,
+    expect_old: int,
+    expect_new: int,
+) -> None:
+    """Happy path for "_get_task_data", with different handling of old/new sources.
+
+    Args:
+        downloader (AdmeDownloader): Instance of AdmeDownloader class.
+        task (DownloadTask): The metadata of a downloading task, here: date (YYYY-MM)
+        expect_old (int): Expected call count for _get_from_old_source.
+        expect_new (int): Expected call count for _get_from_new_source.
+    """
+    mock_df = get_mock_df(task)
+
+    with patch.object(
+        downloader, "_get_from_old_source", return_value=mock_df
+    ) as mock_old:
+        with patch.object(
+            downloader, "_get_from_new_source", return_value=mock_df
+        ) as mock_new:
+            df = downloader._get_task_data(task)
+
+    assert not df.empty
+    assert isinstance(df.columns, pd.MultiIndex)
+
+    top_level_cols = set(df.columns.get_level_values(0))
+    for c in EXPECTED_COLS:
+        assert c in top_level_cols
+
+    assert mock_old.call_count == expect_old
+    assert mock_new.call_count == expect_new
+
+
+def test_get_task_data_no_generation_data(
+    downloader: AdmeDownloader, task: DownloadTask
+) -> None:
+    """Failure path for "_get_task_data" when the dataframe is empty.
+
+    Args:
+        downloader (AdmeDownloader): Instance of AdmeDownloader class.
+        task (DownloadTask): The metadata of a downloading task, here: date (YYYY-MM)
+    """
+    empty_df = pd.DataFrame()
+
+    with patch.object(downloader, "_get_from_old_source", return_value=empty_df):
+        with patch.object(downloader, "_get_from_new_source", return_value=empty_df):
+            with pytest.raises(MissingDataError, match="No energy data available"):
+                downloader._get_task_data(task)
+
+
+def test_get_task_data_structure_changed_missing_columns(
+    downloader: AdmeDownloader, task: DownloadTask
+) -> None:
+    """Failure path for "_get_task_data" when expected columns are missing.
+
+    Args:
+        downloader (AdmeDownloader): Instance of AdmeDownloader class.
+        task (DownloadTask): The metadata of a downloading task, here: date (YYYY-MM)
+    """
+    mock_df = get_mock_df(task, [TIME_COL])  # only time column!
+
+    with patch.object(downloader, "_get_from_old_source", return_value=mock_df):
+        with patch.object(downloader, "_get_from_new_source", return_value=mock_df):
+            with pytest.raises(DataStructureError, match="Missing columns"):
+                downloader._get_task_data(task)
+
+
+# ----------------------------------
+# Tests - Data crawling helper methods
+# ----------------------------------
+def test_get_from_new_source(downloader: AdmeDownloader, task: DownloadTask) -> None:
+    """Happy path for "_get_from_new_source" method, ensuring correct URL.
+
+    Args:
+        downloader (AdmeDownloader): Instance of AdmeDownloader class.
+        task (DownloadTask): The metadata of a downloading task, here: date (YYYY-MM)
+    """
+    # mock_df with an extra column to be cut off
+    cols = [TIME_COL] + [(c, "A") for c in EXPECTED_COLS if c != "/"] + [("Extra", "X")]
+    mock_df = get_mock_df(task, cols)
+
+    with patch(
+        "rbc.energy.adme.downloader.load_df_from_file", return_value=mock_df
+    ) as mock_load:
+        df = downloader._get_from_new_source(task=task)
+
+    expected_url = f"{URL_BASE_NEW}anod={task.year}&mesd={task.month:02d}&periodo=1&fuente=0&tipo=1"
+    mock_load.assert_called_with(expected_url, ".csv", delimiter=";", header=[0, 1])
+
+    assert len(df) == 1
+    assert list(df.columns.get_level_values(0)) == EXPECTED_COLS
+    assert "Extra" not in df.columns.get_level_values(0)
+
+
+def test_get_from_new_source_missing_time_column(
+    downloader: AdmeDownloader, task: DownloadTask
+) -> None:
+    """Failure path for "_get_from_new_source" when relevant column(s) are missing.
+
+    Args:
+        downloader (AdmeDownloader): Instance of AdmeDownloader class.
+        task (DownloadTask): The metadata of a downloading task, here: date (YYYY-MM)
+    """
+    mock_df = get_mock_df(task, [TIME_COL])  # only time column!
+
+    with patch("rbc.energy.adme.downloader.load_df_from_file", return_value=mock_df):
+        with pytest.raises(DataStructureError, match="Relevant columns are missing"):
+            downloader._get_from_new_source(task=task)
+
+
+def test_get_from_old_source(downloader: AdmeDownloader, task: DownloadTask) -> None:
+    """Happy path for "_get_from_old_source" method, ensuring correct URL and month filter.
+
+    Args:
+        downloader (AdmeDownloader): Instance of AdmeDownloader class.
+        task (DownloadTask): The metadata of a downloading task, here: date (YYYY-MM)
+    """
+    # mock_df with standard columns and extra column to be cut off
+    mock_df = get_mock_df(
+        task, [TIME_COL, ("Hidráulico", "A"), ("Extra", "X")], n_rows=3
+    )
+
+    # make second and third rows the next months' day 1 hour 0 and 1
+    mock_df.loc[1, TIME_COL] = f"01-{str(task.month + 1).zfill(2)}-{task.year} 00:00"
+    mock_df.loc[2, TIME_COL] = f"01-{str(task.month + 1).zfill(2)}-{task.year} 01:00"
+    # convert TIME_COL to datetime, as _load_yearly_excel would
+    mock_df[TIME_COL] = pd.to_datetime(mock_df[TIME_COL], dayfirst=True)
+
+    with patch.object(
+        downloader, "_load_yearly_excel", return_value=mock_df
+    ) as mock_load:
+        df = downloader._get_from_old_source(task=task)
+
+    expected_url = f"{URL_BASE_OLD}gpf_{task.year}.xlsx"
+    mock_load.assert_called_with(expected_url)
+
+    assert len(df) == 2  # month filter means hour 1 of next month's day 1 is cut
+    assert pd.to_datetime(df.loc[0, TIME_COL], dayfirst=True).month == task.month
+    assert pd.to_datetime(df.loc[1, TIME_COL], dayfirst=True).month == task.month + 1
+    assert df[TIME_COL].dtype == object  # check TIME_COL has been formatted back to str
+
+
+def test_load_yearly_excel(downloader: AdmeDownloader) -> None:
+    """Happy path for "_load_yearly_excel" method, ensuring correct Excel sheet handling.
+
+    Args:
+        downloader (AdmeDownloader): Instance of AdmeDownloader class.
+    """
+    # mock df with single column headers and similar setup at what GPF sheet returns
+    mock_xlsx = MagicMock(spec=pd.ExcelFile, sheet_names=list(EXPECTED_OLD_SHEETS))
+    mock_df = pd.DataFrame(
+        {"Fecha": ["01-01-2010 01:00"], "Hydro A": [100.0], "Eólica": [10.0]}
+    )
+
+    with patch(
+        "rbc.energy.adme.downloader.load_excel_from_file", return_value=mock_xlsx
+    ), patch("rbc.energy.adme.downloader.pd.read_excel", return_value=mock_df):
+        df = downloader._load_yearly_excel("https://fake.url/gpf_2010.xlsx")
+
+    assert isinstance(df.columns, pd.MultiIndex)
+    assert TIME_COL in df.columns
+    assert pd.api.types.is_datetime64_any_dtype(df[TIME_COL])
+
+
+def test_load_yearly_excel_missing_sheets(downloader: AdmeDownloader) -> None:
+    """Failure path for "_load_yearly_excel" method when required sheets are missing.
+
+    Args:
+        downloader (AdmeDownloader): Instance of AdmeDownloader class.
+    """
+    mock_xlsx = MagicMock(spec=pd.ExcelFile, sheet_names=["GPF"])
+
+    with patch(
+        "rbc.energy.adme.downloader.load_excel_from_file", return_value=mock_xlsx
+    ):
+        with pytest.raises(DataStructureError, match="Not all required sheets"):
+            downloader._load_yearly_excel("https://fake.url/gpf_2010.xlsx")
+
+
+def test_load_yearly_excel_bad_content(downloader: AdmeDownloader) -> None:
+    """Failure path for "_load_yearly_excel" method when sheet has unparsable content.
+
+    Args:
+        downloader (AdmeDownloader): Instance of AdmeDownloader class.
+    """
+    mock_xlsx = MagicMock(spec=pd.ExcelFile, sheet_names=list(EXPECTED_OLD_SHEETS))
+
+    with patch(
+        "rbc.energy.adme.downloader.load_excel_from_file", return_value=mock_xlsx
+    ), patch("rbc.energy.adme.downloader.pd.read_excel", side_effect=ValueError("bad")):
+        with pytest.raises(DataStructureError, match="does not contain loadable data"):
+            downloader._load_yearly_excel("https://fake.url/gpf_2010.xlsx")
+
+
+def test_load_yearly_excel_not_datetimelike(downloader: AdmeDownloader) -> None:
+    """Failure path for "_load_yearly_excel" method when 'fecha' column is not datetimelike.
+
+    Args:
+        downloader (AdmeDownloader): Instance of AdmeDownloader class.
+    """
+    mock_xlsx = MagicMock(spec=pd.ExcelFile, sheet_names=list(EXPECTED_OLD_SHEETS))
+    mock_df = pd.DataFrame({"Fecha": ["not-a-date"], "Hydro Plant A": [100.0]})
+
+    with patch(
+        "rbc.energy.adme.downloader.load_excel_from_file", return_value=mock_xlsx
+    ), patch("rbc.energy.adme.downloader.pd.read_excel", return_value=mock_df):
+        with pytest.raises(DataStructureError, match="no longer datetimelike"):
+            downloader._load_yearly_excel("https://fake.url/gpf_2010.xlsx")

--- a/tests/energy/adme/test_downloader.py
+++ b/tests/energy/adme/test_downloader.py
@@ -349,7 +349,7 @@ def test_get_from_old_source(downloader: AdmeDownloader, task: DownloadTask) -> 
     assert len(df) == 2  # month filter means hour 1 of next month's day 1 is cut
     assert pd.to_datetime(df.loc[0, TIME_COL], dayfirst=True).month == task.month
     assert pd.to_datetime(df.loc[1, TIME_COL], dayfirst=True).month == task.month + 1
-    assert df[TIME_COL].dtype == object  # check TIME_COL has been formatted back to str
+    assert pd.api.types.is_string_dtype(df[TIME_COL])  # check TIME_COL are str again
 
 
 def test_load_yearly_excel(downloader: AdmeDownloader) -> None:

--- a/tests/energy/adme/test_downloader.py
+++ b/tests/energy/adme/test_downloader.py
@@ -141,7 +141,7 @@ def test_downloader_initialization_invalid_access(init_args: dict) -> None:
         with pytest.raises(ConnectionError, match="API/URL access failed"):
             AdmeDownloader(**init_args)
 
-        assert mock_head.call_count == 2
+        assert mock_head.call_count == 1
 
 
 def test_download_data_resume(init_args: dict) -> None:

--- a/tests/energy/aeso/test_downloader.py
+++ b/tests/energy/aeso/test_downloader.py
@@ -170,16 +170,19 @@ def test_downloader_initialization_invalid_access(init_args: dict) -> None:
 def test_download_data_resume(init_args: dict) -> None:
     """Happy path for "download_data" method when resuming from checkpoint.
 
+    If all monthly tasks are already marked as done in the checkpoint, the
+    downloader should not attempt any downloads.
+
     Args:
         init_args (dict): Arguments used to initialize an AesoDownloader instance.
     """
     args = init_args.copy()
 
     # save a fake checkpoint file
-    y = args["years"][0]
     checkpoint = {
         DownloadTask(date=d, temporal_resolution=t_res).identifier: 1
         for t_res in args["temporal_resolutions"]
+        for y in args["years"]
         for d in pd.date_range(start=f"{y}-01", end=f"{y}-12", freq="MS").strftime(
             "%Y-%m"
         )

--- a/tests/energy/eat/test_downloader.py
+++ b/tests/energy/eat/test_downloader.py
@@ -119,15 +119,18 @@ def test_downloader_initialization_invalid_access(init_args: dict) -> None:
 def test_download_data_resume(init_args: dict) -> None:
     """Happy path for "download_data" method when resuming from checkpoint.
 
+    If all monthly tasks are already marked as done in the checkpoint, the
+    downloader should not attempt any downloads.
+
     Args:
         init_args (dict): Arguments used to initialize an EatDownloader instance.
     """
     args = init_args.copy()
-    y = args["years"][0]
 
     # save a fake checkpoint file
     checkpoint = {
         DownloadTask(date=d, temporal_resolution="30min").identifier: 1
+        for y in args["years"]
         for d in pd.date_range(start=f"{y}-01", end=f"{y}-12", freq="MS")
         .strftime("%Y-%m")
         .tolist()

--- a/tests/energy/eia/test_downloader.py
+++ b/tests/energy/eia/test_downloader.py
@@ -141,15 +141,18 @@ def test_downloader_initialization_invalid_access(init_args: dict) -> None:
 def test_download_data_resume(init_args: dict) -> None:
     """Happy path for "download_data" method when resuming from checkpoint.
 
+    If all daily tasks are already marked as done in the checkpoint, the
+    downloader should not attempt any downloads.
+
     Args:
         init_args (dict): Arguments used to initialize an EiaDownloader instance.
     """
     args = init_args.copy()
 
     # save a fake checkpoint file
-    y = args["years"][0]
     checkpoint = {
         DownloadTask(date=d).identifier: 1
+        for y in args["years"]
         for d in pd.date_range(start=f"{y}-01-01", end=f"{y}-12-31")
         .strftime("%Y-%m-%d")
         .tolist()

--- a/tests/energy/entsoe/test_downloader.py
+++ b/tests/energy/entsoe/test_downloader.py
@@ -167,7 +167,12 @@ def test_download_day_data(downloader: EntsoeDownloader, task: DownloadTask) -> 
         downloader (EntsoeDownloader): Instance of EntsoeDownloader class.
         task (DownloadTask): The metadata of a downloading task, here: date (YYYY-MM-DD), bz
     """
-    mock_df = pd.DataFrame({"Generation_MW": [16.2], "Temporal_Resolution": ["PT60M"]})
+    mock_df = pd.DataFrame(
+        {
+            "time_series.period.point.quantity": [16.2],
+            "time_series.period.resolution": ["PT60M"],
+        }
+    )
 
     with patch.object(downloader, "_get_task_data", return_value=mock_df):
         status = downloader._download_task_data(task)
@@ -177,7 +182,7 @@ def test_download_day_data(downloader: EntsoeDownloader, task: DownloadTask) -> 
         assert expected_file.is_file(), f"The CSV {expected_file} was not created!"
 
         saved_df = pd.read_csv(expected_file)
-        assert saved_df.iloc[0]["Generation_MW"] == 16.2
+        assert saved_df.iloc[0]["time_series.period.point.quantity"] == 16.2
 
 
 def test_get_task_data(downloader: EntsoeDownloader, task: DownloadTask) -> None:
@@ -214,9 +219,9 @@ def test_get_task_data(downloader: EntsoeDownloader, task: DownloadTask) -> None
     assert not df.empty
     assert len(df) == 1
     assert "timestamp" in df.columns
-    assert "Generation_MW" in df.columns
+    assert "time_series.period.point.quantity" in df.columns
     assert df.iloc[0]["timestamp"] == timestamp
-    assert df.iloc[0]["Generation_MW"] == 100
+    assert df.iloc[0]["time_series.period.point.quantity"] == 100
     assert mock_extract.call_count == 1
 
 
@@ -325,8 +330,8 @@ def test_save_task_data_single_tres(
     """
     df = pd.DataFrame(
         {
-            "Generation_MW": [10.0, 20.0],
-            "Temporal_Resolution": ["PT60M", None],
+            "time_series.period.point.quantity": [10.0, 20.0],
+            "time_series.period.resolution": ["PT60M", None],
         }
     )
     downloader._save_task_data(task, df)
@@ -336,7 +341,7 @@ def test_save_task_data_single_tres(
 
     saved_df = pd.read_csv(expected_file)
     assert len(saved_df) == 1  # row with missing temporal resolution value removed
-    assert saved_df.iloc[0]["Generation_MW"] == 10.0
+    assert saved_df.iloc[0]["time_series.period.point.quantity"] == 10.0
 
 
 def test_save_task_data_two_tres(
@@ -350,8 +355,8 @@ def test_save_task_data_two_tres(
     """
     df = pd.DataFrame(
         {
-            "Generation_MW": [10.0, 20.0],
-            "Temporal_Resolution": ["PT60M", "PT20M"],
+            "time_series.period.point.quantity": [10.0, 20.0],
+            "time_series.period.resolution": ["PT60M", "PT20M"],
         }
     )
     downloader._save_task_data(task, df)
@@ -367,8 +372,8 @@ def test_save_task_data_two_tres(
 
     assert len(df_1h) == 1
     assert len(df_20min) == 1
-    assert df_1h.iloc[0]["Generation_MW"] == 10.0
-    assert df_20min.iloc[0]["Generation_MW"] == 20.0
+    assert df_1h.iloc[0]["time_series.period.point.quantity"] == 10.0
+    assert df_20min.iloc[0]["time_series.period.point.quantity"] == 20.0
 
 
 def test_save_task_data_invalid_tres(
@@ -378,8 +383,8 @@ def test_save_task_data_invalid_tres(
     df = pd.DataFrame(
         {
             "timestamp": [f"{task.date}T00:00:00+00:00"],
-            "Generation_MW": [16.2],
-            "Temporal_Resolution": ["INVALID"],
+            "time_series.period.point.quantity": [16.2],
+            "time_series.period.resolution": ["INVALID"],
         }
     )
     with pytest.raises(DataStructureError, match="Unknown ENTSO-E temporal resolution"):

--- a/tests/energy/entsoe/test_downloader.py
+++ b/tests/energy/entsoe/test_downloader.py
@@ -121,16 +121,19 @@ def test_downloader_initialization_invalid_credentials(init_args: dict) -> None:
 def test_download_data_resume(init_args: dict) -> None:
     """Happy path for "download_data" method when resuming from checkpoint.
 
+    If all daily tasks are already marked as done in the checkpoint, the
+    downloader should not attempt any downloads.
+
     Args:
         init_args (dict): Arguments used to initialize an EntsoeDownloader instance.
     """
     args = init_args.copy()
 
     # save a fake checkpoint file
-    bz = args["bidding_zones"][0]
-    y = args["years"][0]
     checkpoint = {
         DownloadTask(date=d, bidding_zone=bz).identifier: 1
+        for bz in args["bidding_zones"]
+        for y in args["years"]
         for d in pd.date_range(start=f"{y}-01-01", end=f"{y}-12-31").strftime(
             "%Y-%m-%d"
         )

--- a/tests/energy/epias/test_downloader.py
+++ b/tests/energy/epias/test_downloader.py
@@ -131,15 +131,18 @@ def test_downloader_initialization_invalid_credentials(init_args: dict) -> None:
 def test_download_data_resume(init_args: dict) -> None:
     """Happy path for "download_data" method when resuming from checkpoint.
 
+    If all daily tasks are already marked as done in the checkpoint, the
+    downloader should not attempt any downloads.
+
     Args:
         init_args (dict): Arguments used to initialize an EpiasDownloader instance.
     """
     args = init_args.copy()
 
     # save a fake checkpoint file
-    y = args["years"][0]
     checkpoint = {
         DownloadTask(date=d).identifier: 1
+        for y in args["years"]
         for d in pd.date_range(start=f"{y}-01-01", end=f"{y}-12-31")
         .strftime("%Y-%m-%d")
         .tolist()

--- a/tests/energy/ieso/test_downloader.py
+++ b/tests/energy/ieso/test_downloader.py
@@ -343,21 +343,23 @@ def test_lru_cache_works(downloader: IesoDownloader, task: DownloadTask) -> None
         downloader (IesoDownloader): Instance of IesoDownloader class.
         task (DownloadTask): The metadata of a downloading task, here: date (YYYY-MM)
     """
+    mock_xlsx = MagicMock(spec=pd.ExcelFile, sheet_names=["Output", "Capability"])
     mock_df = pd.DataFrame(
         {"DATE": pd.to_datetime(f"{task.date}-01"), "HOUR": [1], "GEN_A": [10]}
     )
 
     downloader._load_yearly_excel.cache_clear()
 
-    with patch("rbc.energy.ieso.downloader.load_df_from_file") as mock_load:
-        mock_load.side_effect = [mock_df, mock_df]
-
+    with patch(
+        "rbc.energy.ieso.downloader.load_excel_from_file", return_value=mock_xlsx
+    ) as mock_load, patch(
+        "rbc.energy.ieso.downloader.pd.read_excel", return_value=mock_df
+    ):
         downloader._get_from_old_source(task=task)
         downloader._get_from_old_source(task=task)
         downloader._get_from_old_source(task=task)
 
-        # check method called 2x - both in _load_yearly_excel call in 1st _get_from_old_source
-        assert mock_load.call_count == 2
+        assert mock_load.call_count == 1  # only called once despite 3 calls
 
 
 def test_get_from_old_source_structure_changed(
@@ -383,6 +385,15 @@ def test_load_yearly_excel(downloader: IesoDownloader, task: DownloadTask) -> No
         downloader (IesoDownloader): Instance of IesoDownloader class.
         task (DownloadTask): The metadata of a downloading task, here: date (YYYY-MM)
     """
+    mock_xlsx = MagicMock(
+        spec=pd.ExcelFile,
+        sheet_names=[
+            "Output",
+            "Available Capacities",
+            "Capability - see Notes",
+            "Capability",
+        ],
+    )
     mock_df_out = pd.DataFrame(
         {"DATE": [f"{task.date}-01"], "HOUR": [1], "GEN_A": [10]}
     )
@@ -390,9 +401,16 @@ def test_load_yearly_excel(downloader: IesoDownloader, task: DownloadTask) -> No
         {"DATE": [f"{task.date}-01"], "HOUR": [1], "GEN_A": [100]}
     )
 
-    with patch("rbc.energy.ieso.downloader.load_df_from_file") as mock_load:
-        mock_load.side_effect = [mock_df_out, ValueError, mock_df_cap]
-
+    with patch(
+        "rbc.energy.ieso.downloader.load_excel_from_file", return_value=mock_xlsx
+    ), patch(
+        "rbc.energy.ieso.downloader.pd.read_excel",
+        side_effect=[
+            mock_df_out,  # Output sheet
+            ValueError,  # Available Capacities - not found
+            mock_df_cap,  # Capability - see Notes
+        ],
+    ) as mock_load:
         df = downloader._load_yearly_excel(url="http://fake.xlsx")
 
         # check that returned df has correct new structure (up to 'HOUR 2')
@@ -400,8 +418,8 @@ def test_load_yearly_excel(downloader: IesoDownloader, task: DownloadTask) -> No
             col in df.columns for col in ["Delivery Date", "Generator", "Measurement"]
         )
         assert len(df) == 2
-        assert df["Hour 1"].iloc[0] == 100  # 'Capability' measurement
-        assert df["Hour 1"].iloc[1] == 10  # 'Output' measurement
+        assert df["Hour 1"].iloc[0] == 100
+        assert df["Hour 1"].iloc[1] == 10
 
         # assert that mocked function was called correctly
         assert mock_load.call_count == 3
@@ -420,13 +438,22 @@ def test_load_yearly_excel_missing_capacity(
         downloader (IesoDownloader): Instance of IesoDownloader class.
         task (DownloadTask): The metadata of a downloading task, here: date (YYYY-MM)
     """
+    mock_xlsx = MagicMock(spec=pd.ExcelFile, sheet_names=["Output", "Capability"])
     mock_df_out = pd.DataFrame(
         {"DATE": [f"{task.date}-01"], "HOUR": [1], "GEN_A": [10]}
     )
 
-    with patch("rbc.energy.ieso.downloader.load_df_from_file") as mock_load:
-        mock_load.side_effect = [mock_df_out, ValueError, ValueError, ValueError]
-
+    with patch(
+        "rbc.energy.ieso.downloader.load_excel_from_file", return_value=mock_xlsx
+    ), patch(
+        "rbc.energy.ieso.downloader.pd.read_excel",
+        side_effect=[
+            mock_df_out,  # Output sheet
+            ValueError,  # Available Capacities - not found
+            ValueError,  # Capability - see Notes - not found
+            ValueError,  # Capability - not found
+        ],
+    ):
         with pytest.raises(DataStructureError, match="No valid capacity sheets"):
             downloader._load_yearly_excel(url="http://fake.xlsx")
 

--- a/tests/energy/ieso/test_downloader.py
+++ b/tests/energy/ieso/test_downloader.py
@@ -3,6 +3,7 @@
 
 import pickle
 from pathlib import Path
+from typing import Generator
 from unittest.mock import MagicMock, patch
 
 import pandas as pd
@@ -88,6 +89,13 @@ def get_mock_df(specific_task: DownloadTask) -> pd.DataFrame:
         },
         index=[0],
     )
+
+
+@pytest.fixture(autouse=True)
+def clear_cache() -> Generator[None, None, None]:
+    """Clear lru_cache after each test to avoid cache pollution."""
+    yield
+    IesoDownloader._load_yearly_excel.cache_clear()
 
 
 # ----------------------------------
@@ -347,8 +355,6 @@ def test_lru_cache_works(downloader: IesoDownloader, task: DownloadTask) -> None
     mock_df = pd.DataFrame(
         {"DATE": pd.to_datetime(f"{task.date}-01"), "HOUR": [1], "GEN_A": [10]}
     )
-
-    downloader._load_yearly_excel.cache_clear()
 
     with patch(
         "rbc.energy.ieso.downloader.load_excel_from_file", return_value=mock_xlsx

--- a/tests/energy/ieso/test_downloader.py
+++ b/tests/energy/ieso/test_downloader.py
@@ -109,7 +109,7 @@ def test_downloader_initialization(downloader: IesoDownloader, init_args: dict) 
 
 
 def test_downloader_initialization_invalid_access(init_args: dict) -> None:
-    """Failure path for class initialization with invalid URL.
+    """Failure path for class initialization with invalid URLs.
 
     Args:
         init_args (dict): Arguments used to initialize an IesoDownloader instance.
@@ -120,19 +120,24 @@ def test_downloader_initialization_invalid_access(init_args: dict) -> None:
         with pytest.raises(ConnectionError, match="API/URL access failed"):
             IesoDownloader(**init_args)
 
+            assert mock_head.call_count == 2
+
 
 def test_download_data_resume(init_args: dict) -> None:
     """Happy path for "download_data" method when resuming from checkpoint.
+
+    If all monthly tasks are already marked as done in the checkpoint, the
+    downloader should not attempt any downloads.
 
     Args:
         init_args (dict): Arguments used to initialize an IesoDownloader instance.
     """
     args = init_args.copy()
-    y = args["years"][0]
 
     # save a fake checkpoint file
     checkpoint = {
         DownloadTask(date=d).identifier: 1
+        for y in args["years"]
         for d in pd.date_range(start=f"{y}-01", end=f"{y}-12", freq="MS")
         .strftime("%Y-%m")
         .tolist()

--- a/tests/energy/ons/test_downloader.py
+++ b/tests/energy/ons/test_downloader.py
@@ -10,7 +10,7 @@ import pytest
 from requests import exceptions
 
 from rbc.energy.ons import OnsDownloader
-from rbc.energy.ons.downloader import EXPECTED_COLS_MAPPING, URL_BASE
+from rbc.energy.ons.downloader import EXPECTED_COLS, URL_BASE
 from rbc.energy.utils import DataStructureError, DownloadTask, MissingDataError
 
 
@@ -72,11 +72,11 @@ def get_mock_df(spec_task: DownloadTask) -> pd.DataFrame:
     Returns:
         pandas.DataFrame: Mock dataframe.
     """
-    row: dict[str, object] = {c: ["A"] for c in EXPECTED_COLS_MAPPING.keys()}
+    row: dict[str, object] = {c: ["A"] for c in EXPECTED_COLS}
     row.update(
         {
             c: f"{spec_task.date}-01 00:00:00"
-            for c in EXPECTED_COLS_MAPPING.keys()
+            for c in EXPECTED_COLS
             if "din_instante" in c
         }
     )
@@ -204,9 +204,9 @@ def test_get_task_data(
 
     assert not df.empty
     assert len(df) == 1
-    assert df.iloc[0]["datetime"] == f"{task.date}-01 00:00:00"
-    assert df.iloc[0]["plant_name"] == "A"
-    assert df.iloc[0]["generation_MWmed"] == 10.0
+    assert df.iloc[0]["din_instante"] == f"{task.date}-01 00:00:00"
+    assert df.iloc[0]["nom_usina"] == "A"
+    assert df.iloc[0]["val_geracao"] == 10.0
     assert mock_old.call_count == expect_old
     assert mock_new.call_count == expect_new
 
@@ -220,7 +220,7 @@ def test_get_task_data_no_generation_data(
         downloader (OnsDownloader): Instance of OnsDownloader class.
         task (DownloadTask): The metadata of a downloading task, here: date (YYYY-MM)
     """
-    mock_df = pd.DataFrame(columns=EXPECTED_COLS_MAPPING)
+    mock_df = pd.DataFrame(columns=EXPECTED_COLS)
 
     with patch.object(downloader, "_get_from_yearly_csv", return_value=mock_df):
         with patch.object(downloader, "_get_from_monthly_csv", return_value=mock_df):

--- a/tests/energy/ons/test_downloader.py
+++ b/tests/energy/ons/test_downloader.py
@@ -3,6 +3,7 @@
 
 import pickle
 from pathlib import Path
+from typing import Generator
 from unittest.mock import MagicMock, patch
 
 import pandas as pd
@@ -82,6 +83,13 @@ def get_mock_df(spec_task: DownloadTask) -> pd.DataFrame:
     )
     row.update({"val_geracao": 10.0})
     return pd.DataFrame(row, index=[0])
+
+
+@pytest.fixture(autouse=True)
+def clear_cache() -> Generator[None, None, None]:
+    """Clear lru_cache after each test to avoid cache pollution."""
+    yield
+    OnsDownloader._load_yearly_csv.cache_clear()
 
 
 # ----------------------------------
@@ -316,8 +324,6 @@ def test_lru_cache_works(downloader: OnsDownloader, task: DownloadTask) -> None:
         }
     )
 
-    downloader._load_yearly_csv.cache_clear()
-
     with patch("rbc.energy.ons.downloader.load_df_from_file") as mock_load:
         mock_load.return_value = mock_df
 
@@ -335,8 +341,6 @@ def test_load_yearly_csv(downloader: OnsDownloader, task: DownloadTask) -> None:
         downloader (OnsDownloader): Instance of OnsDownloader class.
         task (DownloadTask): The metadata of a downloading task, here: date (YYYY-MM)
     """
-    downloader._load_yearly_csv.cache_clear()
-
     with patch("rbc.energy.ons.downloader.load_df_from_file") as mock_load:
         mock_load.return_value = get_mock_df(task)
 
@@ -367,8 +371,6 @@ def test_load_yearly_csv_structure_changed(
         mock_df_dict (dict): Dictionary of mock dataframe columns.
         expected_match (str): Expected match string.
     """
-    downloader._load_yearly_csv.cache_clear()
-
     with patch("rbc.energy.ons.downloader.load_df_from_file") as mock_load:
         mock_load.return_value = pd.DataFrame(mock_df_dict)
 

--- a/tests/energy/ons/test_downloader.py
+++ b/tests/energy/ons/test_downloader.py
@@ -118,15 +118,18 @@ def test_downloader_initialization_invalid_access(init_args: dict) -> None:
 def test_download_data_resume(init_args: dict) -> None:
     """Happy path for "download_data" method when resuming from checkpoint.
 
+    If all monthly tasks are already marked as done in the checkpoint, the
+    downloader should not attempt any downloads.
+
     Args:
         init_args (dict): Arguments used to initialize an OnsDownloader instance.
     """
     args = init_args.copy()
-    y = args["years"][0]
 
     # save a fake checkpoint file
     checkpoint = {
         DownloadTask(date=d).identifier: 1
+        for y in args["years"]
         for d in pd.date_range(start=f"{y}-01", end=f"{y}-12", freq="MS")
         .strftime("%Y-%m")
         .tolist()

--- a/tests/energy/test_utils.py
+++ b/tests/energy/test_utils.py
@@ -2,8 +2,10 @@
 """Tests for energy utility functions and classes."""
 
 import pickle
+import zipfile
 from pathlib import Path
 from types import SimpleNamespace
+from typing import Callable, Literal
 from unittest.mock import MagicMock, patch
 
 import pandas as pd
@@ -18,6 +20,7 @@ from rbc.energy.utils import (
     InvalidError,
     MissingDataError,
     load_df_from_file,
+    load_excel_from_file,
     write_df_to_csv,
 )
 
@@ -591,7 +594,7 @@ class TestDownloadTaskValidation:
 # ----------------------------------
 # Tests - Other utils
 # ----------------------------------
-def test_write_df_to_csv_and_load_df_from_file(tmp_path: Path) -> None:
+def test_write_df_to_csv(tmp_path: Path) -> None:
     """Happy path for _write_df_to_csv, ensuring writing a dataframe to a csv works.
 
     Args:
@@ -609,7 +612,7 @@ def test_write_df_to_csv_and_load_df_from_file(tmp_path: Path) -> None:
 
 @pytest.mark.parametrize("file_name", ["valid.csv", "valid.xlsx"])
 def test_load_df_from_file(tmp_path: Path, file_name) -> None:
-    """Happy path for _load_df_from_file, ensuring reading a df from a csv / excel works.
+    """Happy path for "load_df_from_file", ensuring reading a df from a csv / excel works.
 
     Args:
         tmp_path (Path): Path to temporary directory.
@@ -629,16 +632,98 @@ def test_load_df_from_file(tmp_path: Path, file_name) -> None:
     pd.testing.assert_frame_equal(read_df, mock_df)
 
 
-def test_load_df_from_file_invalid_extension() -> None:
-    """Failure path for "load_df_from_file" when file has unsupported extensions."""
+@pytest.mark.parametrize(
+    "file_name, file_type",
+    [
+        ("valid", ".csv"),  # no suffix - file_type provides it
+        ("valid.xlsx", ".csv"),  # wrong suffix - file_type overrides it
+    ],
+)
+def test_load_df_from_file_manual_file_type(
+    tmp_path: Path, file_name: str, file_type: Literal[".csv", ".xlsx"]
+) -> None:
+    """Happy path for "load_df_from_file" when manual file type is provided.
+
+    Args:
+        tmp_path (Path): Path to temporary directory.
+        file_name (str): Name of file.
+        file_type (str): Type of file.
+    """
+    file_path = Path(tmp_path, file_name)
+    mock_df = pd.DataFrame({"total": [16.2]})
+
+    mock_df.to_csv(file_path, index=False)  # always save as CSV content
+    assert file_path.is_file()
+
+    read_df = load_df_from_file(file_path, file_type=file_type)
+    pd.testing.assert_frame_equal(read_df, mock_df)
+
+
+def test_load_excel_from_file(tmp_path: Path) -> None:
+    """Happy path for "load_excel_from_file", ensuring reading an ExcelFile from an excel works.
+
+    Args:
+        tmp_path (Path): Path to temporary directory.
+    """
+    file_path = Path(tmp_path, "valid.xlsx")
+    mock_df = pd.DataFrame({"total": [16.2]})
+
+    pytest.importorskip("openpyxl")
+    mock_df.to_excel(file_path, index=False)
+    assert file_path.is_file()
+
+    read_excel = load_excel_from_file(file_path)
+    read_df = pd.read_excel(read_excel)
+    assert isinstance(read_excel, pd.ExcelFile)
+    pd.testing.assert_frame_equal(read_df, mock_df)
+
+
+@pytest.mark.parametrize("helper", [load_df_from_file, load_excel_from_file])
+def test_load_from_file_invalid_extension(helper: Callable) -> None:
+    """Failure paths for "load_..._from_file" helpers when file has unsupported extensions.
+
+    Args:
+        helper (Callable): Helper function to test.
+    """
     with pytest.raises(InvalidError, match="Invalid extension"):
-        load_df_from_file("test.txt")
+        helper("test.txt")
 
 
-def test_load_df_from_file_not_found() -> None:
-    """Failure path for "load_df_from_file" when file is missing."""
+def test_load_df_from_file_invalid_file_type() -> None:
+    """Failure path for "load_df_from_file" when an invalid file_type is provided."""
+    with pytest.raises(InvalidError, match="Invalid extension"):
+        load_df_from_file("test.csv", file_type=".txt")  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize("helper", [load_df_from_file, load_excel_from_file])
+def test_load_from_file_not_found(helper: Callable) -> None:
+    """Failure paths for "load_..._from_file" helpers when file is missing.
+
+    Args:
+        helper (Callable): Helper function to test.
+    """
     with pytest.raises(InvalidError, match="Invalid path"):
-        load_df_from_file("non_existent_file.csv")
+        helper("non_existent_file.xlsx")
+
+
+@pytest.mark.parametrize(
+    "helper, function",
+    [(load_df_from_file, "read_excel"), (load_excel_from_file, "ExcelFile")],
+)
+def test_load_from_file_inaccessible_url(helper: Callable, function: str) -> None:
+    """Failure paths for "load_..._from_file" helpers when an inaccessible url is provided.
+
+    Args:
+        helper (Callable): Helper function to test.
+        function (str): Pandas function used in the helper.
+    """
+    with patch(
+        f"rbc.energy.utils.pd.{function}", side_effect=exceptions.HTTPError
+    ) as mock_read_excel:
+        with pytest.raises(exceptions.HTTPError):
+            helper("https://www.website.com/test.xlsx")
+
+    mock_read_excel.assert_called_once()
 
 
 def test_load_df_from_file_bad_args() -> None:
@@ -647,12 +732,12 @@ def test_load_df_from_file_bad_args() -> None:
         load_df_from_file("test.csv", sheet_name="Sheet1")
 
 
-def test_load_df_from_file_inaccessible_url() -> None:
-    """Failure path for "load_df_from_file" when an inaccessible url is provided."""
+def test_load_excel_from_file_bad_content() -> None:
+    """Failure path for "load_excel_from_file" when content is bad (BadZipFile)."""
     with patch(
-        "rbc.energy.utils.pd.read_csv", side_effect=ConnectionError
-    ) as mock_read_csv:
-        with pytest.raises(ConnectionError):
-            load_df_from_file("https://www.website.com/test.csv")
+        "rbc.energy.utils.pd.ExcelFile", side_effect=zipfile.BadZipFile
+    ) as mock_read_excel:
+        with pytest.raises(InvalidError, match="Invalid file content"):
+            load_excel_from_file("test.xlsx")
 
-    mock_read_csv.assert_called_once()
+    mock_read_excel.assert_called_once()


### PR DESCRIPTION
# New data crawler for ADME (Uruguay) energy data

Code and tests for downloading data from [ADME](https://www.adme.com.uy/controlpanel.php) ("Generación por fuente mensual" UI panel) via the existing `load_df_from_url` and new `load_excel_from_file` functionalities (s. "Additional changes"). This can function as an example for future data crawlers and encompasses:

- a config YAML file `configs/energy/adme.yaml` for source-related settings,
- a data downloader in `rbc/energy/adme/downloader.py`,
- a script for running the downloader in `scripts/energy/adme_download.py`,
- tests for the downloader in `tests/energy/adme/test_downloader.py`.
- updated documentation (`README.md` and `docs/data_sources.md`)

### Additional changes

- **enery/utils.py**: 
	- enhanced `load_df_from_file` function with `file_type` argument for cases where the `file_path` has no explicit ending (i.e. for ADME) 
	- new `load_excel_from_file` function for cases when multiple sheets from an excel are of interest --> the prevents having to load the excel again and again via `load_df_from_file`
- **IESO**: use `load_excel_from_file` for old excels, thus preventing repetitive file loading
- **ONS, ENTSO-e**: removed "processing"-like steps (converted `EXPECTED_COLS_MAPPING` dict for simplifying/translating column names to `EXPECTED_COLS` list and stuck with original column names). These steps have been moved to the processors (s. [processing branch](https://github.com/RenewBench-Association/RenewBench-Crawler/tree/backup/energy_processors/rbc/energy)).

## New dependencies
/

## Related issues

- Closes #22

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules