### PR TITLE
Features/aemo

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -25,6 +25,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install uv, set the python version, and enable cache
         uses: astral-sh/setup-uv@v5

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Install dependencies
         run: |
           uv pip install coverage==7.6.4
-          uv pip install pytest pytest-cov coverage-badge .
+          uv pip install pytest pytest-cov coverage-badge ".[dev]"
 
       - name: Test with pytest and coverage badge
         run: |

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -32,9 +32,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install dependencies
-        run: |
-          uv pip install coverage==7.6.4
-          uv pip install pytest pytest-cov coverage-badge ".[dev]"
+        run: uv pip install ".[dev]"
 
       - name: Test with pytest and coverage badge
         run: |

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ The RenewBench-Crawler repository is structured as follows:
 │   │   └── schema.py             # Pydantic config models and registry
 │   ├── energy/                 # Energy data crawlers
 │   │   ├── adme/                 # ADME (Uruguay)
+│   │   ├── aemo/                 # AEMO (Australia)
 │   │   ├── aeso/                 # AESO (Canada, Alberta)
 │   │   ├── eat/                  # EA Te Mana Hiko (New Zealand)
 │   │   ├── eia/                  # EIA (US)

--- a/configs/energy/aemo.yaml
+++ b/configs/energy/aemo.yaml
@@ -1,0 +1,4 @@
+paths:
+  dst_dir_raw: /lsdf/raw/energy/aemo/
+access:
+  api_key: "YOUR-SECRET-KEY---DON'T-COMMIT!!!"

--- a/docs/data_sources.md
+++ b/docs/data_sources.md
@@ -18,7 +18,7 @@ RenewBench-Crawler package.
 | **Chile**                | CEN      | planned            |                          |                   |                                                                                                                                                                                                                                                                                                                        |
 | **Brazil**               | ONS      | downloader &check; | hourly; per plant        | public            | [Website](https://dados.ons.org.br/dataset/geracao-usina-2), Data hosting on AWS S3                                                                                                                                                                                                                                    |
 | **Uruguay**              | ADME     | downloader &check; | hourly; per plant        | public            | [Website](https://www.adme.com.uy/controlpanel.php), Data hosting [old](https://www.adme.com.uy/gpf_historico.php) / [new](https://www.adme.com.uy/panelControl/gpf.php)                                                                                                                                               |
-| **Australia**            | AEMO     | planned            |                          |                   |                                                                                                                                                                                                                                                                                                                        |
+| **Australia**            | AEMO     | downloader &check; | hourly/5 min; per plant  | API token         | [Website](https://www.aemo.com.au/),<br> [Python package](https://github.com/opennem/openelectricity-python), [API docs](https://docs.openelectricity.org.au/)                                                                                                                                                         |
 | **New<br>Zealand**       | EAT      | downloader &check; | 30 min; per plant        | public            | [Website / Data hosting](https://www.ea.govt.nz/data-and-insights/datasets/wholesale/generation/generation-output/)                                                                                                                                                                                                    |
 | **Japan**                | REI      | planned            | hourly; per region       |                   |                                                                                                                                                                                                                                                                                                                        |
 | **Taiwan**               | Taipower | downloader &check; | 10 min; per plant        | public            | [Website](https://www.taipower.com.tw/d006/loadGraph/loadGraph/genshx_e.html), [JSON](https://www.taipower.com.tw/d006/loadGraph/loadGraph/data/genary_eng.json),<br> [Example parser](https://github.com/electricitymaps/electricitymaps-contrib/blob/master/electricitymap/contrib/parsers/TAIPOWER.py)              |
@@ -55,9 +55,19 @@ RenewBench-Crawler package.
 
   `time_series.period.point.secondary_quantity` – consumption in MW (if the unit is consuming, else `NaN`)
 
-  `time_series.quantity_measure_unit_name` – physical unit of the reported quantities (usually `MAW`)
+  `time_series.quantity_measure_unit_name` – physical unit of the reported quantities
+  (usually `MAW`). According to [their TP docs](https://transparencyplatform.zendesk.com/hc/en-us/articles/16648326220564-Actual-Generation-per-Generation-Unit-16-1-A):
+  "Average of all available instantaneous net power output values in each Market Time Unit."
+  => MWh if `time_series.period.resolution = PT60M` (= 1h)
 
   `time_series.period.resolution` – string describing the time step (e.g. `PT15M`, `PT60M`)
+
+**STAC**
+
+- `measurement_type = 'net_output'`
+  - According to [their TP docs](https://transparencyplatform.zendesk.com/hc/en-us/articles/16648326220564-Actual-Generation-per-Generation-Unit-16-1-A):
+    "Actual net generation output (MW) per market time unit and per generation unit of 100
+    MW or more installed generation capacity. "
 
 </details>
 
@@ -117,7 +127,7 @@ RenewBench-Crawler package.
 
   `value` - net generation
 
-  `value-units` - unit of net generation
+  `value-units` - unit of net generation (commonly MWh)
 
 </details>
 
@@ -156,7 +166,9 @@ RenewBench-Crawler package.
 
   `Asset Grouping` - the meter that behind-the-fence assets share, if appropriate.
 
-  `Volume` - volume reported via SCADA (similar to that reported on CSD page)
+  `Volume` - volume reported via SCADA (similar to that reported on CSD page). According to
+  [their website](https://www.aeso.ca/market/market-and-system-reporting/data-requests/historical-generation-data/):
+  "The reported volume is the average generation over the given period." = MWh
 
   `Maximum Capability` - maximum capacity reported to the AESO
 
@@ -169,6 +181,14 @@ RenewBench-Crawler package.
   `Planning Area` - AESO planning area the asset is located in
 
   `Region` - AESO region the asset is located in
+
+**STAC**
+
+- `measurement_type = 'gross_output'`
+  -  According to [their website](https://www.aeso.ca/market/market-and-system-reporting/data-requests/historical-generation-data/):
+    "\[...\] this data is not the same as settlement meter data.
+    This data generally represents what was generated at the unit, not necessarily
+    what is delivered to the AESO grid."
 
 </details>
 
@@ -197,7 +217,9 @@ RenewBench-Crawler package.
   `Fuel Type` – fuel type (not given in `.xlsx` so `=NaN`; to be filled in during processing)
 
   `Measurement` – type of measurement:
-  - `Output`: generation in MW
+  - `Output`: generation in MW. According to [their docs](https://reports-public.ieso.ca/docrefs/helpfile/GenOutputCapability_h4.pdf):
+    "Output is the actual energy production of the unit or facility. The hourly output is the facility’s five-minute
+     outputs averaged over an hour." => MWh
   - `Capability`: available capacity
 
   `Hour 1`, `Hour 2`, …, `Hour 24` – ending hour intervals (i.e. `00:00 - 01:00` to `23:00 to
@@ -211,7 +233,8 @@ RenewBench-Crawler package.
 
 **Access**
 - Website: [ONS generation data](https://dados.ons.org.br/dataset/geracao-usina-2)
-- Requirements: public, no authentication needed (CC Attribution License)
+- Requirements: public, no authentication needed
+- License: [CC Attribution](https://dados.ons.org.br/dataset/geracao-usina-2)
 
 **Download & data structure**
 - Spatial resolution: per plant
@@ -269,7 +292,9 @@ RenewBench-Crawler package.
   `(/, Fecha)` – timestamp end (!) in local format (`DD-MM-YYYY HH:MM`)
 
   `(Hidráulico, <unit_name>)`, `(Biomasa, <unit_name>)`, `(Térmico, <unit_name>)`,
-  `(Eólico, <unit_name>)`, `(Solar, <unit_name>)` - generation per plant and source in MWh
+  `(Eólico, <unit_name>)`, `(Solar, <unit_name>)` - generation per plant and source in MWh.
+  According to [their website](https://adme-com-uy.translate.goog/datosabiertos.html?_x_tr_sl=es&_x_tr_tl=en&_x_tr_hl=en-US&_x_tr_pto=wapp):
+  "The file contains hourly data series showing the generation in MW of the different power plants"
 
 > **PLEASE NOTE:**
 >
@@ -278,6 +303,91 @@ RenewBench-Crawler package.
 
 </details>
 
+<details>
+<summary><b>AEMO (Australia)</b></summary>
+
+**Access**
+- Platform: [OpenElectricity](https://platform.openelectricity.org.au/)
+- Docs: [OpenElectricity Rest API](https://docs.openelectricity.org.au/api-reference/overview),
+  [Facility data guide](https://docs.openelectricity.org.au/guides/facilities)
+- Requirements: personal API token
+  1. Create account for the OpenElectricity platform via the [sign-up](https://platform.openelectricity.org.au/sign-up)
+  2. Go to Dashboard > API Keys > "+ Create New Key". This is your API token.
+- Limits: for 5-min data, max 8 days at once; for hourly data, max 32 days at once
+- License: [CC BY-NC 4.0](https://docs.openelectricity.org.au/api-reference/overview#data-licence)
+
+**Download & data structure**
+- Spatial resolution: per generation unit (plant)
+- Temporal resolution: hourly / 5 min
+- Available data timespan: ??? to now
+- Files saved as **raw**: 1 `.csv` per day
+- Columns saved as **raw**:
+
+  `timestamp` – timestamp end (!) in UTC-aware ISO 8601 (`YYYY-MM-DDTHH:MM:SS+00:00`;
+  `+10:00` for NEM, `+08:00` for WEM)
+
+  `code` – facility code
+
+  `name` – facility name
+
+  `network_id` – AEMO network identifier (e.g. `NEM`, `WEM`, `AU`)
+
+  `network_region` – network region identifier (e.g. `NSW1`, `QLD1`, `SA1`)
+
+  `description` – free-text facility description (HTML stripped)
+
+  `npi_id` – AEMO NPI identifier of the facility (if available)
+
+  `location` – location dict of the facility (i.e. `{'lat': ..., 'lng': ...}`)
+
+  `unit_code` – unique unit name (starts with facility name)
+
+  `unit_fueltech_id` – fuel/technology classification of the unit
+
+  `unit_status_id` – status of the unit (e.g. operating, retired)
+
+  `unit_dispatch_type` – dispatch type of the unit (e.g. `GENERATOR`, `LOAD`)
+
+  `unit_capacity_registered` – registered capacity of the unit (probably MW)
+
+  `unit_capacity_maximum` – maximum capacity of the unit (probably MW)
+
+  `unit_capacity_storage` – storage capacity of the unit
+
+  `value` – energy generated in the interval (MWh), derived from AEMO power data
+
+  `unit_data_first_seen` – first date the unit appears in AEMO / OpenElectricity data
+
+  `unit_data_last_seen` – last date the unit appears in AEMO / OpenElectricity data
+
+  `unit_commencement_date` – official commencement date of the unit
+
+> **PLEASE NOTE:**
+>
+> The times are stored in an End-of-Interval format that will require conversion!
+> (s. [the docs](https://docs.openelectricity.org.au/guides/curtailment#understanding-aemo%E2%80%99s-timestamp-convention))
+>
+> The stored energy generation/load values in MWh are calculated from AEMO's power data
+> (for more information, s. [their docs](https://docs.openelectricity.org.au/guides/energy#difference-between-energy-and-power))
+> All data is based on 5-min instantaneous power \[MW\], meaning hourly values are always
+> aggregated. For power, this aggregration is erroneously done by summation.
+> [An issue](https://github.com/opennem/opennem/issues/523) was created to address this.
+> Energy seems to be independent of this problem.
+
+**STAC**
+
+- `measurement_type = 'curtailed_gross_output'`
+  - According to [OpenElectricity](https://docs.openelectricity.org.au/guides/curtailment#how-open-electricity-reports-curtailment):
+    Curtailment is not included directly in the data but can theoretically be accessed
+    separately. This is not done here.
+  - AEMO publishes [SCADA data](https://www.nemweb.com.au/Reports/), which is
+    ["power dispatch data"](https://docs.openelectricity.org.au/guides/power#data) parsed
+    directly by [OpenElectricity](https://github.com/opennem/opennem/blob/main/opennem/crawl.py#L44).
+    According to [AEMO's term definitions](https://www.aemo.com.au/-/media/files/electricity/nem/planning_and_forecasting/demand-forecasts/operational-consumption-definition.pdf),
+    their provided [generation output](https://www.aemo.com.au/energy-systems/electricity/national-electricity-market-nem/data-nem/market-management-system-mms-data/generation-and-load)
+    seems to be "as generated" (total gross production on-site, not net grid injections).
+
+</details>
 
 <details>
 <summary><b>EAT (New Zealand)</b></summary>

--- a/docs/data_sources.md
+++ b/docs/data_sources.md
@@ -10,7 +10,7 @@ RenewBench-Crawler package.
 
 | Region                   | Source   | Status             | Resolution               | Access            | Resources                                                                                                                                                                                                                                                                                                              |
 |--------------------------|----------|--------------------|--------------------------|-------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| **Europe**               | ENTSO-e  | downloader &check; | hourly/15 min; per plant | API token         | [TP](https://transparency.entsoe.eu/), [API guide](https://transparencyplatform.zendesk.com/hc/en-us/sections/12783116987028-Restful-API-integration-guide),<br> [API how-to](https://transparencyplatform.zendesk.com/hc/en-us/articles/12845911031188-How-to-get-security-token)                                     |
+| **Europe**               | ENTSO-e  | downloader &check; | hourly/higher; per plant | API token         | [TP](https://transparency.entsoe.eu/), [API guide](https://transparencyplatform.zendesk.com/hc/en-us/sections/12783116987028-Restful-API-integration-guide),<br> [API how-to](https://transparencyplatform.zendesk.com/hc/en-us/articles/12845911031188-How-to-get-security-token)                                     |
 | **Turkey**               | EPIAS    | downloader &check; | hourly; per plant        | Login credentials | [TP](https://seffaflik.epias.com.tr/home), [Docs](https://seffaflik.epias.com.tr/electricity-service/technical/en/index.html),<br> [Registration form](https://kayit.epias.com.tr/epias-transparency-platform-registration-form)                                                                                       |
 | **USA**                  | EIA      | downloader &check; | hourly; per company      | API token         | [API browser](https://www.eia.gov/opendata/browser/), [API docs](https://www.eia.gov/opendata/documentation.php),<br> [API registration form](https://www.eia.gov/opendata/register.php)                                                                                                                               |
 | **Canada<br> (Alberta)** | AESO     | downloader &check; | hourly/5 min; per plant  | `box` API token   | [Website](https://www.aeso.ca/market/market-and-system-reporting/data-requests/historical-generation-data/), [Data hosting](https://aeso.app.box.com/s/qofgn9axnnw6uq3ip1goiq2ngb11txe5/folder/196731538687), <br> [API how-to](https://developer.box.com/guides/authentication/tokens/developer-tokens) (s. details!) |
@@ -64,7 +64,7 @@ RenewBench-Crawler package.
 
 **STAC**
 
-- `measurement_type = 'net_output'`
+- `measurement_type`: `'net_output'`
   - According to [their TP docs](https://transparencyplatform.zendesk.com/hc/en-us/articles/16648326220564-Actual-Generation-per-Generation-Unit-16-1-A):
     "Actual net generation output (MW) per market time unit and per generation unit of 100
     MW or more installed generation capacity. "
@@ -184,7 +184,7 @@ RenewBench-Crawler package.
 
 **STAC**
 
-- `measurement_type = 'gross_output'`
+- `measurement_type`: `'gross_output'`
   -  According to [their website](https://www.aeso.ca/market/market-and-system-reporting/data-requests/historical-generation-data/):
     "\[...\] this data is not the same as settlement meter data.
     This data generally represents what was generated at the unit, not necessarily
@@ -336,8 +336,6 @@ RenewBench-Crawler package.
 
   `description` – free-text facility description (HTML stripped)
 
-  `npi_id` – AEMO NPI identifier of the facility (if available)
-
   `location` – location dict of the facility (i.e. `{'lat': ..., 'lng': ...}`)
 
   `unit_code` – unique unit name (starts with facility name)
@@ -354,13 +352,13 @@ RenewBench-Crawler package.
 
   `unit_capacity_storage` – storage capacity of the unit
 
-  `value` – energy generated in the interval (MWh), derived from AEMO power data
-
   `unit_data_first_seen` – first date the unit appears in AEMO / OpenElectricity data
 
   `unit_data_last_seen` – last date the unit appears in AEMO / OpenElectricity data
 
   `unit_commencement_date` – official commencement date of the unit
+
+  `value` – energy generated in the interval (MWh), derived from AEMO power data
 
 > **PLEASE NOTE:**
 >
@@ -376,7 +374,7 @@ RenewBench-Crawler package.
 
 **STAC**
 
-- `measurement_type = 'curtailed_gross_output'`
+- `measurement_type`: `'curtailed_gross_output'`
   - According to [OpenElectricity](https://docs.openelectricity.org.au/guides/curtailment#how-open-electricity-reports-curtailment):
     Curtailment is not included directly in the data but can theoretically be accessed
     separately. This is not done here.
@@ -386,6 +384,11 @@ RenewBench-Crawler package.
     According to [AEMO's term definitions](https://www.aemo.com.au/-/media/files/electricity/nem/planning_and_forecasting/demand-forecasts/operational-consumption-definition.pdf),
     their provided [generation output](https://www.aemo.com.au/energy-systems/electricity/national-electricity-market-nem/data-nem/market-management-system-mms-data/generation-and-load)
     seems to be "as generated" (total gross production on-site, not net grid injections).
+- `entity_type`: `'unit'`
+
+  The parsed data is specifically for units. These all are associated with a facility
+  (under `code` and `name`) for which consolidated data is generated in postprocessing to
+  create `entity_type`: `'facility'` rows.
 
 </details>
 

--- a/docs/data_sources.md
+++ b/docs/data_sources.md
@@ -319,8 +319,8 @@ RenewBench-Crawler package.
 **Download & data structure**
 - Spatial resolution: per generation unit (plant)
 - Temporal resolution: hourly / 5 min
-- Available data timespan: ??? to now
-- Files saved as **raw**: 1 `.csv` per day
+- Available data timespan: 1998 to now
+- Files saved as **raw**: 1 `.csv` per day for 5-min, 1 `.csv` per month for 1h
 - Columns saved as **raw**:
 
   `timestamp` – timestamp end (!) in UTC-aware ISO 8601 (`YYYY-MM-DDTHH:MM:SS+00:00`;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ dev = [
     "mypy",
     "pre-commit",
     "pytest",
+    "pytest-asyncio",
     "pytest-cov",
     "pytest-mpi",
     "ruff",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     "eptr2",
     "geopandas",
     "loguru",
-    "openelectricity @ git+https://github.com/RenewBench-Association/openelectricity.git@fix/async_get_facility_data",
+    "openelectricity @ git+https://github.com/RenewBench-Association/openelectricity.git@fix/async_get_facility_data#egg=openelectricity",
     "pandas",
     "pydantic",
     "pyyaml",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     "eptr2",
     "geopandas",
     "loguru",
-    "openelectricity @ git+https://github.com/RenewBench-Association/openelectricity.git@fix/async_get_facility_data#egg=openelectricity",
+    "openelectricity @ git+https://github.com/RenewBench-Association/openelectricity-python.git@fix/async_get_facility_data",
     "pandas",
     "pydantic",
     "pyyaml",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,8 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
-    "coverage",
+    "coverage==7.6.4",
+    "coverage-badge",
     "mypy",
     "pre-commit",
     "pytest",
@@ -87,8 +88,8 @@ exclude = [
 line-length = 88
 indent-width = 4
 
-# Assume Python 3.8.
-target-version = "py38"
+# Assume Python 3.11
+target-version = "py311"
 
 [tool.ruff.lint]
 # Enable Pyflakes (`F`) and a subset of the pycodestyle (`E`)  codes by default.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
     "geopandas",
     "loguru",
     "openelectricity @ git+https://github.com/RenewBench-Association/openelectricity-python.git@fix/async_get_facility_data",
+    "openpyxl",
     "pandas",
     "pydantic",
     "pyyaml",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     "eptr2",
     "geopandas",
     "loguru",
-    "nemosis",
+    "openelectricity @ git+https://github.com/RenewBench-Association/openelectricity.git@fix/async_get_facility_data",
     "pandas",
     "pydantic",
     "pyyaml",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,9 @@ build-backend = "hatchling.build"
 [tool.hatch.build.targets.wheel]
 packages = ["rbc"]
 
+[tool.hatch.metadata]
+allow-direct-references = true
+
 [project]
 name = "RenewBench-Crawler"
 version = "0.0.1"

--- a/rbc/config/schema.py
+++ b/rbc/config/schema.py
@@ -126,6 +126,20 @@ class AdmeConfig(PathValidation, BaseModel):
     paths: Paths
 
 
+class AemoConfig(PathValidation, AccessValidation, BaseModel):
+    """Configuration schema for the AEMO energy data source.
+
+    Attributes:
+        source (Literal): Name of the data source.
+        paths (Paths): Paths pydantic model for paths.
+        access (AccessAPI): Access pydantic model for access settings.
+    """
+
+    source: Literal["aemo"] = "aemo"
+    paths: Paths
+    access: AccessAPI
+
+
 class AesoConfig(PathValidation, AccessValidation, BaseModel):
     """Configuration schema for the AESO energy data source.
 
@@ -276,6 +290,7 @@ class Barra2Config(PathValidation, BaseModel):
 # ----------------------------------
 SCHEMA_REGISTRY: dict[str, Type[BaseModel]] = {
     "adme": AdmeConfig,
+    "aemo": AemoConfig,
     "aeso": AesoConfig,
     "eat": EatConfig,
     "eia": EiaConfig,

--- a/rbc/energy/aemo/__init__.py
+++ b/rbc/energy/aemo/__init__.py
@@ -1,0 +1,3 @@
+from rbc.energy.aemo.downloader import AemoDownloader
+
+__all__ = ["AemoDownloader"]

--- a/rbc/energy/aemo/downloader.py
+++ b/rbc/energy/aemo/downloader.py
@@ -322,11 +322,11 @@ class AemoDownloader(EnergyDownloader):
          'project_lodgement_date', 'created_at', 'updated_at']
         All columns are combined into one df by adding the prefix 'unit' to the unit data.
         The lookup dictionary is generated from this dataframe to have the keys:
-        ["code", "network_id", "unit_code", "start", "timezone"]
+        ["code", "network_id", "unit_code", "start"]
 
         Returns:
             df_fu (pd.Dataframe): Dataframe of units with their associated facility data.
-            lookup_f (dict): Dict of all units and their start date.
+            lookup_u (dict): Dict of all units and their start date.
 
         Raises:
             DataStructureError: If the API facilities data no longer contains content that
@@ -371,7 +371,7 @@ class AemoDownloader(EnergyDownloader):
 
             # build a lookup dict with start dates for all rows (units)
             df_lookup = df_fu.copy()
-            df_lookup[["start", "timezone"]] = df_lookup.apply(
+            df_lookup["start"] = df_lookup.apply(
                 lambda r: _get_start_date(
                     d1=r["unit_data_first_seen"],
                     d2=r["unit_commencement_date"],
@@ -379,12 +379,10 @@ class AemoDownloader(EnergyDownloader):
                 ),
                 axis=1,
             )
-            df_lookup = df_lookup[
-                ["code", "network_id", "unit_code", "start", "timezone"]
-            ]
+            df_lookup = df_lookup[["code", "network_id", "unit_code", "start"]]
 
             lookup_u = df_lookup.set_index("unit_code")[
-                ["network_id", "start", "timezone"]
+                ["network_id", "start"]
             ].to_dict("index")
 
         except KeyError as e:
@@ -413,8 +411,8 @@ class AemoDownloader(EnergyDownloader):
             list: List of valid units.
         """
         valid_units = [u for u in units if self.lookup_u[u]["start"].year <= year]
-        diff = set(units) - set(valid_units)
 
+        diff = set(units) - set(valid_units)
         if len(diff) > 0:
             logger.warning(
                 f"No energy data for {len(diff)} out of {len(units)} units "
@@ -431,7 +429,7 @@ class AemoDownloader(EnergyDownloader):
 
 def _get_start_date(
     d1: datetime | None, d2: datetime | None, network_id: str
-) -> pd.Series:
+) -> datetime:
     """Define (buffered) start date using d1, d2 or MIN_YEAR depending on which is not None.
 
     In this case, d1 is the "data_first_seen" date and d2 is the "commencement_date". The
@@ -444,7 +442,7 @@ def _get_start_date(
         network_id (str): Network ID used to identify the row's timezone info.
 
     Returns:
-        pd.Series: column "start" with start_date, column "timezone" with timezone info.
+        datetime: unit's start date
     """
     row_tz: tzinfo = VALID_NETWORKS[network_id]
 
@@ -456,4 +454,4 @@ def _get_start_date(
         else (datetime(MIN_YEAR, 1, 1, tzinfo=row_tz))
     )
     buffered_start_date = start_date.replace(month=1, day=1, hour=0, minute=0, second=0)
-    return pd.Series({"start": buffered_start_date, "timezone": row_tz})
+    return buffered_start_date

--- a/rbc/energy/aemo/downloader.py
+++ b/rbc/energy/aemo/downloader.py
@@ -1,0 +1,456 @@
+"""AEMO DATA DOWNLOADER.
+
+Remote API access of AEMO (OpenElectricity) Platform using the openelectricity-python package.
+"""
+
+import asyncio
+import logging
+from concurrent.futures import ThreadPoolExecutor
+from datetime import datetime, timedelta, timezone, tzinfo
+from pathlib import Path
+
+import pandas as pd
+import requests
+from loguru import logger
+from openelectricity import AsyncOEClient, DataMetric, OEClient
+from openelectricity.client import APIError
+from openelectricity.models.facilities import FacilityResponse
+
+from rbc.energy.utils import (
+    WORKERS,
+    DataStructureError,
+    DownloadTask,
+    EnergyDownloader,
+    InvalidError,
+    MissingDataError,
+)
+
+logging.getLogger("openelectricity").setLevel(logging.CRITICAL)
+
+MIN_YEAR = 2006
+VALID_NETWORKS = {
+    "NEM": timezone(timedelta(hours=10)),
+    "WEM": timezone(timedelta(hours=8)),
+    "AU": timezone(timedelta(hours=10)),
+}
+# (s. https://docs.openelectricity.org.au/sdk/typescript/utilities#date-and-time-utilities)
+EXPECTED_COLS = [
+    "timestamp",
+    "code",
+    "name",
+    "network_id",
+    "network_region",
+    "description",
+    "npi_id",
+    "location",
+    "unit_code",
+    "unit_fueltech_id",
+    "unit_status_id",
+    "unit_dispatch_type",
+    "unit_capacity_registered",
+    "unit_capacity_maximum",
+    "unit_capacity_storage",
+    "value",
+    "unit_data_first_seen",
+    "unit_data_last_seen",
+    "unit_commencement_date",
+]
+
+
+class AemoDownloader(EnergyDownloader):
+    """AEMO data downloader.
+
+    Attributes:
+        token (str): The personal OpenElectricity API token.
+        client (OEClient): OEClient object for AEMO (OpenElectricity) data access.
+        df_units (pd.DataFrame): Dataframe containing facilities and units information.
+        units_lookup (dict): Lookup dict for facility start dates.
+        valid_units (list): List of valid AEMO facility units for the given time frame.
+    """
+
+    def __init__(
+        self,
+        token: str,
+        output_path: Path,
+        years: list[int],
+        temporal_resolutions: list[str],
+        resume: bool = True,
+    ):
+        """Initializes the instance.
+
+        Args:
+            token (str): The personal OpenElectricity API token.
+            output_path (Path): Path to the output directory.
+            years (list[int]): List of years to get data for.
+            temporal_resolutions (list[str]): The temporal resolutions to download.
+            resume (bool, optional): Whether to resume from a previous download (True)
+                or start from scratch (False). Defaults to True.
+
+        Raises:
+            InvalidError: If provided temporal_resolutions are invalid (not 1h &/ 5min) or if
+                login credentials are incorrect.
+        """
+        super().__init__(
+            output_path=output_path, years=years, start_year=MIN_YEAR, resume=resume
+        )
+        self.temporal_resolutions = temporal_resolutions
+
+        invalid_t_res = set(temporal_resolutions) - set({"1h", "5min"})
+        if invalid_t_res:
+            raise InvalidError(
+                f"Invalid temporal resolution(s): {sorted(invalid_t_res)}"
+            )
+
+        # API setup
+        self.token = token
+        self.client = OEClient(api_key=token)
+        try:
+            self.client.get_current_user()
+        except APIError as e:
+            raise InvalidError(f"AEMO (OpenElectricity) connection failed: {e}") from e
+
+        logger.info(
+            f"AEMO (OpenElectricity) Downloader initialized for:\n- years:\t\t{years}"
+        )
+
+        # get existing facilities and units dataframe and lookup dict for start dates
+        self.df_units, self.units_lookup = self._get_facilities_and_units()
+
+        # pre-filter units to only those that generate data in the requested year(s)
+        latest_year = max(years)
+        unique_units = self.df_units["unit_code"].unique()
+        self.valid_units = [
+            unit
+            for unit in unique_units
+            if self.units_lookup[unit]["start"].year <= latest_year
+        ]
+
+        diff_units = set(unique_units) - set(self.valid_units)
+        if len(diff_units) > 0:
+            logger.warning(
+                f"No energy data for {len(diff_units)} out of {len(unique_units)} units "
+                f"(not yet producing in {latest_year}). Skipping:\n\n{diff_units}"
+            )
+
+    def download_data(self) -> None:
+        """Parse data for all given years from AEMO (OpenElectricity) and save to CSV."""
+        # download per month for "1h", per day for anything else (i.e. "5min")
+        tasks = [
+            DownloadTask(date=d, temporal_resolution=t_res)
+            for t_res in self.temporal_resolutions
+            for d in self._get_date_list()
+            # for d in (
+            #     self._get_month_list() if t_res == "1h" else self._get_date_list()
+            # )
+        ]
+
+        logger.info(
+            f"Downloading tasks: {tasks[0].identifier} --- {tasks[-1].identifier}"
+        )
+        with ThreadPoolExecutor(max_workers=WORKERS) as executor:
+            executor.map(self._threading_wrapper, tasks)
+
+    def _get_task_data(self, task: DownloadTask) -> pd.DataFrame:  # type: ignore[override]
+        """Get AEMO (OpenElectricity) generation data per plant for one specific date.
+
+        AEMO follows an End-of-Interval timestamp convention, meaning values for an hour
+        are saved on the dot of the next hour (i.e. "01:00" = data from 0-1 AM, not 1-2 AM).
+        This means for each day, data starts with hour 1 of Day 1 and hour 0 of Day 2
+        (i.e. start = "2018-01-01T01:00", end = "2018-01-02T00:00"). Analagous for 5 min data.
+
+        Args:
+            task (DownloadTask): The metadata of a downloading task, here: date (YYYY-MM-DD)
+
+        Returns:
+            df (pd.DataFrame): Dataframe for specific date.
+
+        Raises:
+            MissingDataError: If no generation data exists.
+            DataStructureError: If the data structure changed and relevant columns are now
+                missing (this will cause the entire run to be killed).
+        """
+        start = datetime.fromisoformat(task.date)
+        start = start.replace(second=1)
+        end = start + timedelta(days=1)
+        t_res = task.temporal_resolution
+        t_res = t_res if "min" not in t_res else t_res.replace("min", "m")
+
+        # filter list of units even further based on current task at hand
+        valid_units = [
+            unit
+            for unit in self.valid_units
+            if self.units_lookup[unit]["start"].year <= task.year
+        ]
+
+        async def fetch_task_data() -> list:
+            """Fetch all data for a task (date, t_res) using an async (parallel) client.
+
+            This is implemented as a nested function to forgo unnecessary argument definition
+            (it requires parameters defined in the main method, e.g. start, end, t_res).
+
+            Returns:
+                list: List of data from all units for a given task (date, t_res)
+            """
+            async with AsyncOEClient(api_key=self.token) as a_client:
+                semaphore = asyncio.Semaphore(10)  # few workers to work with threading
+                tasks = []
+
+                # get data for 1 unit at a time because results are otherwise aggregated
+                for unit in valid_units:
+                    unit_start = self.units_lookup[unit]["start"]
+                    task_end = end.replace(tzinfo=self.units_lookup[unit]["timezone"])
+
+                    if task_end < unit_start:
+                        logger.info(
+                            f"No energy data for unit {unit} (it's before {unit_start}). "
+                            f"Skipping..."
+                        )  # don't raise error here or loop will be interrupted
+                    else:
+                        try:
+                            tasks.append(
+                                self._fetch_unit_data_async(
+                                    a_client,
+                                    semaphore,
+                                    network_code=self.units_lookup[unit]["network_id"],
+                                    unit_code=unit,
+                                    date_start=start,
+                                    date_end=end,
+                                    temporal_res=t_res,
+                                )
+                            )
+                        except requests.exceptions.HTTPError:
+                            logger.warning(
+                                f"Defining task {task} as failed given that "
+                                f"data for unit {unit} could not be fetched."
+                            )
+                            raise
+
+                results = await asyncio.gather(*tasks)
+                return [item for sublist in results for item in sublist]
+
+        loop = asyncio.new_event_loop()
+        try:
+            asyncio.set_event_loop(loop)
+            data = loop.run_until_complete(fetch_task_data())
+        finally:
+            loop.close()
+
+        if not data:
+            raise MissingDataError(f"No generation data for {task.date}")
+
+        # define dataframe to be saved
+        df = pd.DataFrame(data)
+        try:
+            df = pd.merge(self.df_units, df, on=["unit_code"])
+            df = df[EXPECTED_COLS].sort_values(by=["timestamp"])
+        except KeyError as e:
+            raise DataStructureError(
+                f"AEMO (OpenElectricity) structure change detected! Relevant column missing "
+                f"from facility and units data: {e}"
+            )
+
+        return df
+
+    @staticmethod
+    async def _fetch_unit_data_async(
+        async_client: AsyncOEClient,
+        semaphore: asyncio.Semaphore,
+        network_code: str,
+        unit_code: str,
+        date_start: datetime,
+        date_end: datetime,
+        temporal_res: str,
+    ) -> list[dict] | list[None]:
+        """Fetch data for one specific unit at a time, within the realm of the given task.
+
+        The OpenElectricity API offers the download of DataMetric.ENERGY and DataMetric.POWER
+        data, where POWER [MW] is the instantenous output at a specific point in time and
+        ENERGY [MWh] is the average of power generated during a given interval and the
+        previous interval (s. https://docs.openelectricity.org.au/guides/energy).
+        All data is based on the 5-min interval values, i.e. 1h values are aggregated from
+        that.
+
+        Args:
+            async_client (AsyncOEClient): AsyncOEClient object from OpenElectricity API.
+            semaphore (asyncio.Semaphore): Asyncio parallelization lock.
+            network_code (str): Network code.
+            unit_code (str): Unit code.
+            date_start (datetime): Start of timeframe to fetch data for.
+            date_end (datetime): End of timeframe to fetch data from.
+            temporal_res (str): Temporal resolution to fetch data for.
+
+        Returns:
+            list: List of all unit data for the task in dict form or empty, if none exists.
+
+        Raises:
+            HTTPError: If unit data exists but an error occurred during fetching.
+        """
+        async with semaphore:
+            try:
+                response = await async_client.get_facility_data(
+                    network_code=network_code,
+                    unit_code=unit_code,
+                    metrics=[DataMetric.ENERGY],
+                    interval=temporal_res,
+                    date_start=date_start,
+                    date_end=date_end,
+                )
+                # map the nested response back to a flat list of dicts
+                return [
+                    {"timestamp": e.root[0], "unit_code": unit_code, "value": e.root[1]}
+                    for s in response.data
+                    for result in s.results
+                    for e in result.data
+                ]
+
+            except APIError as e:  # openelectricity-package error that will be raised
+                status_code = e.status_code
+                detail = e.detail
+
+                if status_code == 404:  # when data is permanently missing (404), skip!
+                    logger.info(
+                        f"No energy data for unit {unit_code}. Skipping..."
+                    )  # don't raise error here or loop will be interrupted
+                    return []
+
+                response = requests.Response()
+                response.status_code = status_code
+                response.reason = detail
+
+                raise requests.exceptions.HTTPError(
+                    f"Error {status_code} retrieving {unit_code} data with "
+                    f"the OpenElectricity API: {detail}",
+                    response=response,
+                )
+
+    # --------------------------------------------
+    # Helper methods
+    # --------------------------------------------
+    def _get_facilities_and_units(self) -> tuple[pd.DataFrame, dict]:
+        """Get dataframe of all facilities and units and lookup dict for start dates.
+
+        This method requests data of all existing energy generation facilities, given as:
+        ['code', 'name', 'network_id', 'network_region', 'description', 'npi_id',
+         'location', 'units', 'created_at', 'updated_at']
+        Information on any units these facilities have is stored under the 'units' header:
+        ['code', 'fueltech_id', 'status_id', 'capacity_registered', 'capacity_maximum',
+         'capacity_storage', 'emissions_factor_co2', 'data_first_seen', 'data_last_seen',
+         'dispatch_type', 'commencement_date', 'commencement_date_specificity',
+         'commencement_date_display', 'closure_date', 'closure_date_specificity',
+         'closure_date_display', 'expected_operation_date', 'expected_operation_date_specificity',
+         'expected_operation_date_display', 'expected_closure_date',
+         'expected_closure_date_specificity', 'expected_closure_date_display',
+         'construction_start_date', 'construction_start_date_specificity',
+         'construction_start_date_display', 'project_approval_date',
+         'project_approval_date_specificity', 'project_approval_date_display',
+         'project_lodgement_date', 'created_at', 'updated_at']
+        All columns are combined into one df by adding the prefix 'unit' to the unit data.
+        The lookup dictionary is generated from this dataframe to have the keys:
+        ["code", "network_id", "unit_code", "start", "timezone"]
+
+        Returns:
+            df_fu (pd.Dataframe): Dataframe of facilities and units.
+            units_lookup_start (dict): Dict of all units and their start date.
+
+        Raises:
+            DataStructureError: If the API facilities data no longer contains content that
+                can be postprocessed, no data was downloaded, or relevant columns are missing.
+        """
+        facilities: FacilityResponse = self.client.get_facilities(
+            network_id=list(VALID_NETWORKS)
+        )
+
+        try:
+            data: list[dict] = [f.model_dump() for f in facilities.data]
+            df_facilities = pd.DataFrame(data)
+
+        except (AttributeError, ValueError) as e:
+            raise DataStructureError(
+                f"AEMO (OpenElectricity) structure change detected! Facility data no "
+                f"longer contains 'data' object that can be transformed into a df: {e}"
+            )
+
+        # check if data or created dataframe are empty (no data was downloaded)
+        if not data or df_facilities.empty:
+            raise DataStructureError(
+                "AEMO (OpenElectricity) structure change detected! No facilities / units "
+                "data was downloaded."
+            )
+
+        # create merged dataframe and lookup dictionary
+        try:
+            df_facilities.pop("units")
+            df_facilities["description"] = df_facilities["description"].str.replace(
+                r"<[^>]*>", "", regex=True
+            )
+            df_units = pd.json_normalize(
+                data,
+                record_path=["units"],
+                meta=["code", "name", "network_region"],
+                record_prefix="unit_",
+            )
+
+            # merge dataframes on "code", "name", and "network_region"
+            df_fu = pd.merge(
+                df_facilities, df_units, on=["code", "name", "network_region"]
+            )
+
+            # build a lookup dict with start dates for units
+            df_fu[["start", "timezone"]] = df_fu.apply(
+                lambda r: _get_start_date(
+                    d1=r["unit_data_first_seen"],
+                    d2=r["unit_commencement_date"],
+                    network_id=r["network_id"],
+                ),
+                axis=1,
+            )
+            units_lookup_start = (
+                df_fu[["code", "network_id", "unit_code", "start", "timezone"]]
+                .set_index("unit_code")  # make 'unit_code' the dict key value
+                .to_dict(orient="index")  # convert to {key: {col: value}} format
+            )
+            df_fu.pop("start")
+            df_fu.pop("timezone")
+
+        except KeyError as e:
+            raise DataStructureError(
+                f"AEMO (OpenElectricity) structure change detected! Relevant column missing "
+                f"from facility and units data: {e}"
+            )
+        except NotImplementedError as e:
+            raise DataStructureError(
+                f"AEMO (OpenElectricity) structure change detected! Data content has been "
+                f"reformatted so that json normalisation does not work anymore: {e}"
+            )
+
+        return df_fu, units_lookup_start
+
+
+def _get_start_date(
+    d1: datetime | None, d2: datetime | None, network_id: str
+) -> pd.Series:
+    """Set start date as d1, d2 or MIN_YEAR datetime object depending on which is not None.
+
+    In this case, d1 is the "data_first_seen" date and d2 is the "commencement_date". The
+    assumption here is that the "data_first_seen" date is what we're actually looking for,
+    but since that is sometimes None, the fallback is d2, or even the MIN_YEAR value.
+
+    Args:
+        d1 (datetime | None): first datetime object (or None)
+        d2 (datetime | None): second datetime object (or None)
+        network_id (str): Network ID used to identify the row's timezone info.
+
+    Returns:
+        pd.Series: column "start" with start_date, column "timezone" with timezone info.
+    """
+    row_tz: tzinfo = VALID_NETWORKS[network_id]
+
+    start_date = (
+        d1
+        if isinstance(d1, datetime)
+        else d2
+        if isinstance(d2, datetime)
+        else (datetime(MIN_YEAR, 1, 1, tzinfo=row_tz))
+    )
+
+    return pd.Series({"start": start_date, "timezone": row_tz})

--- a/rbc/energy/aemo/downloader.py
+++ b/rbc/energy/aemo/downloader.py
@@ -41,7 +41,6 @@ EXPECTED_COLS = [
     "network_id",
     "network_region",
     "description",
-    "npi_id",
     "location",
     "unit_code",
     "unit_fueltech_id",
@@ -50,10 +49,10 @@ EXPECTED_COLS = [
     "unit_capacity_registered",
     "unit_capacity_maximum",
     "unit_capacity_storage",
-    "value",
     "unit_data_first_seen",
     "unit_data_last_seen",
     "unit_commencement_date",
+    "value",
 ]
 
 
@@ -63,9 +62,9 @@ class AemoDownloader(EnergyDownloader):
     Attributes:
         token (str): The personal OpenElectricity API token.
         client (OEClient): OEClient object for AEMO (OpenElectricity) data access.
-        df_units (pd.DataFrame): Dataframe containing facilities and units information.
-        units_lookup (dict): Lookup dict for facility start dates.
-        valid_units (list): List of valid AEMO facility units for the given time frame.
+        df_fu (pd.DataFrame): Dataframe containing information on all units.
+        lookup_u (dict): Lookup dict for unit start dates.
+        valid_u (list): List of valid AEMO units for the given time frame.
     """
 
     def __init__(
@@ -113,26 +112,14 @@ class AemoDownloader(EnergyDownloader):
             f"AEMO (OpenElectricity) Downloader initialized for:\n- years:\t\t{years}"
         )
 
-        # get existing facilities and units dataframe and lookup dict for start dates
-        self.df_units, self.units_lookup = self._get_facilities_and_units()
+        # get dataframe of existing facilities & units and lookup dict for start dates
+        self.df_fu, self.lookup_u = self._get_facilities_and_units()
 
         # pre-filter units to only those that generate data in the requested year(s)
-        latest_year = max(years)
-        unique_units = self.df_units["unit_code"].unique()
-        self.valid_units = [
-            unit
-            for unit in unique_units
-            if self.units_lookup[unit]["start"].year <= latest_year
-        ]
-
-        diff_units = set(unique_units) - set(self.valid_units)
-        if len(diff_units) > 0:
-            logger.warning(
-                f"No energy data for {len(diff_units)} out of {len(unique_units)} units "
-                f"(not yet producing in {latest_year}). Skipping:\n\n{diff_units}"
-            )
-        else:
-            logger.info(f"All units {len(unique_units)} are producing energy data.")
+        unique_u = self.df_fu["unit_code"].unique()
+        self.valid_u = self._get_valid_units(
+            units=unique_u, year=max(years), verbose=True
+        )
 
     def download_data(self) -> None:
         """Parse data for all given years from AEMO (OpenElectricity) and save to CSV."""
@@ -163,7 +150,7 @@ class AemoDownloader(EnergyDownloader):
             task (DownloadTask): The metadata of a downloading task, here: date (YYYY-MM-DD)
 
         Returns:
-            df (pd.DataFrame): Dataframe for specific date.
+            df_fu (pd.DataFrame): Dataframe of units for specific date.
 
         Raises:
             MissingDataError: If no generation data exists.
@@ -182,12 +169,8 @@ class AemoDownloader(EnergyDownloader):
         t_res = task.temporal_resolution
         t_res = t_res if "min" not in t_res else t_res.replace("min", "m")
 
-        # filter list of units even further based on current task at hand
-        valid_units = [
-            unit
-            for unit in self.valid_units
-            if self.units_lookup[unit]["start"].year <= task.year
-        ]
+        # filter list of units further based on current task
+        valid_u = self._get_valid_units(units=self.valid_u, year=task.year)
 
         async def fetch_task_data() -> list:
             """Fetch all data for a task (date, t_res) using an async (parallel) client.
@@ -203,65 +186,42 @@ class AemoDownloader(EnergyDownloader):
                 tasks = []
 
                 # get data for 1 unit at a time because results are otherwise aggregated
-                for unit in valid_units:
-                    unit_start = self.units_lookup[unit]["start"]
-                    task_end = end.replace(tzinfo=self.units_lookup[unit]["timezone"])
-
-                    if task_end.date() < unit_start.date():
-                        logger.debug(
-                            f"No energy data for unit {unit} (it's before {unit_start}). "
-                            f"Skipping..."
-                        )  # don't raise error here or loop will be interrupted
-                    else:
-                        try:
-                            tasks.append(
-                                self._fetch_unit_data_async(
-                                    a_client,
-                                    semaphore,
-                                    network_code=self.units_lookup[unit]["network_id"],
-                                    unit_code=unit,
-                                    date_start=start,
-                                    date_end=end,
-                                    temporal_res=t_res,
-                                )
-                            )
-                        except requests.exceptions.HTTPError:
-                            logger.warning(
-                                f"Defining task {task} as failed given that "
-                                f"data for unit {unit} could not be fetched."
-                            )
-                            raise
+                for unit in valid_u:
+                    tasks.append(
+                        self._fetch_unit_data_async(
+                            a_client,
+                            semaphore,
+                            network_code=self.lookup_u[unit]["network_id"],
+                            unit_code=unit,
+                            date_start=start,
+                            date_end=end,
+                            temporal_res=t_res,
+                        )
+                    )
 
                 results = await asyncio.gather(*tasks)
 
-                units_w_data = sum(1 for r in results if r)
-                units_wo_data = sum(1 for r in results if not r)
                 logger.info(
-                    f"Task {task.identifier}: {units_w_data} units with data, "
-                    f"{units_wo_data} units without data."
+                    f"Task {task.identifier}: {sum(1 for r in results if r)} / {len(results)}"
+                    f" units with data"
                 )
-
                 return [item for sublist in results for item in sublist]
 
-        loop = asyncio.new_event_loop()
-        try:
-            asyncio.set_event_loop(loop)
-            data = loop.run_until_complete(fetch_task_data())
-        finally:
-            loop.close()
+        # get results
+        data = asyncio.run(fetch_task_data())
 
         if not data:
             raise MissingDataError(f"No generation data for {task.date}")
 
         # define dataframe to be saved
-        df = pd.DataFrame(data)
+        df_api = pd.DataFrame(data)
         try:
-            df = pd.merge(self.df_units, df, on=["unit_code"])
+            df = pd.merge(self.df_fu, df_api, on=["unit_code"])
             df = df[EXPECTED_COLS].sort_values(by=["timestamp"])
         except KeyError as e:
             raise DataStructureError(
                 f"AEMO (OpenElectricity) structure change detected! Relevant column missing "
-                f"from facility and units data: {e}"
+                f"from facilities and units data: {e}"
             )
 
         return df
@@ -313,10 +273,10 @@ class AemoDownloader(EnergyDownloader):
                 # map the nested response back to a flat list of dicts
                 logger.debug(f"Energy data found for unit {unit_code}")
                 return [
-                    {"timestamp": e.root[0], "unit_code": unit_code, "value": e.root[1]}
+                    {"timestamp": d.root[0], "unit_code": unit_code, "value": d.root[1]}
                     for s in response.data
                     for result in s.results
-                    for e in result.data
+                    for d in result.data
                 ]
 
             except APIError as e:  # openelectricity-package error that will be raised
@@ -365,8 +325,8 @@ class AemoDownloader(EnergyDownloader):
         ["code", "network_id", "unit_code", "start", "timezone"]
 
         Returns:
-            df_fu (pd.Dataframe): Dataframe of facilities and units.
-            units_lookup_start (dict): Dict of all units and their start date.
+            df_fu (pd.Dataframe): Dataframe of units with their associated facility data.
+            lookup_f (dict): Dict of all units and their start date.
 
         Raises:
             DataStructureError: If the API facilities data no longer contains content that
@@ -378,7 +338,7 @@ class AemoDownloader(EnergyDownloader):
 
         try:
             data: list[dict] = [f.model_dump() for f in facilities.data]
-            df_facilities = pd.DataFrame(data)
+            df_f = pd.DataFrame(data)
 
         except (AttributeError, ValueError) as e:
             raise DataStructureError(
@@ -387,7 +347,7 @@ class AemoDownloader(EnergyDownloader):
             )
 
         # check if data or created dataframe are empty (no data was downloaded)
-        if not data or df_facilities.empty:
+        if not data or df_f.empty:
             raise DataStructureError(
                 "AEMO (OpenElectricity) structure change detected! No facilities / units "
                 "data was downloaded."
@@ -395,24 +355,23 @@ class AemoDownloader(EnergyDownloader):
 
         # create merged dataframe and lookup dictionary
         try:
-            df_facilities.pop("units")
-            df_facilities["description"] = df_facilities["description"].str.replace(
+            df_f.pop("units")
+            df_f["description"] = df_f["description"].str.replace(
                 r"<[^>]*>", "", regex=True
             )
-            df_units = pd.json_normalize(
+
+            # build a dataframe of units including their facilities information
+            df_u = pd.json_normalize(
                 data,
                 record_path=["units"],
                 meta=["code", "name", "network_region"],
                 record_prefix="unit_",
             )
+            df_fu = pd.merge(df_f, df_u, on=["code", "name", "network_region"])
 
-            # merge dataframes on "code", "name", and "network_region"
-            df_fu = pd.merge(
-                df_facilities, df_units, on=["code", "name", "network_region"]
-            )
-
-            # build a lookup dict with start dates for units
-            df_fu[["start", "timezone"]] = df_fu.apply(
+            # build a lookup dict with start dates for all rows (units)
+            df_lookup = df_fu.copy()
+            df_lookup[["start", "timezone"]] = df_lookup.apply(
                 lambda r: _get_start_date(
                     d1=r["unit_data_first_seen"],
                     d2=r["unit_commencement_date"],
@@ -420,13 +379,13 @@ class AemoDownloader(EnergyDownloader):
                 ),
                 axis=1,
             )
-            units_lookup_start = (
-                df_fu[["code", "network_id", "unit_code", "start", "timezone"]]
-                .set_index("unit_code")  # make 'unit_code' the dict key value
-                .to_dict(orient="index")  # convert to {key: {col: value}} format
-            )
-            df_fu.pop("start")
-            df_fu.pop("timezone")
+            df_lookup = df_lookup[
+                ["code", "network_id", "unit_code", "start", "timezone"]
+            ]
+
+            lookup_u = df_lookup.set_index("unit_code")[
+                ["network_id", "start", "timezone"]
+            ].to_dict("index")
 
         except KeyError as e:
             raise DataStructureError(
@@ -439,7 +398,35 @@ class AemoDownloader(EnergyDownloader):
                 f"reformatted so that json normalisation does not work anymore: {e}"
             )
 
-        return df_fu, units_lookup_start
+        return df_fu, lookup_u
+
+    def _get_valid_units(self, units: list, year: int, verbose: bool = False) -> list:
+        """Get a list of units that are valid based on start date.
+
+        Args:
+            units (list): List of all units as basis for getting valid ones.
+            year (int, optional): Year to compare to start time.
+            verbose (bool, optional): Whether to log verbosely (i.e. skipped units) or not.
+                Defaults to False.
+
+        Returns:
+            list: List of valid units.
+        """
+        valid_units = [u for u in units if self.lookup_u[u]["start"].year <= year]
+        diff = set(units) - set(valid_units)
+
+        if len(diff) > 0:
+            logger.warning(
+                f"No energy data for {len(diff)} out of {len(units)} units "
+                f"(not yet generating in {year})."
+            )
+            if verbose:
+                logger.warning(f"Skipping:\n{diff}")
+        else:
+            if verbose:
+                logger.info(f"All {len(units)} units are producing energy data.")
+
+        return valid_units
 
 
 def _get_start_date(

--- a/rbc/energy/aemo/downloader.py
+++ b/rbc/energy/aemo/downloader.py
@@ -235,7 +235,7 @@ class AemoDownloader(EnergyDownloader):
         date_start: datetime,
         date_end: datetime,
         temporal_res: str,
-    ) -> list[dict] | list[None]:
+    ) -> list[dict]:
         """Fetch data for one specific unit at a time, within the realm of the given task.
 
         The OpenElectricity API offers the download of DataMetric.ENERGY and DataMetric.POWER
@@ -355,7 +355,7 @@ class AemoDownloader(EnergyDownloader):
 
         # create merged dataframe and lookup dictionary
         try:
-            df_f.pop("units")
+            df_f = df_f.drop(columns=["units"])
             df_f["description"] = df_f["description"].str.replace(
                 r"<[^>]*>", "", regex=True
             )

--- a/rbc/energy/aemo/downloader.py
+++ b/rbc/energy/aemo/downloader.py
@@ -131,6 +131,8 @@ class AemoDownloader(EnergyDownloader):
                 f"No energy data for {len(diff_units)} out of {len(unique_units)} units "
                 f"(not yet producing in {latest_year}). Skipping:\n\n{diff_units}"
             )
+        else:
+            logger.info(f"All units {len(unique_units)} are producing energy data.")
 
     def download_data(self) -> None:
         """Parse data for all given years from AEMO (OpenElectricity) and save to CSV."""
@@ -236,7 +238,7 @@ class AemoDownloader(EnergyDownloader):
                 units_wo_data = sum(1 for r in results if not r)
                 logger.info(
                     f"Task {task.identifier}: {units_w_data} units with data, "
-                    f" {units_wo_data} units without data."
+                    f"{units_wo_data} units without data."
                 )
 
                 return [item for sublist in results for item in sublist]
@@ -443,7 +445,7 @@ class AemoDownloader(EnergyDownloader):
 def _get_start_date(
     d1: datetime | None, d2: datetime | None, network_id: str
 ) -> pd.Series:
-    """Set start date as d1, d2 or MIN_YEAR datetime object depending on which is not None.
+    """Define (buffered) start date using d1, d2 or MIN_YEAR depending on which is not None.
 
     In this case, d1 is the "data_first_seen" date and d2 is the "commencement_date". The
     assumption here is that the "data_first_seen" date is what we're actually looking for,
@@ -466,5 +468,5 @@ def _get_start_date(
         if isinstance(d2, datetime)
         else (datetime(MIN_YEAR, 1, 1, tzinfo=row_tz))
     )
-
-    return pd.Series({"start": start_date, "timezone": row_tz})
+    buffered_start_date = start_date.replace(month=1, day=1, hour=0, minute=0, second=0)
+    return pd.Series({"start": buffered_start_date, "timezone": row_tz})

--- a/rbc/energy/aemo/downloader.py
+++ b/rbc/energy/aemo/downloader.py
@@ -201,7 +201,7 @@ class AemoDownloader(EnergyDownloader):
                     task_end = end.replace(tzinfo=self.units_lookup[unit]["timezone"])
 
                     if task_end < unit_start:
-                        logger.info(
+                        logger.debug(
                             f"No energy data for unit {unit} (it's before {unit_start}). "
                             f"Skipping..."
                         )  # don't raise error here or loop will be interrupted
@@ -296,6 +296,7 @@ class AemoDownloader(EnergyDownloader):
                     date_end=date_end,
                 )
                 # map the nested response back to a flat list of dicts
+                logger.debug(f"Energy data found for unit {unit_code}")
                 return [
                     {"timestamp": e.root[0], "unit_code": unit_code, "value": e.root[1]}
                     for s in response.data
@@ -308,7 +309,7 @@ class AemoDownloader(EnergyDownloader):
                 detail = e.detail
 
                 if status_code == 404:  # when data is permanently missing (404), skip!
-                    logger.info(
+                    logger.debug(
                         f"No energy data for unit {unit_code}. Skipping..."
                     )  # don't raise error here or loop will be interrupted
                     return []

--- a/rbc/energy/aemo/downloader.py
+++ b/rbc/energy/aemo/downloader.py
@@ -94,7 +94,7 @@ class AemoDownloader(EnergyDownloader):
         )
         self.temporal_resolutions = temporal_resolutions
 
-        invalid_t_res = set(temporal_resolutions) - set({"1h", "5min"})
+        invalid_t_res = set(temporal_resolutions) - {"1h", "5min"}
         if invalid_t_res:
             raise InvalidError(
                 f"Invalid temporal resolution(s): {sorted(invalid_t_res)}"
@@ -144,7 +144,7 @@ class AemoDownloader(EnergyDownloader):
         AEMO follows an End-of-Interval timestamp convention, meaning values for an hour
         are saved on the dot of the next hour (i.e. "01:00" = data from 0-1 AM, not 1-2 AM).
         This means for each day, data starts with hour 1 of Day 1 and hour 0 of Day 2
-        (i.e. start = "2018-01-01T01:00", end = "2018-01-02T00:00"). Analagous for 5 min data.
+        (i.e. start = "2018-01-01T01:00", end = "2018-01-02T00:00"). Analogous for 5 min data.
 
         Args:
             task (DownloadTask): The metadata of a downloading task, here: date (YYYY-MM-DD)
@@ -220,8 +220,8 @@ class AemoDownloader(EnergyDownloader):
             df = df[EXPECTED_COLS].sort_values(by=["timestamp"])
         except KeyError as e:
             raise DataStructureError(
-                f"AEMO (OpenElectricity) structure change detected! Relevant column missing "
-                f"from facilities and units data: {e}"
+                f"AEMO (OpenElectricity) structure change detected! Relevant column(s) "
+                f"missing from facilities and units data: {e}"
             )
 
         return df
@@ -385,15 +385,10 @@ class AemoDownloader(EnergyDownloader):
                 ["network_id", "start"]
             ].to_dict("index")
 
-        except KeyError as e:
+        except (KeyError, ValueError) as e:
             raise DataStructureError(
                 f"AEMO (OpenElectricity) structure change detected! Relevant column missing "
                 f"from facility and units data: {e}"
-            )
-        except NotImplementedError as e:
-            raise DataStructureError(
-                f"AEMO (OpenElectricity) structure change detected! Data content has been "
-                f"reformatted so that json normalisation does not work anymore: {e}"
             )
 
         return df_fu, lookup_u
@@ -443,8 +438,14 @@ def _get_start_date(
 
     Returns:
         datetime: unit's start date
+
+    Raises:
+        InvalidError: If provided network_id is not valid (not defined in VALID_NETWORKS).
     """
-    row_tz: tzinfo = VALID_NETWORKS[network_id]
+    try:
+        row_tz: tzinfo = VALID_NETWORKS[network_id]
+    except KeyError as e:
+        raise InvalidError(f"Invalid network ID provided: {e}")
 
     start_date = (
         d1

--- a/rbc/energy/aemo/downloader.py
+++ b/rbc/energy/aemo/downloader.py
@@ -27,7 +27,7 @@ from rbc.energy.utils import (
 
 logging.getLogger("openelectricity").setLevel(logging.CRITICAL)
 
-MIN_YEAR = 2006
+MIN_YEAR = 1998  # start in December
 VALID_NETWORKS = {
     "NEM": timezone(timedelta(hours=10)),
     "WEM": timezone(timedelta(hours=8)),

--- a/rbc/energy/aemo/downloader.py
+++ b/rbc/energy/aemo/downloader.py
@@ -17,6 +17,7 @@ from openelectricity.client import APIError
 from openelectricity.models.facilities import FacilityResponse
 
 from rbc.energy.utils import (
+    ASYNC_WORKERS,
     WORKERS,
     DataStructureError,
     DownloadTask,
@@ -33,7 +34,8 @@ VALID_NETWORKS = {
     "WEM": timezone(timedelta(hours=8)),
     "AU": timezone(timedelta(hours=10)),
 }
-# (s. https://docs.openelectricity.org.au/sdk/typescript/utilities#date-and-time-utilities)
+# For more information on Australian timezones, s.
+# https://docs.openelectricity.org.au/sdk/typescript/utilities#date-and-time-utilities
 EXPECTED_COLS = [
     "timestamp",
     "code",
@@ -157,17 +159,17 @@ class AemoDownloader(EnergyDownloader):
             DataStructureError: If the data structure changed and relevant columns are now
                 missing (this will cause the entire run to be killed).
         """
+        t_res = task.temporal_resolution
+        t_res = t_res if "min" not in t_res else t_res.replace("min", "m")
+
         start = task.dt.to_pydatetime()
         start = start.replace(second=1)  # to ensure end-of-interval timeframe
 
-        task_type = "month" if len(task.date.split("-")) == 2 else "day"
+        task_type = "month" if t_res == "1h" else "day"
         if task_type == "month":
             end = (start + pd.offsets.MonthBegin(1)).to_pydatetime()
         else:
             end = start + timedelta(days=1)
-
-        t_res = task.temporal_resolution
-        t_res = t_res if "min" not in t_res else t_res.replace("min", "m")
 
         # filter list of units further based on current task
         valid_u = self._get_valid_units(units=self.valid_u, year=task.year)
@@ -182,12 +184,14 @@ class AemoDownloader(EnergyDownloader):
                 list: List of data from all units for a given task (date, t_res)
             """
             async with AsyncOEClient(api_key=self.token) as a_client:
-                semaphore = asyncio.Semaphore(10)  # few workers to work with threading
-                tasks = []
+                semaphore = asyncio.Semaphore(
+                    ASYNC_WORKERS
+                )  # few to work with threading
+                coroutines = []
 
                 # get data for 1 unit at a time because results are otherwise aggregated
                 for unit in valid_u:
-                    tasks.append(
+                    coroutines.append(
                         self._fetch_unit_data_async(
                             a_client,
                             semaphore,
@@ -199,7 +203,7 @@ class AemoDownloader(EnergyDownloader):
                         )
                     )
 
-                results = await asyncio.gather(*tasks)
+                results = await asyncio.gather(*coroutines)
 
                 logger.info(
                     f"Task {task.identifier}: {sum(1 for r in results if r)} / {len(results)}"

--- a/rbc/energy/aemo/downloader.py
+++ b/rbc/energy/aemo/downloader.py
@@ -138,10 +138,9 @@ class AemoDownloader(EnergyDownloader):
         tasks = [
             DownloadTask(date=d, temporal_resolution=t_res)
             for t_res in self.temporal_resolutions
-            for d in self._get_date_list()
-            # for d in (
-            #     self._get_month_list() if t_res == "1h" else self._get_date_list()
-            # )
+            for d in (
+                self._get_month_list() if t_res == "1h" else self._get_date_list()
+            )
         ]
 
         logger.info(
@@ -169,9 +168,15 @@ class AemoDownloader(EnergyDownloader):
             DataStructureError: If the data structure changed and relevant columns are now
                 missing (this will cause the entire run to be killed).
         """
-        start = datetime.fromisoformat(task.date)
-        start = start.replace(second=1)
-        end = start + timedelta(days=1)
+        start = task.dt.to_pydatetime()
+        start = start.replace(second=1)  # to ensure end-of-interval timeframe
+
+        task_type = "month" if len(task.date.split("-")) == 2 else "day"
+        if task_type == "month":
+            end = (start + pd.offsets.MonthBegin(1)).to_pydatetime()
+        else:
+            end = start + timedelta(days=1)
+
         t_res = task.temporal_resolution
         t_res = t_res if "min" not in t_res else t_res.replace("min", "m")
 
@@ -200,7 +205,7 @@ class AemoDownloader(EnergyDownloader):
                     unit_start = self.units_lookup[unit]["start"]
                     task_end = end.replace(tzinfo=self.units_lookup[unit]["timezone"])
 
-                    if task_end < unit_start:
+                    if task_end.date() < unit_start.date():
                         logger.debug(
                             f"No energy data for unit {unit} (it's before {unit_start}). "
                             f"Skipping..."
@@ -226,6 +231,14 @@ class AemoDownloader(EnergyDownloader):
                             raise
 
                 results = await asyncio.gather(*tasks)
+
+                units_w_data = sum(1 for r in results if r)
+                units_wo_data = sum(1 for r in results if not r)
+                logger.info(
+                    f"Task {task.identifier}: {units_w_data} units with data, "
+                    f" {units_wo_data} units without data."
+                )
+
                 return [item for sublist in results for item in sublist]
 
         loop = asyncio.new_event_loop()

--- a/rbc/energy/taipower/downloader.py
+++ b/rbc/energy/taipower/downloader.py
@@ -6,11 +6,11 @@ Remote access of Taipower website to fetch current live data with.
 import sys
 from datetime import datetime
 from pathlib import Path
+from zoneinfo import ZoneInfo
 
 import pandas as pd
 import requests.exceptions
 from requests import Session
-from zoneinfo import ZoneInfo
 
 TIMEZONE = ZoneInfo("Asia/Taipei")
 URL = "http://www.taipower.com.tw/d006/loadGraph/loadGraph/data/genary_eng.json"

--- a/rbc/energy/utils.py
+++ b/rbc/energy/utils.py
@@ -21,6 +21,7 @@ import urllib3
 from loguru import logger
 
 WORKERS = 4
+ASYNC_WORKERS = 10
 MAX_RETRIES = 3
 RETRY_DELAY = 5
 MAX_RATE_LIMIT_RETRIES = 6

--- a/rbc/utils.py
+++ b/rbc/utils.py
@@ -36,6 +36,7 @@ def handle_exceptions(
 
 def setup_logging(
     output_dir: Path,
+    verbose: bool = False,
     retention: bool = False,
     compression: bool = False,
 ) -> None:
@@ -43,21 +44,32 @@ def setup_logging(
 
     Args:
         output_dir (Path): Directory where the script outputs will be saved.
+        verbose (bool): Whether to include DEBUG logging messages in file. Defaults to False.
         retention (bool): Whether to delete log files older than 30 days. Defaults to False.
         compression (bool): Whether to compress log files. Defaults to False.
     """
+    log_level = "DEBUG" if verbose else "INFO"
+
+    # define the file logging sink
     log_dir = Path(output_dir, "logs")
     log_dir.mkdir(parents=True, exist_ok=True)
     log_path = Path(log_dir, f"{datetime.now().strftime('%Y-%m-%d_%H%M%S')}.log")
 
-    # add file logging
-    logger.add(
-        log_path,
-        retention="30 days" if retention else None,  # delete files older than 30 days
-        compression="zip" if compression else None,  # compress logs to zip
-        level="INFO",
+    # configure logger to have both a console sink and file logging sink
+    logger.configure(
+        handlers=[
+            {"sink": sys.stderr, "level": log_level},
+            {
+                "sink": log_path,
+                "level": log_level,
+                "retention": "30 days" if retention else None,  # delete files >30 days
+                "compression": "zip" if compression else None,  # compress logs to zip
+            },
+        ]
     )
+
     # register the global exception hook
     sys.excepthook = handle_exceptions
 
-    logger.info(f"Log file initialized. Writing to: {log_path}")
+    logger.info(f"Logging initialized with level {log_level}.")
+    logger.info(f"Log file writing to: {log_path}")

--- a/scripts/energy/aemo_download.py
+++ b/scripts/energy/aemo_download.py
@@ -49,6 +49,12 @@ def parse_arguments() -> Namespace:
     )
     parser.set_defaults(resume=True)
     parser.add_argument(
+        "--verbose",
+        dest="verbose",
+        action="store_true",
+        help="Log with high verbosity (DEBUG) to include per-unit logging messages.",
+    )
+    parser.add_argument(
         "-o",
         "--cfg_options",
         action="append",
@@ -64,7 +70,7 @@ def main() -> None:
     overrides = parse_key_value_pairs(args.cfg_options) if args.cfg_options else None
 
     cfg = load_config(source=SOURCE, overrides=overrides)
-    setup_logging(output_dir=cfg.paths.dst_dir_raw)
+    setup_logging(output_dir=cfg.paths.dst_dir_raw, verbose=args.verbose)
     logger.info(f"Flags for the '{SOURCE}' download:\n{args}")
     logger.info(f"Config for the '{SOURCE}' download:\n{cfg}")
 

--- a/scripts/energy/aemo_download.py
+++ b/scripts/energy/aemo_download.py
@@ -29,7 +29,7 @@ def parse_arguments() -> Namespace:
         "--years",
         nargs="+",
         type=int,
-        default=list(range(MIN_YEAR, datetime.now().year + 1)),  # 5min: 2015-2023
+        default=list(range(MIN_YEAR, datetime.now().year + 1)),
         help=f"Years to download. Example: -y 2020 2021. "
         f"Default: {list(range(MIN_YEAR, datetime.now().year + 1))}",
     )

--- a/scripts/energy/aemo_download.py
+++ b/scripts/energy/aemo_download.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python
+"""AEMO (OpenElectricity) DATA DOWNLOAD SCRIPT.
+
+Download data from AEMO using OpenElectricity API for Australia.
+"""
+
+from argparse import ArgumentParser, Namespace
+from datetime import datetime
+
+from loguru import logger
+
+from rbc.config.loader import load_config, parse_key_value_pairs
+from rbc.energy.aemo import AemoDownloader
+from rbc.energy.aemo.downloader import MIN_YEAR
+from rbc.utils import setup_logging
+
+SOURCE = "aemo"
+
+
+def parse_arguments() -> Namespace:
+    """Parse command line arguments.
+
+    Returns:
+        argparse.Namespace: Namespace parsed command line arguments.
+    """
+    parser = ArgumentParser(prog="AEMO data download")
+    parser.add_argument(
+        "-y",
+        "--years",
+        nargs="+",
+        type=int,
+        default=list(range(MIN_YEAR, datetime.now().year + 1)),  # 5min: 2015-2023
+        help=f"Years to download. Example: -y 2020 2021. "
+        f"Default: {list(range(MIN_YEAR, datetime.now().year + 1))}",
+    )
+    parser.add_argument(
+        "-tr",
+        "--temporal_resolutions",
+        nargs="+",
+        type=str,
+        default=["1h", "5min"],  # these are the available resolutions
+        help=f"Temporal resolutions to download. Example: --temporal_resolutions 1h 5min. Default: {['1h', '5min']}",
+    )
+    parser.add_argument(
+        "--no-resume",
+        dest="resume",
+        action="store_false",
+        help="Do not resume download from a previous checkpoint.",
+    )
+    parser.set_defaults(resume=True)
+    parser.add_argument(
+        "-o",
+        "--cfg_options",
+        action="append",
+        help="Override YAML config values (supports nested keys). "
+        "Example: -o paths.dst_dir_raw=/your/path/ -o access.api_key=YOUR-SECRET-KEY",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    """Coordinating AEMO data download."""
+    args = parse_arguments()
+    overrides = parse_key_value_pairs(args.cfg_options) if args.cfg_options else None
+
+    cfg = load_config(source=SOURCE, overrides=overrides)
+    setup_logging(output_dir=cfg.paths.dst_dir_raw)
+    logger.info(f"Flags for the '{SOURCE}' download:\n{args}")
+    logger.info(f"Config for the '{SOURCE}' download:\n{cfg}")
+
+    downloader = AemoDownloader(
+        token=cfg.access.api_key,
+        output_path=cfg.paths.dst_dir_raw,
+        years=args.years,
+        temporal_resolutions=args.temporal_resolutions,
+        resume=args.resume,
+    )
+    downloader.download_data()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/config/conftest.py
+++ b/tests/config/conftest.py
@@ -17,6 +17,10 @@ def source_configs(tmp_path: Path) -> dict:
     """
     return {
         "adme": {"paths": {"dst_dir_raw": str(Path(tmp_path, "adme"))}},
+        "aemo": {
+            "paths": {"dst_dir_raw": str(Path(tmp_path, "aemo"))},
+            "access": {"api_key": "token"},
+        },
         "aeso": {
             "paths": {"dst_dir_raw": str(Path(tmp_path, "aeso"))},
             "access": {"api_key": "token"},

--- a/tests/energy/adme/test_downloader.py
+++ b/tests/energy/adme/test_downloader.py
@@ -359,15 +359,13 @@ def test_load_yearly_excel(downloader: AdmeDownloader) -> None:
         downloader (AdmeDownloader): Instance of AdmeDownloader class.
     """
     # mock df with single column headers and similar setup at what GPF sheet returns
-    mock_xlsx = MagicMock(spec=pd.ExcelFile, sheet_names=list(EXPECTED_OLD_SHEETS))
+    mock_xls = MagicMock(spec=pd.ExcelFile, sheet_names=list(EXPECTED_OLD_SHEETS))
     mock_df = pd.DataFrame(
         {"Fecha": ["01-01-2010 01:00"], "Hydro A": [100.0], "Eólica": [10.0]}
     )
 
     with (
-        patch(
-            "rbc.energy.adme.downloader.load_excel_from_file", return_value=mock_xlsx
-        ),
+        patch("rbc.energy.adme.downloader.load_excel_from_file", return_value=mock_xls),
         patch("rbc.energy.adme.downloader.pd.read_excel", return_value=mock_df),
     ):
         df = downloader._load_yearly_excel("https://fake.url/gpf_2010.xlsx")
@@ -383,11 +381,9 @@ def test_load_yearly_excel_missing_sheets(downloader: AdmeDownloader) -> None:
     Args:
         downloader (AdmeDownloader): Instance of AdmeDownloader class.
     """
-    mock_xlsx = MagicMock(spec=pd.ExcelFile, sheet_names=["GPF"])
+    mock_xl = MagicMock(spec=pd.ExcelFile, sheet_names=["GPF"])
 
-    with patch(
-        "rbc.energy.adme.downloader.load_excel_from_file", return_value=mock_xlsx
-    ):
+    with patch("rbc.energy.adme.downloader.load_excel_from_file", return_value=mock_xl):
         with pytest.raises(DataStructureError, match="Not all required sheets"):
             downloader._load_yearly_excel("https://fake.url/gpf_2010.xlsx")
 
@@ -398,15 +394,11 @@ def test_load_yearly_excel_bad_content(downloader: AdmeDownloader) -> None:
     Args:
         downloader (AdmeDownloader): Instance of AdmeDownloader class.
     """
-    mock_xlsx = MagicMock(spec=pd.ExcelFile, sheet_names=list(EXPECTED_OLD_SHEETS))
+    mock_xls = MagicMock(spec=pd.ExcelFile, sheet_names=list(EXPECTED_OLD_SHEETS))
 
     with (
-        patch(
-            "rbc.energy.adme.downloader.load_excel_from_file", return_value=mock_xlsx
-        ),
-        patch(
-            "rbc.energy.adme.downloader.pd.read_excel", side_effect=ValueError("bad")
-        ),
+        patch("rbc.energy.adme.downloader.load_excel_from_file", return_value=mock_xls),
+        patch("rbc.energy.adme.downloader.pd.read_excel", side_effect=ValueError),
     ):
         with pytest.raises(DataStructureError, match="does not contain loadable data"):
             downloader._load_yearly_excel("https://fake.url/gpf_2010.xlsx")
@@ -418,13 +410,11 @@ def test_load_yearly_excel_not_datetimelike(downloader: AdmeDownloader) -> None:
     Args:
         downloader (AdmeDownloader): Instance of AdmeDownloader class.
     """
-    mock_xlsx = MagicMock(spec=pd.ExcelFile, sheet_names=list(EXPECTED_OLD_SHEETS))
+    mock_xls = MagicMock(spec=pd.ExcelFile, sheet_names=list(EXPECTED_OLD_SHEETS))
     mock_df = pd.DataFrame({"Fecha": ["not-a-date"], "Hydro Plant A": [100.0]})
 
     with (
-        patch(
-            "rbc.energy.adme.downloader.load_excel_from_file", return_value=mock_xlsx
-        ),
+        patch("rbc.energy.adme.downloader.load_excel_from_file", return_value=mock_xls),
         patch("rbc.energy.adme.downloader.pd.read_excel", return_value=mock_df),
     ):
         with pytest.raises(DataStructureError, match="no longer datetimelike"):

--- a/tests/energy/adme/test_downloader.py
+++ b/tests/energy/adme/test_downloader.py
@@ -364,9 +364,12 @@ def test_load_yearly_excel(downloader: AdmeDownloader) -> None:
         {"Fecha": ["01-01-2010 01:00"], "Hydro A": [100.0], "Eólica": [10.0]}
     )
 
-    with patch(
-        "rbc.energy.adme.downloader.load_excel_from_file", return_value=mock_xlsx
-    ), patch("rbc.energy.adme.downloader.pd.read_excel", return_value=mock_df):
+    with (
+        patch(
+            "rbc.energy.adme.downloader.load_excel_from_file", return_value=mock_xlsx
+        ),
+        patch("rbc.energy.adme.downloader.pd.read_excel", return_value=mock_df),
+    ):
         df = downloader._load_yearly_excel("https://fake.url/gpf_2010.xlsx")
 
     assert isinstance(df.columns, pd.MultiIndex)
@@ -397,9 +400,14 @@ def test_load_yearly_excel_bad_content(downloader: AdmeDownloader) -> None:
     """
     mock_xlsx = MagicMock(spec=pd.ExcelFile, sheet_names=list(EXPECTED_OLD_SHEETS))
 
-    with patch(
-        "rbc.energy.adme.downloader.load_excel_from_file", return_value=mock_xlsx
-    ), patch("rbc.energy.adme.downloader.pd.read_excel", side_effect=ValueError("bad")):
+    with (
+        patch(
+            "rbc.energy.adme.downloader.load_excel_from_file", return_value=mock_xlsx
+        ),
+        patch(
+            "rbc.energy.adme.downloader.pd.read_excel", side_effect=ValueError("bad")
+        ),
+    ):
         with pytest.raises(DataStructureError, match="does not contain loadable data"):
             downloader._load_yearly_excel("https://fake.url/gpf_2010.xlsx")
 
@@ -413,8 +421,11 @@ def test_load_yearly_excel_not_datetimelike(downloader: AdmeDownloader) -> None:
     mock_xlsx = MagicMock(spec=pd.ExcelFile, sheet_names=list(EXPECTED_OLD_SHEETS))
     mock_df = pd.DataFrame({"Fecha": ["not-a-date"], "Hydro Plant A": [100.0]})
 
-    with patch(
-        "rbc.energy.adme.downloader.load_excel_from_file", return_value=mock_xlsx
-    ), patch("rbc.energy.adme.downloader.pd.read_excel", return_value=mock_df):
+    with (
+        patch(
+            "rbc.energy.adme.downloader.load_excel_from_file", return_value=mock_xlsx
+        ),
+        patch("rbc.energy.adme.downloader.pd.read_excel", return_value=mock_df),
+    ):
         with pytest.raises(DataStructureError, match="no longer datetimelike"):
             downloader._load_yearly_excel("https://fake.url/gpf_2010.xlsx")

--- a/tests/energy/aemo/test_downloader.py
+++ b/tests/energy/aemo/test_downloader.py
@@ -358,9 +358,10 @@ def test_fetch_task_data_flattens_results(
             return mock_df[fetch_out_cols].iloc[[1, 3]].to_dict("records")
         return []
 
-    with patch.object(downloader, "_fetch_unit_data_async") as mock_fetch, patch(
-        "rbc.energy.aemo.downloader.AsyncOEClient"
-    ) as mock_async_client:
+    with (
+        patch.object(downloader, "_fetch_unit_data_async") as mock_fetch,
+        patch("rbc.energy.aemo.downloader.AsyncOEClient") as mock_async_client,
+    ):
         mock_fetch.side_effect = fake_fetch
         mock_async_client.return_value.__aenter__ = AsyncMock(return_value=MagicMock())
         mock_async_client.return_value.__aexit__ = AsyncMock(return_value=None)

--- a/tests/energy/aemo/test_downloader.py
+++ b/tests/energy/aemo/test_downloader.py
@@ -620,7 +620,6 @@ def test_get_start_date(
 
     out = _get_start_date(d1=d1, d2=d2, network_id=network_id)
     assert out == expected_out
-    assert out.year == expected_year
     assert out.tzinfo is tz
 
 

--- a/tests/energy/aemo/test_downloader.py
+++ b/tests/energy/aemo/test_downloader.py
@@ -1,0 +1,629 @@
+# tests/energy/aemo/test_downloader.py
+"""Tests for AEMO energy data downloader."""
+
+import asyncio
+import pickle
+from datetime import datetime
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pandas as pd
+import pytest
+from openelectricity.client import APIError
+from requests import exceptions
+
+from rbc.energy.aemo import AemoDownloader
+from rbc.energy.aemo.downloader import (
+    EXPECTED_COLS,
+    MIN_YEAR,
+    VALID_NETWORKS,
+    _get_start_date,
+)
+from rbc.energy.utils import (
+    DataStructureError,
+    DownloadTask,
+    InvalidError,
+    MissingDataError,
+)
+
+
+# ----------------------------------
+# Fixtures
+# ----------------------------------
+@pytest.fixture
+def init_args(tmp_path: Path) -> dict:
+    """Creates a basic setup with a temporary directory.
+
+    Args:
+        tmp_path (Path): Path to the temporary directory.
+
+    Returns:
+        dict: initialization arguments.
+    """
+    return {
+        "token": "fake_token",
+        "output_path": tmp_path,
+        "years": [2020],
+        "temporal_resolutions": ["1h", "5min"],
+        "resume": False,
+    }
+
+
+@pytest.fixture(params=["1h", "5min"])
+def task(request: pytest.FixtureRequest, init_args: dict) -> DownloadTask:
+    """Gets a task as 'date=YYYY-MM-DD'/'YYYY-MM' depending on param from the init arguments.
+
+    Args:
+        request (FixtureRequest): Special pytest fixture used to access 'params' values.
+        init_args (dict): Arguments used to initialize an AemoDownloader instance.
+
+    Returns:
+        DownloadTask: The metadata of a downloading task, here: date (YYYY-MM-DD / YYYY-MM)
+    """
+    t_res = request.param
+    year = init_args["years"][0]
+    date = f"{year}-01" if t_res == "1h" else f"{year}-01-01"
+    return DownloadTask(date=date, temporal_resolution=t_res)
+
+
+def get_mock_df(spec_task: DownloadTask, rows: int = 1) -> pd.DataFrame:
+    """Gets a mock dataframe for a specific task.
+
+    Args:
+        spec_task (DownloadTask): Metadata of a download task, here: date (YYYY-MM/-DD), t_res
+        rows (int, optional): Number of rows to mock. Defaults to 1.
+
+    Returns:
+        pd.DataFrame: Mock dataframe.
+    """
+    tz = VALID_NETWORKS["NEM"]
+    year = spec_task.year
+    month = spec_task.month
+
+    rows_list = []
+    hour = 0
+    for r in range(rows):
+        if r % 2 == 0:
+            name = "A"
+            hour += 1
+        else:
+            name = "B"
+
+        row: dict[str, object] = {c: name for c in EXPECTED_COLS}
+        row.update(
+            {
+                "timestamp": datetime(year, month, 1, hour, tzinfo=tz),
+                "network_id": list(VALID_NETWORKS.keys())[0],
+                "unit_data_first_seen": datetime(year - 2, 1, 1, tzinfo=tz),
+                "unit_data_last_seen": datetime(year + 1, 1, 1, tzinfo=tz),
+                "unit_commencement_date": datetime(year - 1, 1, 1, tzinfo=tz),
+                "value": 16.0,
+            }
+        )
+        rows_list.append(row)
+
+    return pd.DataFrame(rows_list)
+
+
+def get_mock_fu(spec_task: DownloadTask, rows: int = 1) -> tuple[pd.DataFrame, dict]:
+    """Get facilities/units df and lookup table (one row per unique unit).
+
+    Args:
+        spec_task (DownloadTask): Metadata of a download task, here: date (YYYY-MM/-DD), t_res
+        rows (int, optional): Number of rows to mock. Defaults to 1.
+
+    Returns:
+        mock_df_fu (pd.Dataframe): Dataframe of facilities and units.
+        mock_lookup_u (dict): Dict of all units and their start date.
+    """
+    mock_df_fu = get_mock_df(spec_task=spec_task, rows=rows)
+    mock_df_fu = mock_df_fu.drop(columns=["timestamp", "value"])
+    mock_df_fu = mock_df_fu.drop_duplicates(
+        subset=["unit_code"]
+    )  # 1 row per unique unit
+    mock_lookup_u = (
+        mock_df_fu.set_index("unit_code")[["network_id", "unit_data_first_seen"]]
+        .rename(columns={"unit_data_first_seen": "start"})
+        .to_dict(orient="index")
+    )
+    return mock_df_fu, mock_lookup_u
+
+
+@pytest.fixture
+def downloader(init_args: dict, task: DownloadTask) -> AemoDownloader:
+    """Provides an AemoDownloader with mocked API and preloaded facility/unit data.
+
+    Args:
+        init_args (dict): Arguments used to initialize an AemoDownloader instance.
+        task (DownloadTask): Metadata of the download tasks, here: date (YYYY-MM/-DD), t_res
+
+    Returns:
+        AemoDownloader: AemoDownloader instance.
+    """
+    mock_fu = get_mock_fu(spec_task=task, rows=1)
+
+    with patch("rbc.energy.aemo.downloader.OEClient") as mock_client:
+        mock_client.return_value.get_current_user.return_value = None
+
+        with patch.object(
+            AemoDownloader, "_get_facilities_and_units", return_value=mock_fu
+        ):
+            return AemoDownloader(**init_args)
+
+
+# ----------------------------------
+# Tests - Initialization
+# ----------------------------------
+def test_downloader_initialization(downloader: AemoDownloader, init_args: dict) -> None:
+    """Happy path for class initialization.
+
+    Check that the AemoDownloader sets up paths and checkpoint correctly.
+
+    Args:
+        downloader (AemoDownloader): Instance of AemoDownloader class.
+        init_args (dict): Arguments used to initialize an AemoDownloader instance.
+    """
+    assert downloader.years == init_args["years"]
+    assert downloader.temporal_resolutions == init_args["temporal_resolutions"]
+    assert downloader.output_path == init_args["output_path"]
+    assert downloader.checkpoint_path == Path(init_args["output_path"], "status.pickle")
+    assert downloader.checkpoint == {}
+    assert downloader.valid_u  # assert not empty
+    assert downloader.lookup_u
+    assert isinstance(downloader.df_fu, pd.DataFrame)
+
+
+def test_downloader_initialization_invalid_tres(init_args: dict) -> None:
+    """Failure path for class initialization with invalid temporal resolution.
+
+    Args:
+        init_args (dict): Arguments used to initialize an AemoDownloader instance.
+    """
+    args = init_args.copy()
+    args["temporal_resolutions"] = ["invalid"]
+
+    with pytest.raises(InvalidError, match="Invalid temporal resolution"):
+        AemoDownloader(**args)
+
+
+def test_downloader_initialization_invalid_access(init_args: dict) -> None:
+    """Failure path for class initialization with invalid request.
+
+    Args:
+        init_args (dict): Arguments used to initialize an AemoDownloader instance.
+    """
+    error = APIError(status_code=401, detail="Unauthorized")
+
+    with patch("rbc.energy.aemo.downloader.OEClient") as mock_client:
+        mock_client.return_value.get_current_user.side_effect = error
+        with pytest.raises(InvalidError, match="connection failed"):
+            AemoDownloader(**init_args)
+
+
+def test_download_data_resume(init_args: dict, task: DownloadTask) -> None:
+    """Happy path for "download_data" method when resuming from checkpoint.
+
+    If all daily / monthly tasks are already marked as done in the checkpoint, the
+    downloader should not attempt any downloads.
+
+    Args:
+        init_args (dict): Arguments used to initialize an AemoDownloader instance.
+        task (DownloadTask): Metadata of the download tasks, here: date (YYYY-MM/-DD), t_res
+    """
+    args = init_args.copy()
+
+    # save a fake checkpoint file
+    checkpoint = {
+        DownloadTask(date=d, temporal_resolution=t_res).identifier: 1
+        for t_res in args["temporal_resolutions"]
+        for y in args["years"]
+        for d in (
+            pd.date_range(start=f"{y}-01", end=f"{y}-12", freq="MS").strftime("%Y-%m")
+            if t_res == "1h"
+            else pd.date_range(start=f"{y}-01-01", end=f"{y}-12-31").strftime(
+                "%Y-%m-%d"
+            )
+        )
+    }
+    checkpoint_path = Path(args["output_path"], "status.pickle")
+    checkpoint_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(checkpoint_path, "wb") as f:
+        pickle.dump(checkpoint, f)
+
+    args["resume"] = True
+    mock_fu = get_mock_fu(task)
+
+    with patch("rbc.energy.aemo.downloader.OEClient") as mock_client:
+        with patch.object(
+            AemoDownloader, "_get_facilities_and_units", return_value=mock_fu
+        ):
+            mock_client.return_value.get_current_user.return_value = None
+            downloader = AemoDownloader(**args)
+
+            with patch.object(downloader, "_download_task_data") as mock_dump:
+                mock_dump.return_value = 1
+                downloader.download_data()
+
+                assert mock_dump.call_count == 0
+                assert downloader.checkpoint == checkpoint
+
+
+# ----------------------------------
+# Tests - Data crawling logic
+# ----------------------------------
+def test_download_task_data(downloader: AemoDownloader, task: DownloadTask) -> None:
+    """Happy path for "_download_task_data" method.
+
+    Args:
+        downloader (AemoDownloader): Instance of AemoDownloader class.
+        task (DownloadTask): Metadata of the download tasks, here: date (YYYY-MM/-DD), t_res
+    """
+    mock_df = pd.DataFrame({"value": [16.2]})
+
+    with patch.object(downloader, "_get_task_data", return_value=mock_df):
+        status = downloader._download_task_data(task)
+
+        assert status == 1
+        expected_file = downloader._build_task_path(task)
+        assert expected_file.is_file(), f"The CSV {expected_file} was not created!"
+
+        saved_df = pd.read_csv(expected_file)
+        assert saved_df.iloc[0]["value"] == 16.2
+
+
+def test_get_task_data(downloader: AemoDownloader, task: DownloadTask) -> None:
+    """Happy path for "_get_task_data" method.
+
+    Args:
+        downloader (AemoDownloader): Instance of AemoDownloader class.
+        task (DownloadTask): Metadata of the download tasks, here: date (YYYY-MM/-DD), t_res
+    """
+    mock_df = get_mock_df(task)
+    mock_df = mock_df[["timestamp", "unit_code", "value"]]
+
+    with patch("rbc.energy.aemo.downloader.asyncio.run") as mock_run:
+        mock_run.return_value = mock_df.to_dict(orient="records")
+        df = downloader._get_task_data(task)
+        mock_run.call_args[0][0].close()  # close coroutine to prevent RuntimeWarning
+
+    assert not df.empty
+    assert len(df) == 1
+    assert df.iloc[0]["value"] == 16.0
+    assert mock_run.call_count == 1
+
+
+def test_get_task_data_no_generation_data(
+    downloader: AemoDownloader, task: DownloadTask
+) -> None:
+    """Failure path for "_get_task_data" method when no generation data is available.
+
+    Args:
+        downloader (AemoDownloader): Instance of AemoDownloader class.
+        task (DownloadTask): Metadata of the download tasks, here: date (YYYY-MM/-DD), t_res
+    """
+    mock_df_list = pd.DataFrame(columns=EXPECTED_COLS).to_dict(orient="records")
+
+    with patch("rbc.energy.aemo.downloader.asyncio.run") as mock_run:
+        mock_run.return_value = mock_df_list
+        with pytest.raises(MissingDataError, match="No generation data"):
+            downloader._get_task_data(task)
+        mock_run.call_args[0][0].close()
+
+
+def test_get_task_data_structure_changed(
+    downloader: AemoDownloader, task: DownloadTask
+) -> None:
+    """Failure path for "_get_task_data" method when dataframe doesn't have all columns.
+
+    Args:
+        downloader (AemoDownloader): Instance of AemoDownloader class.
+        task (DownloadTask): Metadata of the download tasks, here: date (YYYY-MM/-DD), t_res
+    """
+    mock_df = get_mock_df(task).drop(columns="unit_code")
+
+    with patch("rbc.energy.aemo.downloader.asyncio.run") as mock_run:
+        mock_run.return_value = mock_df.to_dict(orient="records")
+        with pytest.raises(DataStructureError, match="Relevant column"):
+            downloader._get_task_data(task)
+        mock_run.call_args[0][0].close()
+
+
+# ----------------------------------
+# Tests - Data crawling async methods
+# ----------------------------------
+def test_fetch_task_data_flattens_results(
+    downloader: AemoDownloader, task: DownloadTask
+) -> None:
+    """Happy path for nested "fetch_task_data" method to see if results are flattened.
+
+    Args:
+        downloader (AemoDownloader): Instance of AemoDownloader class.
+        task (DownloadTask): Metadata of the download tasks, here: date (YYYY-MM/-DD), t_res
+    """
+    mock_df = get_mock_df(task, 4)
+    u1 = mock_df["unit_code"].iloc[0]
+    u2 = mock_df["unit_code"].iloc[1]
+    mock_df_fu, mock_lookup_u = get_mock_fu(task, 4)
+    downloader.valid_u = [u1, u2]
+    downloader.lookup_u = mock_lookup_u
+    downloader.df_fu = mock_df_fu
+    fetch_out_cols = ["timestamp", "unit_code", "value"]
+
+    async def fake_fetch(*args, **kwargs):
+        """Fake _fetch_unit_data_async method that returns a list per unit."""
+        unit_code = kwargs.get("unit_code")
+        if unit_code == u1:
+            return mock_df[fetch_out_cols].iloc[[0, 2]].to_dict("records")
+        elif unit_code == u2:
+            return mock_df[fetch_out_cols].iloc[[1, 3]].to_dict("records")
+        return []
+
+    with patch.object(downloader, "_fetch_unit_data_async") as mock_fetch, patch(
+        "rbc.energy.aemo.downloader.AsyncOEClient"
+    ) as mock_async_client:
+        mock_fetch.side_effect = fake_fetch
+        mock_async_client.return_value.__aenter__ = AsyncMock(return_value=MagicMock())
+        mock_async_client.return_value.__aexit__ = AsyncMock(return_value=None)
+        df = downloader._get_task_data(task)
+
+    assert len(df) == 4  # 2 units x 2 rows each, flattened
+    assert set(df["unit_code"]) == {u1, u2}  # two unique units
+    assert len(set(df["timestamp"])) == 2  # two unique timestamps
+    assert mock_fetch.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_fetch_unit_data_async() -> None:
+    """Happy path for "_fetch_unit_data_async" method."""
+    ts_start = datetime(2020, 1, 1, 1, 0, 1)
+    ts_end = ts_start.replace(hour=ts_start.hour + 1)
+
+    mock_data_points = [
+        MagicMock(root=(ts_start, 10.0)),
+        MagicMock(root=(ts_end, 20.0)),
+    ]
+    mock_result = MagicMock(data=mock_data_points)
+    mock_series = MagicMock(results=[mock_result])
+    mock_response = MagicMock(data=[mock_series])
+
+    mock_client = AsyncMock()
+    mock_client.get_facility_data = AsyncMock(return_value=mock_response)
+
+    result = await AemoDownloader._fetch_unit_data_async(
+        async_client=mock_client,
+        semaphore=asyncio.Semaphore(10),
+        network_code="NEM",
+        unit_code="A",
+        date_start=ts_start,
+        date_end=ts_end,
+        temporal_res="1h",
+    )
+    assert len(result) == 2
+    assert result[0] == {"timestamp": ts_start, "unit_code": "A", "value": 10.0}
+
+
+@pytest.mark.asyncio
+async def test_fetch_unit_data_async_no_data() -> None:
+    """Happy path for "_fetch_unit_data_async" when API returns 404 (no data)."""
+    mock_client = MagicMock()
+    mock_client.get_facility_data = MagicMock(
+        side_effect=APIError(status_code=404, detail="Not Found")
+    )
+    semaphore = asyncio.Semaphore(10)
+
+    result = await AemoDownloader._fetch_unit_data_async(
+        async_client=mock_client,
+        semaphore=semaphore,
+        network_code="NEM",
+        unit_code="UNIT1",
+        date_start=datetime(2020, 1, 1),
+        date_end=datetime(2020, 2, 1),
+        temporal_res="1h",
+    )
+    assert result == []
+
+
+@pytest.mark.asyncio
+async def test_fetch_unit_data_async_server_error() -> None:
+    """Failure path for "_fetch_unit_data_async" when API returns a server error."""
+    mock_client = MagicMock()
+    mock_client.get_facility_data = MagicMock(
+        side_effect=APIError(status_code=500, detail="Internal Server Error")
+    )
+    semaphore = asyncio.Semaphore(10)
+
+    with pytest.raises(exceptions.HTTPError, match="Error 500"):
+        await AemoDownloader._fetch_unit_data_async(
+            async_client=mock_client,
+            semaphore=semaphore,
+            network_code="NEM",
+            unit_code="UNIT1",
+            date_start=datetime(2020, 1, 1),
+            date_end=datetime(2020, 2, 1),
+            temporal_res="1h",
+        )
+
+
+# ----------------------------------
+# Tests - Data crawling helper methods
+# ----------------------------------
+def test_get_facilities_and_units(downloader: AemoDownloader) -> None:
+    """Happy path for "_get_facilities_and_units", ensuring correct df and lookup.
+
+    Args:
+        downloader (AemoDownloader): Instance of AemoDownloader class.
+    """
+    tz = VALID_NETWORKS["NEM"]
+    mock_facility = MagicMock()
+    mock_facility.model_dump.return_value = {
+        "code": "FAC1",
+        "name": "Facility 1",
+        "network_id": "NEM",
+        "network_region": "NSW1",
+        "description": "<b>A facility</b>",
+        "npi_id": None,
+        "location": {"lat": 0.0, "lng": 0.0},
+        "created_at": None,
+        "updated_at": None,
+        "units": [
+            {
+                "code": "UNIT1",
+                "fueltech_id": "solar",
+                "status_id": "operating",
+                "dispatch_type": "GENERATOR",
+                "capacity_registered": 100.0,
+                "capacity_maximum": 110.0,
+                "capacity_storage": None,
+                "data_first_seen": datetime(2018, 6, 15, tzinfo=tz),
+                "data_last_seen": datetime(2025, 1, 1, tzinfo=tz),
+                "commencement_date": datetime(2018, 1, 1, tzinfo=tz),
+            }
+        ],
+    }
+    mock_facilities = MagicMock(data=[mock_facility])
+
+    with patch.object(
+        downloader.client, "get_facilities", return_value=mock_facilities
+    ):
+        df_fu, lookup_u = downloader._get_facilities_and_units()
+
+    assert not df_fu.empty
+    assert "unit_code" in df_fu.columns
+    assert "<b>" not in df_fu.iloc[0]["description"]
+
+    assert "UNIT1" in lookup_u
+    assert lookup_u["UNIT1"]["network_id"] == "NEM"
+
+
+def test_get_facilities_and_units_no_data(downloader: AemoDownloader) -> None:
+    """Failure path for "_get_facilities_and_units" when no data is returned.
+
+    Args:
+        downloader (AemoDownloader): Instance of AemoDownloader class.
+    """
+    facilities = MagicMock(data=[])
+
+    with patch.object(downloader.client, "get_facilities", return_value=facilities):
+        with pytest.raises(DataStructureError, match="No facilities"):
+            downloader._get_facilities_and_units()
+
+
+def test_get_facilities_and_units_bad_structure(downloader: AemoDownloader) -> None:
+    """Failure path for "_get_facilities_and_units" when data can't be transformed.
+
+    Args:
+        downloader (AemoDownloader): Instance of AemoDownloader class.
+    """
+    mock_facility = MagicMock()
+    mock_facility.model_dump.side_effect = AttributeError("no model_dump")
+    mock_response = MagicMock(data=[mock_facility])
+
+    with patch.object(downloader.client, "get_facilities", return_value=mock_response):
+        with pytest.raises(DataStructureError, match="Facility data"):
+            downloader._get_facilities_and_units()
+
+
+def test_get_facilities_and_units_missing_column(downloader: AemoDownloader) -> None:
+    """Failure path when facility data is missing required columns.
+
+    Args:
+        downloader (AemoDownloader): Instance of AemoDownloader class.
+    """
+    mock_facility = MagicMock()
+    mock_facility.model_dump.return_value = {"code": "A", "name": "Facility A"}
+    mock_response = MagicMock(data=[mock_facility])
+
+    with patch.object(downloader.client, "get_facilities", return_value=mock_response):
+        with pytest.raises(DataStructureError, match="Relevant column"):
+            downloader._get_facilities_and_units()
+
+
+def test_get_valid_units(downloader: AemoDownloader) -> None:
+    """Happy path for "_get_valid_units", ensuring correct filtering by year and logging.
+
+    Args:
+        downloader (AemoDownloader): Instance of AemoDownloader class.
+    """
+    unit_code = list(downloader.lookup_u.keys())[0]
+    start_year = downloader.lookup_u[unit_code]["start"].year
+
+    with patch("rbc.energy.aemo.downloader.logger") as mock_logger:
+        # year after start: unit included
+        valid = downloader._get_valid_units(units=[unit_code], year=start_year + 1)
+        assert unit_code in valid
+
+        # exact start year: unit included
+        valid_exact = downloader._get_valid_units(units=[unit_code], year=start_year)
+        assert unit_code in valid_exact
+
+        # year before start: unit excluded
+        valid_before = downloader._get_valid_units(
+            units=[unit_code], year=start_year - 1
+        )
+        assert unit_code not in valid_before
+
+        # verbose=False: warning logged but no "Skipping" detail
+        mock_logger.reset_mock()
+        downloader._get_valid_units(
+            units=[unit_code], year=start_year - 1, verbose=False
+        )
+        assert mock_logger.warning.call_count == 1
+        assert "Skipping" not in mock_logger.warning.call_args_list[0][0][0]
+
+        # verbose=True: both warning messages logged including "Skipping"
+        mock_logger.reset_mock()
+        downloader._get_valid_units(
+            units=[unit_code], year=start_year - 1, verbose=True
+        )
+        assert mock_logger.warning.call_count == 2
+        assert "Skipping" in mock_logger.warning.call_args_list[1][0][0]
+
+        # verbose=True, all valid: info message logged
+        mock_logger.reset_mock()
+        downloader._get_valid_units(
+            units=[unit_code], year=start_year + 1, verbose=True
+        )
+        assert mock_logger.info.call_count == 1
+        assert "All" in mock_logger.info.call_args_list[0][0][0]
+
+
+# ----------------------------------
+# Tests - General helper methods
+# ----------------------------------
+@pytest.mark.parametrize(
+    "d1_year, d2_year, expected_year",
+    [
+        (2020, 2019, 2020),
+        (2020, None, 2020),
+        (None, 2019, 2019),
+        (None, None, MIN_YEAR),
+    ],
+)
+def test_get_start_date(
+    d1_year: int | None, d2_year: int | None, expected_year: int
+) -> None:
+    """Happy path for "_get_start_date" function.
+
+    Args:
+        d1_year (int | None): First potential start date year.
+        d2_year (int | None): Second potential start date year.
+        expected_year (int): Expected year of the function output.
+    """
+    network_id = list(VALID_NETWORKS.keys())[0]
+    tz = VALID_NETWORKS[network_id]
+
+    d1, d2, expected_out = [
+        datetime(y, 1, 1, tzinfo=tz) if isinstance(y, int) else None
+        for y in [d1_year, d2_year, expected_year]
+    ]
+
+    out = _get_start_date(d1=d1, d2=d2, network_id=network_id)
+    assert out == expected_out
+    assert out.year == expected_year
+    assert out.tzinfo is tz
+
+
+def test_get_start_date_invalid_network() -> None:
+    """Failure path for "_get_start_date" function when an invalid network is provided."""
+    with pytest.raises(InvalidError, match="Invalid network ID"):
+        _get_start_date(d1=None, d2=None, network_id="fake_ID")

--- a/tests/energy/aeso/test_downloader.py
+++ b/tests/energy/aeso/test_downloader.py
@@ -80,7 +80,7 @@ def downloader(init_args: dict, mock_lookup: dict) -> AesoDownloader:
 
 @pytest.fixture(params=["1h", "5min"])
 def task(request: pytest.FixtureRequest, init_args: dict) -> DownloadTask:
-    """Gets a task as 'date=YYYY-MM, temporal_resolution=1h' from the init arguments.
+    """Gets a task as 'date=YYYY-MM' for two temporal resolutions from the init arguments.
 
     Args:
         request (FixtureRequest): Special pytest fixture used to access 'params' values.
@@ -102,7 +102,7 @@ def get_mock_df(spec_task: DownloadTask) -> pd.DataFrame:
         spec_task (DownloadTask): The metadata of a download task, here: date (YYYY-MM), t_res
 
     Returns:
-        pandas.DataFrame: Mock dataframe.
+        pd.DataFrame: Mock dataframe.
     """
     row: dict[str, object] = {c: ["A"] for c in EXPECTED_COLS}
     row.update(
@@ -212,10 +212,10 @@ def test_download_data_resume(init_args: dict) -> None:
 # Tests - Data crawling logic
 # ----------------------------------
 def test_download_task_data(downloader: AesoDownloader, task: DownloadTask) -> None:
-    """Happy path for "_download_task_data" method when resuming from checkpoint.
+    """Happy path for "_download_task_data" method.
 
     Args:
-        downloader (IesoDownloader): Instance of AesoDownloader class.
+        downloader (AesoDownloader): Instance of AesoDownloader class.
         task (DownloadTask): The metadata of a downloading task, here: date (YYYY-MM), t_res
     """
     mock_df = pd.DataFrame({"Volume": [16.2]})

--- a/tests/energy/eia/test_downloader.py
+++ b/tests/energy/eia/test_downloader.py
@@ -268,9 +268,10 @@ def test_get_task_data_rate_limit_fail(
         downloader (EiaDownloader): Instance of EiaDownloader class.
         task (DownloadTask): The metadata of a downloading task, here: date (YYYY-MM-DD)
     """
-    with patch("rbc.energy.eia.downloader.requests.get") as mock_get, patch(
-        "rbc.energy.eia.downloader.time.sleep"
-    ) as mock_sleep:
+    with (
+        patch("rbc.energy.eia.downloader.requests.get") as mock_get,
+        patch("rbc.energy.eia.downloader.time.sleep") as mock_sleep,
+    ):
         mock_get.side_effect = [MagicMock(status_code=429)] * (
             MAX_RATE_LIMIT_RETRIES + 1
         )

--- a/tests/energy/entsoe/test_downloader.py
+++ b/tests/energy/entsoe/test_downloader.py
@@ -303,11 +303,13 @@ def test_get_task_data_structure_changed(
         downloader (EntsoeDownloader): Instance of EntsoeDownloader class.
         task (DownloadTask): The metadata of a downloading task, here: date (YYYY-MM-DD), bz
     """
-    with patch(
-        "rbc.energy.entsoe.downloader.ActualGenerationPerGenerationUnit"
-    ) as mock_api, patch(
-        "rbc.energy.entsoe.downloader.extract_records"
-    ) as mock_extract, patch("rbc.energy.entsoe.downloader.add_timestamps") as mock_ts:
+    with (
+        patch(
+            "rbc.energy.entsoe.downloader.ActualGenerationPerGenerationUnit"
+        ) as mock_api,
+        patch("rbc.energy.entsoe.downloader.extract_records") as mock_extract,
+        patch("rbc.energy.entsoe.downloader.add_timestamps") as mock_ts,
+    ):
         mock_api.return_value.query_api.return_value = ["dummy_data"]
         mock_extract.return_value = [{"some_col": 1}]
         mock_ts.return_value = [{"some_col": 1, "timestamp": "2020-01-01"}]

--- a/tests/energy/ieso/test_downloader.py
+++ b/tests/energy/ieso/test_downloader.py
@@ -356,10 +356,11 @@ def test_lru_cache_works(downloader: IesoDownloader, task: DownloadTask) -> None
         {"DATE": pd.to_datetime(f"{task.date}-01"), "HOUR": [1], "GEN_A": [10]}
     )
 
-    with patch(
-        "rbc.energy.ieso.downloader.load_excel_from_file", return_value=mock_xlsx
-    ) as mock_load, patch(
-        "rbc.energy.ieso.downloader.pd.read_excel", return_value=mock_df
+    with (
+        patch(
+            "rbc.energy.ieso.downloader.load_excel_from_file", return_value=mock_xlsx
+        ) as mock_load,
+        patch("rbc.energy.ieso.downloader.pd.read_excel", return_value=mock_df),
     ):
         downloader._get_from_old_source(task=task)
         downloader._get_from_old_source(task=task)
@@ -407,16 +408,19 @@ def test_load_yearly_excel(downloader: IesoDownloader, task: DownloadTask) -> No
         {"DATE": [f"{task.date}-01"], "HOUR": [1], "GEN_A": [100]}
     )
 
-    with patch(
-        "rbc.energy.ieso.downloader.load_excel_from_file", return_value=mock_xlsx
-    ), patch(
-        "rbc.energy.ieso.downloader.pd.read_excel",
-        side_effect=[
-            mock_df_out,  # Output sheet
-            ValueError,  # Available Capacities - not found
-            mock_df_cap,  # Capability - see Notes
-        ],
-    ) as mock_load:
+    with (
+        patch(
+            "rbc.energy.ieso.downloader.load_excel_from_file", return_value=mock_xlsx
+        ),
+        patch(
+            "rbc.energy.ieso.downloader.pd.read_excel",
+            side_effect=[
+                mock_df_out,  # Output sheet
+                ValueError,  # Available Capacities - not found
+                mock_df_cap,  # Capability - see Notes
+            ],
+        ) as mock_load,
+    ):
         df = downloader._load_yearly_excel(url="http://fake.xlsx")
 
         # check that returned df has correct new structure (up to 'HOUR 2')
@@ -449,16 +453,19 @@ def test_load_yearly_excel_missing_capacity(
         {"DATE": [f"{task.date}-01"], "HOUR": [1], "GEN_A": [10]}
     )
 
-    with patch(
-        "rbc.energy.ieso.downloader.load_excel_from_file", return_value=mock_xlsx
-    ), patch(
-        "rbc.energy.ieso.downloader.pd.read_excel",
-        side_effect=[
-            mock_df_out,  # Output sheet
-            ValueError,  # Available Capacities - not found
-            ValueError,  # Capability - see Notes - not found
-            ValueError,  # Capability - not found
-        ],
+    with (
+        patch(
+            "rbc.energy.ieso.downloader.load_excel_from_file", return_value=mock_xlsx
+        ),
+        patch(
+            "rbc.energy.ieso.downloader.pd.read_excel",
+            side_effect=[
+                mock_df_out,  # Output sheet
+                ValueError,  # Available Capacities - not found
+                ValueError,  # Capability - see Notes - not found
+                ValueError,  # Capability - not found
+            ],
+        ),
     ):
         with pytest.raises(DataStructureError, match="No valid capacity sheets"):
             downloader._load_yearly_excel(url="http://fake.xlsx")

--- a/tests/energy/ieso/test_downloader.py
+++ b/tests/energy/ieso/test_downloader.py
@@ -392,7 +392,7 @@ def test_load_yearly_excel(downloader: IesoDownloader, task: DownloadTask) -> No
         downloader (IesoDownloader): Instance of IesoDownloader class.
         task (DownloadTask): The metadata of a downloading task, here: date (YYYY-MM)
     """
-    mock_xlsx = MagicMock(
+    mock_xls = MagicMock(
         spec=pd.ExcelFile,
         sheet_names=[
             "Output",
@@ -409,9 +409,7 @@ def test_load_yearly_excel(downloader: IesoDownloader, task: DownloadTask) -> No
     )
 
     with (
-        patch(
-            "rbc.energy.ieso.downloader.load_excel_from_file", return_value=mock_xlsx
-        ),
+        patch("rbc.energy.ieso.downloader.load_excel_from_file", return_value=mock_xls),
         patch(
             "rbc.energy.ieso.downloader.pd.read_excel",
             side_effect=[
@@ -448,15 +446,13 @@ def test_load_yearly_excel_missing_capacity(
         downloader (IesoDownloader): Instance of IesoDownloader class.
         task (DownloadTask): The metadata of a downloading task, here: date (YYYY-MM)
     """
-    mock_xlsx = MagicMock(spec=pd.ExcelFile, sheet_names=["Output", "Capability"])
+    mock_xls = MagicMock(spec=pd.ExcelFile, sheet_names=["Output", "Capability"])
     mock_df_out = pd.DataFrame(
         {"DATE": [f"{task.date}-01"], "HOUR": [1], "GEN_A": [10]}
     )
 
     with (
-        patch(
-            "rbc.energy.ieso.downloader.load_excel_from_file", return_value=mock_xlsx
-        ),
+        patch("rbc.energy.ieso.downloader.load_excel_from_file", return_value=mock_xls),
         patch(
             "rbc.energy.ieso.downloader.pd.read_excel",
             side_effect=[

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,6 +2,7 @@
 import sys
 from pathlib import Path
 
+import pytest
 from loguru import logger
 
 from rbc.utils import handle_exceptions, setup_logging
@@ -10,28 +11,30 @@ from rbc.utils import handle_exceptions, setup_logging
 # ----------------------------------
 # Tests
 # ----------------------------------
-def test_setup_logging(tmp_path: Path) -> None:
+@pytest.mark.parametrize("verbose, level", [[False, "INFO"], [True, "DEBUG"]])
+def test_setup_logging(tmp_path: Path, verbose: bool, level: str) -> None:
     """Happy path for "setup_logging" function, ensuring messages are logged to file.
 
     Args:
         tmp_path (Path): Path to the temporary directory.
+        verbose (bool, optional): Whether or not to define a high logging verbosity level.
+        level (str): The resulting logging level.
     """
     logger.remove()
-    logs = []
-    sink = logger.add(lambda msg: logs.append(msg.record["message"]), level="INFO")
+    setup_logging(tmp_path, verbose=verbose)
 
-    try:
-        setup_logging(tmp_path)
-        assert any("Log file initialized." in msg for msg in logs)
+    log_dir = Path(tmp_path, "logs")
+    assert log_dir.exists()
 
-        log_dir = Path(tmp_path, "logs")
-        assert log_dir.exists()
+    log_files = list(log_dir.rglob("*.log"))
+    assert len(log_files) == 1
 
-        log_files = list(log_dir.rglob("*.log"))
-        assert len(log_files) == 1
+    log_file = log_files[0]
+    content = log_file.read_text()
 
-    finally:
-        logger.remove(sink)
+    assert f"Logging initialized with level {level}." in content
+    assert "Log file writing to:" in content
+    assert str(log_file.name) in content
 
 
 def test_handle_exceptions(tmp_path: Path):

--- a/tests/weather/barra/test_downloader.py
+++ b/tests/weather/barra/test_downloader.py
@@ -608,9 +608,10 @@ def test_download_variable_success_writes_file(downloader: Barra2Downloader) -> 
     mock_response.iter_content.return_value = [b"ab", b"cd"]
     mock_response.raise_for_status.return_value = None
 
-    with patch("rbc.weather.utils.requests.get", return_value=mock_response), patch(
-        "rbc.weather.utils.tqdm"
-    ) as mock_tqdm:
+    with (
+        patch("rbc.weather.utils.requests.get", return_value=mock_response),
+        patch("rbc.weather.utils.tqdm") as mock_tqdm,
+    ):
         progress = MagicMock()
         progress.__enter__.return_value = progress  # make context manager return itself
         mock_tqdm.return_value = progress
@@ -664,8 +665,9 @@ def test_download_variable_request_exception_removes_existing_partial(
     mock_response.raise_for_status.return_value = None
     mock_response.iter_content.side_effect = _failing_chunks
 
-    with patch("rbc.weather.utils.requests.get", return_value=mock_response), patch(
-        "rbc.weather.utils.tqdm", return_value=MagicMock()
+    with (
+        patch("rbc.weather.utils.requests.get", return_value=mock_response),
+        patch("rbc.weather.utils.tqdm", return_value=MagicMock()),
     ):
         result = downloader._download_task((2020, "01", "1.5m_temperature"))
 
@@ -693,9 +695,10 @@ def test_download_variable_generic_exception_removes_partial(
     mock_response.iter_content.side_effect = _broken_chunks
     mock_response.raise_for_status.return_value = None
 
-    with patch("rbc.weather.utils.requests.get", return_value=mock_response), patch(
-        "rbc.weather.utils.tqdm"
-    ) as mock_tqdm:
+    with (
+        patch("rbc.weather.utils.requests.get", return_value=mock_response),
+        patch("rbc.weather.utils.tqdm") as mock_tqdm,
+    ):
         progress = MagicMock()
         progress.__enter__.return_value = progress
         mock_tqdm.return_value = progress


### PR DESCRIPTION
# New data crawler for AEMO (Australia) energy data

Code and tests for downloading data from [AEMO](https://www.aemo.com.au/) via the OpenElectricity [platform](https://platform.openelectricity.org.au/) (specifically [Python SDK](https://github.com/opennem/openelectricity-python)) and personal API token. This crawler can function as an example for future data crawlers and encompasses:

- a config YAML file `configs/energy/aemo.yaml` for source-related settings,
- a data downloader in `rbc/energy/aemo/downloader.py`,
- a script for running the downloader in `scripts/energy/aemo_download.py`,
- tests for the downloader in `tests/energy/aemo/test_downloader.py`.
- updated documentation (`README.md` and `docs/data_sources.md`)

> **Please note:**
> 1. The leveraged functionality in the OpenElectricity Python package has an error, a [PR](https://github.com/opennem/openelectricity-python/pull/27) was submitted to fix it. Unfortunately, it is unclear when this will be merged, which is why the [forked repository](https://github.com/RenewBench-Association/openelectricity-python) needs to be used for the `AemoDownloader` to work.
> 2. OpenElectricity utilises `asyncio`-based parallelization. This was incorporated into the existing structure and is leveraged by the `AemoDownloader`.

### Additional changes

- **rbc/utils.py**: added `verbose` option to `setup_logging` function to allow for `DEBUG` or `INFO`-based logging

## New dependancies

### Package (project)

`openelectricity`
- from the [forked repository](https://github.com/RenewBench-Association/openelectricity-python)
- in place of previously included and no longer actively maintained package `nemosis`

`openpyxl`
- required by other energy crawlers (apparently forgot to add it in previously)

### Testing (project optional)

`pytest-asyncio`

## Related issues

- Closes #13 (both NEM **and** WEM data - not just NEM)

## Type of change

- [X] New feature (non-breaking change which adds functionality)

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules