### PR TITLE
Bugfix/download barra variable on pressure level

### DIFF
--- a/rbc/weather/barra/downloader.py
+++ b/rbc/weather/barra/downloader.py
@@ -10,14 +10,14 @@ from loguru import logger
 
 from rbc.weather.barra.mappings import (
     C2_20MIN_SINGLE_LEVEL_VARIABLES,
+    C2_DEFAULT_PRESSURE_LEVELS,
     C2_PRESSURE_LEVEL_VARIABLES,
-    C2_PRESSURE_LEVELS,
     C2_SINGLE_LEVEL_VARIABLES,
     DEFAULT_VARIABLES,
     INVARIANT_VARIABLES,
     MODEL_CONFIG,
+    R2_DEFAULT_PRESSURE_LEVELS,
     R2_PRESSURE_LEVEL_VARIABLES,
-    R2_PRESSURE_LEVELS,
     R2_SINGLE_LEVEL_VARIABLES,
     VARIABLE_TO_SHORT_PARAM,
 )
@@ -169,11 +169,11 @@ class Barra2Downloader(WeatherDownloader):
 
         # Setup pressure levels (use model defaults if none provided)
         if pressure_levels is not None:
-            self.pressure_levels = pressure_levels
+            self.pressure_levels = list(map(str, pressure_levels))
         elif self.model == "R2":
-            self.pressure_levels = list(R2_PRESSURE_LEVELS)
+            self.pressure_levels = list(map(str, R2_DEFAULT_PRESSURE_LEVELS))
         elif self.model == "C2":
-            self.pressure_levels = list(C2_PRESSURE_LEVELS)
+            self.pressure_levels = list(map(str, C2_DEFAULT_PRESSURE_LEVELS))
         else:
             self.pressure_levels = []
 
@@ -211,8 +211,9 @@ class Barra2Downloader(WeatherDownloader):
     def _get_tasks(self) -> list[tuple]:
         """Return all download tasks: invariant variables first, then temporal.
 
-        Invariant tasks use the sentinel key ("fx", "fx", variable).
-        Temporal tasks use (year, month, variable).
+        Invariant tasks use the sentinel key ("fx", "fx", variable, "").
+        Single-level tasks use (year, month, variable, "").
+        Pressure-level tasks use (year, month, variable, level) for each pressure level.
 
         Returns:
             list[tuple]: Ordered list of task tuples.
@@ -222,46 +223,71 @@ class Barra2Downloader(WeatherDownloader):
             f"({self.temporal_res} frequency)"
         )
 
+        pressure_codes = (
+            R2_PRESSURE_LEVEL_VARIABLES
+            if self.model == "R2"
+            else C2_PRESSURE_LEVEL_VARIABLES
+            if self.model == "C2"
+            else set()
+        )
+
         invariant_tasks: list[tuple] = [
-            ("fx", "fx", v)
+            ("fx", "fx", v, "")
             for v in self.variables
             if get_short_param(v, VARIABLE_TO_SHORT_PARAM) in INVARIANT_VARIABLES
         ]
-        temporal_tasks: list[tuple] = [
-            (year, month, v)
+        single_tasks: list[tuple] = [
+            (year, month, v, "")
             for year in self.years
             for month in self.months
             for v in self.variables
             if get_short_param(v, VARIABLE_TO_SHORT_PARAM) not in INVARIANT_VARIABLES
+            and get_short_param(v, VARIABLE_TO_SHORT_PARAM) not in pressure_codes
         ]
-        return invariant_tasks + temporal_tasks
+        pressure_tasks: list[tuple] = [
+            (year, month, v, str(level))
+            for year in self.years
+            for month in self.months
+            for v in self.variables
+            if get_short_param(v, VARIABLE_TO_SHORT_PARAM) in pressure_codes
+            for level in self.pressure_levels
+        ]
+
+        return invariant_tasks + single_tasks + pressure_tasks
 
     def _download_task(self, task: tuple) -> int:
         """Download a single BARRA2 data file.
 
         Args:
-            task (tuple): Task tuple of (year, month, variable).
-                Invariant variables use ("fx", "fx", variable).
+            task (tuple): Task tuple of (year, month, variable, level).
+                Invariant variables use ("fx", "fx", variable, "").
+                Single-level variables use (year, month, variable, "").
+                Pressure-level variables use (year, month, variable, "pressure").
 
         Returns:
             int: 1 if successful, 0 if failed.
         """
-        year, month, variable = task
-        return self._download_variables(year=year, month=month, variable=variable)
+        year, month, variable, level = task
+        return self._download_variables(
+            year=year, month=month, variable=variable, level=level
+        )
 
-    def _download_variables(self, year: int | str, month: str, variable: str) -> int:
+    def _download_variables(
+        self, year: int | str, month: str, variable: str, level: str
+    ) -> int:
         """Download a single BARRA2 data file.
 
         Args:
             year (int | str): Year to download, or "fx" for invariant variables.
             month (str): Month to download (format: '01' to '12'), or "fx" for invariant variables.
             variable (str): Variable name (e.g., 'temperature', '10m_u_component_of_wind').
+            level (str): Pressure level as string (e.g. "1000"), or "" for single-level/invariant variables.
 
         Returns:
             int: 1 if successful, 0 if failed.
         """
-        url = self._build_opendap_url(year, month, variable)
-        output_file = self._construct_file_path(year, month, variable)
+        url = self._build_opendap_url(year, month, variable, level)
+        output_file = self._construct_file_path(year, month, variable, level)
         description = f"{year}-{month} ({variable})"
 
         if output_file.exists():
@@ -280,7 +306,9 @@ class Barra2Downloader(WeatherDownloader):
     # --------------------------------------------
     # Helper methods
     # --------------------------------------------
-    def _build_opendap_url(self, year: int | str, month: str, variable: str) -> str:
+    def _build_opendap_url(
+        self, year: int | str, month: str, variable: str, level: str
+    ) -> str:
         """Build OPeNDAP URL for a specific file on the NCI THREDDS server.
 
         The URL structure follows the NCI THREDDS catalog layout for BARRA2 data.
@@ -289,6 +317,7 @@ class Barra2Downloader(WeatherDownloader):
             year (int | str): Year as integer, or "fx" for invariant variables.
             month (str): Month as string (01-12), or "fx" for invariant variables.
             variable (str): Variable name.
+            level (str): Pressure level as string (e.g. "1000"), or "" for single-level/invariant variables.
 
         Returns:
             str: Full OPeNDAP URL for accessing the file.
@@ -307,19 +336,22 @@ class Barra2Downloader(WeatherDownloader):
         else:
             year_month = f"{year}{month}"
             dataset_file = (
-                f"{barra2_code}_{grid}_ERA5_historical_hres_BOM_"
+                f"{barra2_code}{level}_{grid}_ERA5_historical_hres_BOM_"
                 f"{dataset_label}_v1_{self.temporal_res}_{year_month}-{year_month}.nc"
             )
-            url = f"{base_url}/{self.temporal_res}/{barra2_code}/latest/{dataset_file}"
+            url = f"{base_url}/{self.temporal_res}/{barra2_code}{level}/latest/{dataset_file}"
         return url
 
-    def _construct_file_path(self, year: int | str, month: str, variable: str) -> Path:
+    def _construct_file_path(
+        self, year: int | str, month: str, variable: str, level: str
+    ) -> Path:
         """Construct the local file path for a BARRA2 data file.
 
         Args:
             year (int | str): Year as integer, or "fx" for invariant variables.
             month (str): Month as string (01-12), or "fx" for invariant variables.
             variable (str): Variable name.
+            level (str): Pressure level as string (e.g. "1000"), or "" for single-level/invariant variables.
 
         Returns:
             Path: Full local file path for the data file.
@@ -329,7 +361,7 @@ class Barra2Downloader(WeatherDownloader):
             filename = f"barra2_{self.model}_fx_{barra2_code}.nc"
             return Path(self.invariant_output_path, filename)
         else:
-            filename = f"barra2_{self.model}_{self.temporal_res}_{year}{month}_{barra2_code}.nc"
+            filename = f"barra2_{self.model}_{self.temporal_res}_{year}{month}_{barra2_code}{level}.nc"
             return Path(self.output_path, filename)
 
     def _validate_variables(self) -> None:

--- a/rbc/weather/barra/mappings.py
+++ b/rbc/weather/barra/mappings.py
@@ -246,10 +246,10 @@ C2_PRESSURE_LEVELS = sorted(
 )
 
 # Default: 1000, 950 hPa (lowest 2 pressure levels, ~110m, ~560m altitude)
-R2_DEFAULT_PRESSURE_LEVELS = ["1000", "950"]
+R2_DEFAULT_PRESSURE_LEVELS = [1000, 950]
 
 # Default: 1000, 975, 950 hPa (lowest 3 pressure levels, ~110m, ~300m, ~560m altitude)
-C2_DEFAULT_PRESSURE_LEVELS = ["1000", "975", "950"]
+C2_DEFAULT_PRESSURE_LEVELS = [1000, 975, 950]
 
 # Mapping of variable names to BARRA2 parameter short codes
 VARIABLE_TO_SHORT_PARAM = {

--- a/tests/weather/barra/test_downloader.py
+++ b/tests/weather/barra/test_downloader.py
@@ -273,27 +273,36 @@ def test_checkpoint_resume_behavior(
 # ----------------------------------
 # Tests - File path & URL construction
 # ----------------------------------
-def test_construct_file_path(downloader: Barra2Downloader) -> None:
+@pytest.mark.parametrize(
+    "var, level", [("1.5m_temperature", ""), ("tas", ""), ("temperature", "850")]
+)
+def test_construct_file_path(
+    downloader: Barra2Downloader, var: str, level: str
+) -> None:
     """Test file path construction resolves to BARRA2 code.
 
     Args:
         downloader (Barra2Downloader): Instance of Barra2Downloader class.
+        var (str): Variable name.
+        level (str): Level name.
     """
-    file_path = downloader._construct_file_path(2020, "01", "1.5m_temperature", "")
+    ref_path = downloader._construct_file_path(2020, "01", "1.5m_temperature", "")
+    file_path = downloader._construct_file_path(2020, "01", var, level)
+
+    # common assertions
     assert file_path.parent == downloader.output_path
     assert "R2" in str(file_path)
     assert "1hr" in str(file_path)
     assert "202001" in str(file_path)
-    # File name uses resolved BARRA2 code, not descriptive name
-    assert "tas" in str(file_path)
-    assert str(file_path).endswith(".nc")
-    # Passing a raw BARRA2 code directly is also accepted (passthrough fallback)
-    file_path_raw = downloader._construct_file_path(2020, "01", "tas", "")
-    assert file_path_raw == file_path
-    # Pressure-level file includes the level in the filename
-    file_path_plev = downloader._construct_file_path(2020, "01", "temperature", "850")
-    assert "850" in file_path_plev.name
-    assert file_path_plev != file_path
+    assert file_path.suffix == ".nc"
+
+    # specific assertions depending on if pressure level exists of not
+    if not level:
+        assert file_path == ref_path
+        assert "tas" in file_path.name
+    else:
+        assert file_path != ref_path
+        assert level in file_path.name
 
 
 def test_construct_file_path_different_vars(downloader: Barra2Downloader) -> None:

--- a/tests/weather/barra/test_downloader.py
+++ b/tests/weather/barra/test_downloader.py
@@ -234,7 +234,7 @@ def test_downloader_initialization_optional_args(tmp_path: Path) -> None:
         pressure_levels=custom_levels,
     )
     assert dl_custom.months == ["06"]
-    assert dl_custom.pressure_levels == custom_levels
+    assert dl_custom.pressure_levels == list(map(str, custom_levels))
 
 
 # ----------------------------------
@@ -279,7 +279,7 @@ def test_construct_file_path(downloader: Barra2Downloader) -> None:
     Args:
         downloader (Barra2Downloader): Instance of Barra2Downloader class.
     """
-    file_path = downloader._construct_file_path(2020, "01", "1.5m_temperature")
+    file_path = downloader._construct_file_path(2020, "01", "1.5m_temperature", "")
     assert file_path.parent == downloader.output_path
     assert "R2" in str(file_path)
     assert "1hr" in str(file_path)
@@ -288,8 +288,12 @@ def test_construct_file_path(downloader: Barra2Downloader) -> None:
     assert "tas" in str(file_path)
     assert str(file_path).endswith(".nc")
     # Passing a raw BARRA2 code directly is also accepted (passthrough fallback)
-    file_path_raw = downloader._construct_file_path(2020, "01", "tas")
+    file_path_raw = downloader._construct_file_path(2020, "01", "tas", "")
     assert file_path_raw == file_path
+    # Pressure-level file includes the level in the filename
+    file_path_plev = downloader._construct_file_path(2020, "01", "temperature", "850")
+    assert "850" in file_path_plev.name
+    assert file_path_plev != file_path
 
 
 def test_construct_file_path_different_vars(downloader: Barra2Downloader) -> None:
@@ -298,8 +302,8 @@ def test_construct_file_path_different_vars(downloader: Barra2Downloader) -> Non
     Args:
         downloader (Barra2Downloader): Instance of Barra2Downloader class.
     """
-    path1 = downloader._construct_file_path(2020, "01", "1.5m_temperature")
-    path2 = downloader._construct_file_path(2020, "01", "total_precipitation")
+    path1 = downloader._construct_file_path(2020, "01", "1.5m_temperature", "")
+    path2 = downloader._construct_file_path(2020, "01", "total_precipitation", "")
     assert str(path1) != str(path2)
     assert "tas" in str(path1)
     assert "pr" in str(path2)
@@ -320,7 +324,7 @@ def test_construct_file_path_invariant_uses_fx_name(tmp_path: Path) -> None:
     )
 
     # Invariant variables ignore year/month; use sentinel values matching the actual call site.
-    file_path = downloader._construct_file_path(0, "fx", "orography")
+    file_path = downloader._construct_file_path(0, "fx", "orography", "")
 
     assert file_path.parent.name == "invariant"
     assert file_path.name == "barra2_C2_20min_fx_orog.nc"
@@ -352,7 +356,7 @@ def test_build_opendap_url_r2(downloader: Barra2Downloader) -> None:
     Args:
         downloader (Barra2Downloader): Instance of Barra2Downloader class.
     """
-    url = downloader._build_opendap_url(2020, "06", "1.5m_temperature")
+    url = downloader._build_opendap_url(2020, "06", "1.5m_temperature", "")
     assert "thredds.nci.org.au" in url
     assert "202006" in url
     # URL uses resolved BARRA2 code
@@ -374,8 +378,8 @@ def test_build_opendap_url_different_models(
         years=[2020],
         variables=["1.5m_temperature"],
     )
-    url_r2 = downloader._build_opendap_url(2020, "01", "1.5m_temperature")
-    url_c2 = dl_c2._build_opendap_url(2020, "01", "1.5m_temperature")
+    url_r2 = downloader._build_opendap_url(2020, "01", "1.5m_temperature", "")
+    url_c2 = dl_c2._build_opendap_url(2020, "01", "1.5m_temperature", "")
     assert url_r2 != url_c2
 
 
@@ -394,7 +398,7 @@ def test_build_opendap_url_invariant_uses_fx_path(tmp_path: Path) -> None:
     )
 
     # Invariant variables ignore year/month; use sentinel values matching the actual call site.
-    url = downloader._build_opendap_url(0, "fx", "land_sea_mask")
+    url = downloader._build_opendap_url(0, "fx", "land_sea_mask", "")
 
     assert "/fx/sftlf/latest/" in url
     assert "_v1.nc" in url
@@ -434,8 +438,8 @@ def test_temporal_res_in_file_path(tmp_path: Path) -> None:
         years=[2020],
         variables=["1.5m_temperature"],
     )
-    path_1hr = dl_1hr._construct_file_path(2020, "01", "1.5m_temperature")
-    path_20min = dl_20min._construct_file_path(2020, "01", "1.5m_temperature")
+    path_1hr = dl_1hr._construct_file_path(2020, "01", "1.5m_temperature", "")
+    path_20min = dl_20min._construct_file_path(2020, "01", "1.5m_temperature", "")
     assert "1hr" in str(path_1hr)
     assert "20min" in str(path_20min)
     assert path_1hr != path_20min
@@ -459,8 +463,8 @@ def test_temporal_res_in_opendap_url(tmp_path: Path) -> None:
         years=[2020],
         variables=["1.5m_temperature"],
     )
-    url_1hr = dl_1hr._build_opendap_url(2020, "01", "1.5m_temperature")
-    url_20min = dl_20min._build_opendap_url(2020, "01", "1.5m_temperature")
+    url_1hr = dl_1hr._build_opendap_url(2020, "01", "1.5m_temperature", "")
+    url_20min = dl_20min._build_opendap_url(2020, "01", "1.5m_temperature", "")
     assert "/1hr/" in url_1hr
     assert "/20min/" in url_20min
 
@@ -506,8 +510,8 @@ def test_download_data_skips_completed(init_args: dict) -> None:
     """
     # Save a fake checkpoint marking all tasks as done
     checkpoint = {
-        (2020, "01", "1.5m_temperature"): 1,
-        (2020, "01", "total_precipitation"): 1,
+        (2020, "01", "1.5m_temperature", ""): 1,
+        (2020, "01", "total_precipitation", ""): 1,
     }
     checkpoint_path = Path(init_args["output_path"], "R2", "status.pickle")
     checkpoint_path.parent.mkdir(parents=True, exist_ok=True)
@@ -533,7 +537,7 @@ def test_download_data_calls_download_variable(init_args: dict) -> None:
 
     with patch.object(downloader, "_download_task", return_value=1) as mock_dl:
         downloader.download_data()
-        mock_dl.assert_called_once_with((2020, "01", "1.5m_temperature"))
+        mock_dl.assert_called_once_with((2020, "01", "1.5m_temperature", ""))
 
 
 def test_download_data_calls_download_variable_for_invariant(init_args: dict) -> None:
@@ -547,7 +551,7 @@ def test_download_data_calls_download_variable_for_invariant(init_args: dict) ->
 
     with patch.object(downloader, "_download_task", return_value=1) as mock_dl:
         downloader.download_data()
-        mock_dl.assert_called_once_with(("fx", "fx", "orography"))
+        mock_dl.assert_called_once_with(("fx", "fx", "orography", ""))
 
 
 def test_download_data_skips_completed_invariant(init_args: dict) -> None:
@@ -556,7 +560,7 @@ def test_download_data_skips_completed_invariant(init_args: dict) -> None:
     Args:
         init_args (dict): Initialization arguments for Barra2Downloader.
     """
-    checkpoint: dict = {("fx", "fx", "orography"): 1}
+    checkpoint: dict = {("fx", "fx", "orography", ""): 1}
     checkpoint_path = Path(init_args["output_path"], "R2", "status.pickle")
     checkpoint_path.parent.mkdir(parents=True, exist_ok=True)
     with open(checkpoint_path, "wb") as f:
@@ -569,6 +573,46 @@ def test_download_data_skips_completed_invariant(init_args: dict) -> None:
     with patch.object(downloader, "_download_task") as mock_dl:
         downloader.download_data()
         mock_dl.assert_not_called()
+
+
+# ----------------------------------
+# Tests - Task generation
+# ----------------------------------
+def test_get_tasks_creates_task_per_pressure_level(tmp_path: Path) -> None:
+    """Pressure-level variables generate one task per pressure level.
+
+    Each task carries the level as a string; single-level variables are not affected.
+
+    Args:
+        tmp_path (Path): Path to the temporary directory.
+    """
+    pressure_levels = [500, 850, 1000]
+    downloader = Barra2Downloader(
+        output_path=tmp_path,
+        model="R2",
+        years=[2020],
+        months=["01"],
+        variables=["temperature"],
+        pressure_levels=pressure_levels,
+    )
+    tasks = downloader._get_tasks()
+
+    assert len(tasks) == len(pressure_levels)
+    assert all(t[:3] == (2020, "01", "temperature") for t in tasks)
+    assert {t[3] for t in tasks} == {str(lvl) for lvl in pressure_levels}
+
+
+def test_get_tasks_single_level_variable_has_empty_level(init_args: dict) -> None:
+    """Single-level variables should produce tasks with an empty level string.
+
+    Args:
+        init_args (dict): Initialization arguments for Barra2Downloader.
+    """
+    downloader = Barra2Downloader(**init_args)
+    tasks = downloader._get_tasks()
+
+    single_tasks = [t for t in tasks if t[2] in init_args["variables"]]
+    assert all(t[3] == "" for t in single_tasks)
 
 
 # ----------------------------------
@@ -606,10 +650,10 @@ def test_download_variable_skips_when_file_exists(downloader: Barra2Downloader) 
     Args:
         downloader (Barra2Downloader): Instance of Barra2Downloader class.
     """
-    output_file = downloader._construct_file_path(2020, "01", "1.5m_temperature")
+    output_file = downloader._construct_file_path(2020, "01", "1.5m_temperature", "")
     output_file.write_bytes(b"already here")
 
-    result = downloader._download_task((2020, "01", "1.5m_temperature"))
+    result = downloader._download_task((2020, "01", "1.5m_temperature", ""))
 
     assert result == 1
 
@@ -632,9 +676,9 @@ def test_download_variable_success_writes_file(downloader: Barra2Downloader) -> 
         progress.__enter__.return_value = progress  # make context manager return itself
         mock_tqdm.return_value = progress
 
-        result = downloader._download_task((2020, "01", "1.5m_temperature"))
+        result = downloader._download_task((2020, "01", "1.5m_temperature", ""))
 
-    output_file = downloader._construct_file_path(2020, "01", "1.5m_temperature")
+    output_file = downloader._construct_file_path(2020, "01", "1.5m_temperature", "")
     assert result == 1
     assert output_file.exists()
     assert output_file.read_bytes() == b"abcd"
@@ -650,14 +694,14 @@ def test_download_variable_request_exception_removes_partial(
     Args:
         downloader (Barra2Downloader): Instance of Barra2Downloader class.
     """
-    output_file = downloader._construct_file_path(2020, "01", "1.5m_temperature")
+    output_file = downloader._construct_file_path(2020, "01", "1.5m_temperature", "")
     assert not output_file.exists()
 
     with patch(
         "rbc.weather.utils.requests.get",
         side_effect=requests.exceptions.RequestException("boom"),
     ):
-        result = downloader._download_task((2020, "01", "1.5m_temperature"))
+        result = downloader._download_task((2020, "01", "1.5m_temperature", ""))
 
     assert result == 0
     assert not output_file.exists()
@@ -684,9 +728,9 @@ def test_download_variable_request_exception_removes_existing_partial(
     with patch("rbc.weather.utils.requests.get", return_value=mock_response), patch(
         "rbc.weather.utils.tqdm", return_value=MagicMock()
     ):
-        result = downloader._download_task((2020, "01", "1.5m_temperature"))
+        result = downloader._download_task((2020, "01", "1.5m_temperature", ""))
 
-    output_file = downloader._construct_file_path(2020, "01", "1.5m_temperature")
+    output_file = downloader._construct_file_path(2020, "01", "1.5m_temperature", "")
     assert result == 0
     assert not output_file.exists()
 
@@ -716,9 +760,9 @@ def test_download_variable_generic_exception_removes_partial(
         progress = MagicMock()
         progress.__enter__.return_value = progress
         mock_tqdm.return_value = progress
-        result = downloader._download_task((2020, "01", "1.5m_temperature"))
+        result = downloader._download_task((2020, "01", "1.5m_temperature", ""))
 
-    output_file = downloader._construct_file_path(2020, "01", "1.5m_temperature")
+    output_file = downloader._construct_file_path(2020, "01", "1.5m_temperature", "")
     assert result == 0
     assert not output_file.exists()
 


### PR DESCRIPTION
# Description
- Fixes download of pressure level variables for BARRA2 weather data. 
- Using `<MODEL>_DEFAULT_PRESSURE_LEVELS` instead of `<MODEL>_PRESSURE_LEVELS` as default. 
- Adapting tests to new task logic for pressure-level variables.  

- Closes #51 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
