### PR TITLE
Bugfix: Rate limit error handling (bugfix/running energy crawlers)

### DIFF
--- a/rbc/energy/adme/downloader.py
+++ b/rbc/energy/adme/downloader.py
@@ -107,9 +107,7 @@ class AdmeDownloader(EnergyDownloader):
             df = self._get_from_new_source(task)
 
         if df.empty:
-            raise MissingDataError(
-                f"No energy data available for {task.year}-{task.month}. Skipping..."
-            )
+            raise MissingDataError("No energy data available (after month filter)!")
 
         missing_cols = [
             c for c in EXPECTED_COLS if c not in df.columns.get_level_values(0)

--- a/rbc/energy/aemo/downloader.py
+++ b/rbc/energy/aemo/downloader.py
@@ -215,7 +215,7 @@ class AemoDownloader(EnergyDownloader):
         data = asyncio.run(fetch_task_data())
 
         if not data:
-            raise MissingDataError("No generation data!")
+            raise MissingDataError("No energy data available!")
 
         # define dataframe to be saved
         df_api = pd.DataFrame(data)

--- a/rbc/energy/aemo/downloader.py
+++ b/rbc/energy/aemo/downloader.py
@@ -215,7 +215,7 @@ class AemoDownloader(EnergyDownloader):
         data = asyncio.run(fetch_task_data())
 
         if not data:
-            raise MissingDataError(f"No generation data for {task.date}")
+            raise MissingDataError("No generation data!")
 
         # define dataframe to be saved
         df_api = pd.DataFrame(data)

--- a/rbc/energy/aeso/downloader.py
+++ b/rbc/energy/aeso/downloader.py
@@ -168,7 +168,7 @@ class AesoDownloader(EnergyDownloader):
         df = self._load_zip(item_id=item["id"], item_name=item["name"])
 
         if df.empty:
-            raise MissingDataError("No energy data available! Skipping...")
+            raise MissingDataError("No energy data available!")
 
         missing_cols = [c for c in EXPECTED_COLS if c not in df.columns]
         if missing_cols:
@@ -188,7 +188,7 @@ class AesoDownloader(EnergyDownloader):
         df = df.loc[date_col.dt.to_period("M") == pd.Period(task.date, freq="M")].copy()
 
         if df.empty:
-            raise MissingDataError("No energy data after month filter! Skipping...")
+            raise MissingDataError("No energy data available (after month filter)!")
 
         df = df.sort_values(
             by=["Date (MST)", "Date (MPT)", "Asset Name"], ignore_index=True

--- a/rbc/energy/cen/downloader.py
+++ b/rbc/energy/cen/downloader.py
@@ -214,7 +214,7 @@ class CenDownloader(EnergyDownloader):
                 current_page = dict_body["page"]  # current page
 
                 if data == [] and total_pages == 0:
-                    raise MissingDataError("No energy data available! Skipping...")
+                    raise MissingDataError("No energy data available!")
 
                 all_data.extend(data)
 
@@ -235,7 +235,7 @@ class CenDownloader(EnergyDownloader):
         # Check if created dataframe is as expected
         df_gen = pd.DataFrame(all_data)
         if df_gen.empty:
-            raise MissingDataError("No energy data available! Skipping...")
+            raise MissingDataError("No energy data available!")
 
         missing_cols = [c for c in EXPECTED_COLS if c not in df_gen.columns]
         if missing_cols:

--- a/rbc/energy/cen/downloader.py
+++ b/rbc/energy/cen/downloader.py
@@ -154,12 +154,12 @@ class CenDownloader(EnergyDownloader):
             except exceptions.RequestException as e:
                 # catch ALL requests errors locally (prevents crashing of parent thread!)
                 if attempt_network < MAX_RETRIES:  # retry 3 times
+                    attempt_network += 1
                     logger.warning(
                         f"Network issue for {task.date} (Page {params['page']}): "
                         f"{type(e).__name__}. Retrying page request in 5 seconds..."
                     )
                     time.sleep(5)
-                    attempt_network += 1
                     continue
                 else:
                     raise type(e)(
@@ -170,12 +170,12 @@ class CenDownloader(EnergyDownloader):
             if status_code != 200:
                 if status_code == 429:
                     if attempt_ratelimit < MAX_RETRIES:  # retry 3 times
+                        attempt_ratelimit += 1
                         logger.warning(
                             f"CEN API rate limit reached (429) on page {params['page']}. "
                             f"Sleeping {RATE_LIMIT_RETRY_DELAY} seconds..."
                         )
                         time.sleep(RATE_LIMIT_RETRY_DELAY)
-                        attempt_ratelimit += 1
                         continue
                     else:
                         raise exceptions.HTTPError(
@@ -186,6 +186,7 @@ class CenDownloader(EnergyDownloader):
 
                 if status_code == 500:
                     if attempt_pagesize < 3:
+                        attempt_pagesize += 1
                         logger.warning(
                             "Server overload (too much data requested at once). Halving "
                             "page size and restarting date task..."
@@ -193,7 +194,6 @@ class CenDownloader(EnergyDownloader):
                         params["pageSize"] = int(int(params["pageSize"]) / 2)
                         params["page"] = 1  # reset back to the beginning!
                         all_data = []  # clear already accumulated data so no duplicates
-                        attempt_pagesize += 1
                         continue
                     else:
                         raise exceptions.HTTPError(

--- a/rbc/energy/cen/downloader.py
+++ b/rbc/energy/cen/downloader.py
@@ -13,14 +13,13 @@ from loguru import logger
 from requests import exceptions
 
 from rbc.energy.utils import (
-    MAX_RATE_LIMIT_RETRIES,
     MAX_RETRIES,
+    RATE_LIMIT_RETRY_DELAY,
     WORKERS,
     DataStructureError,
     DownloadTask,
     EnergyDownloader,
     MissingDataError,
-    RateLimitError,
 )
 
 URL_ROOT = "https://sipub.api.coordinador.cl/"
@@ -126,9 +125,9 @@ class CenDownloader(EnergyDownloader):
         Raises:
             ConnectionError/Timeout: If API issue occurred with connection or timeout or if
                 not all available data was downloaded.
-            HTTPError: If request response is not 200 or if the response is 500 (internal
-                error) despite reducing the page size number several times.
-            RateLimitError: If API rate limit has been exceeded.
+            HTTPError: If request response is not 200, if the response is 500 (internal
+                error) despite reducing the page size number several times or if the API
+                rate limit has been reached and the full task requires retrying.
             MissingDataError: If the requested data is an empty list or the loaded df empty.
             DataStructureError: If the CEN structure changed causing response parsing fail or
                 relevant columns to be missed (this will cause the entire run to be killed).
@@ -170,16 +169,19 @@ class CenDownloader(EnergyDownloader):
 
             if status_code != 200:
                 if status_code == 429:
-                    if attempt_ratelimit < MAX_RATE_LIMIT_RETRIES:  # retry 6 times
-                        logger.warning("Rate limit reached. Sleeping 15 seconds...")
-                        time.sleep(15)
+                    if attempt_ratelimit < MAX_RETRIES:  # retry 3 times
+                        logger.warning(
+                            f"CEN API rate limit reached (429) on page {params['page']}. "
+                            f"Sleeping {RATE_LIMIT_RETRY_DELAY} seconds..."
+                        )
+                        time.sleep(RATE_LIMIT_RETRY_DELAY)
                         attempt_ratelimit += 1
                         continue
                     else:
-                        raise RateLimitError(
-                            "API rate limit has been exceeded and waiting 1 min "
-                            "doesn't help. You should wait for a brief cool-down "
-                            "period (CEN doesn't specify a duration), then retry!"
+                        raise exceptions.HTTPError(
+                            f"CEN API rate limit (429) persists for {task.date}: "
+                            f"{response.text[:200]}. Propagating for further handling...",
+                            response=response,
                         )
 
                 if status_code == 500:
@@ -200,7 +202,8 @@ class CenDownloader(EnergyDownloader):
                         )
 
                 raise exceptions.HTTPError(
-                    f"API request failed: {status_code} - {response.text}"
+                    f"API request failed: {status_code} - {response.text}",
+                    response=response,
                 )
 
             try:

--- a/rbc/energy/eat/downloader.py
+++ b/rbc/energy/eat/downloader.py
@@ -98,9 +98,7 @@ class EatDownloader(EnergyDownloader):
         df = load_df_from_file(url, index_col=False)
 
         if df.empty:
-            raise MissingDataError(
-                f"No energy data available for {task.year}-{task.month}. Skipping..."
-            )
+            raise MissingDataError("No energy data available!")
 
         df.columns = [c.strip().lower() for c in df.columns]
         missing_cols = [c for c in EXPECTED_COLS if c not in df.columns]

--- a/rbc/energy/eia/downloader.py
+++ b/rbc/energy/eia/downloader.py
@@ -13,13 +13,13 @@ from loguru import logger
 from requests import exceptions
 
 from rbc.energy.utils import (
-    MAX_RATE_LIMIT_RETRIES,
+    MAX_RETRIES,
+    RATE_LIMIT_RETRY_DELAY,
     WORKERS,
     DataStructureError,
     DownloadTask,
     EnergyDownloader,
     MissingDataError,
-    RateLimitError,
 )
 
 URL_ROOT = "https://api.eia.gov/v2/"
@@ -104,8 +104,8 @@ class EiaDownloader(EnergyDownloader):
         Raises:
             ConnectionError/Timeout: If API issue occurred with connection or timeout or if
                 not all available data was downloaded.
-            HTTPError: If request response is not 200.
-            RateLimitError: If API rate limit has been exceeded.
+            HTTPError: If request response is not 200 or if the API rate limit has been
+                reached and the full task requires retrying.
             DataStructureError: If the EIA structure changed causing response parsing fail or
                 relevant columns to be missed (this will cause the entire run to be killed).
             MissingDataError: If the loaded dataframe is empty.
@@ -125,7 +125,7 @@ class EiaDownloader(EnergyDownloader):
             "length": 5000,  # This is the maximum possible to get at one time!
         }
 
-        all_data = []
+        all_data: list = []
         total_available = None
         limit = 5000
         attempt = 0
@@ -138,20 +138,25 @@ class EiaDownloader(EnergyDownloader):
 
             if response.status_code != 200:
                 if response.status_code == 429:
-                    if attempt < MAX_RATE_LIMIT_RETRIES:  # retry 6 times (= 1 min)
-                        logger.warning("Rate limit reached. Sleeping 10 seconds...")
-                        time.sleep(10)
+                    if attempt < MAX_RETRIES:  # retry 3 times
+                        logger.warning(
+                            f"EIA API rate limit reached (429) after retrieving "
+                            f"{len(all_data)} data elements. "
+                            f"Sleeping {RATE_LIMIT_RETRY_DELAY} seconds..."
+                        )
+                        time.sleep(RATE_LIMIT_RETRY_DELAY)
                         attempt += 1
                         continue
                     else:
-                        raise RateLimitError(
-                            "API rate limit has been exceeded and waiting 1 min "
-                            "doesn't help. You should wait for a brief cool-down "
-                            "period (EIA doesn't specify a duration), then retry!"
+                        raise exceptions.HTTPError(
+                            f"EIA API rate limit (429) persists for {task.date}: "
+                            f"{response.text[:200]}. Propagating for further handling...",
+                            response=response,
                         )
 
                 raise exceptions.HTTPError(
-                    f"API request failed: {response.status_code} - {response.text}"
+                    f"API request failed: {response.status_code} - {response.text}",
+                    response=response,
                 )
 
             try:

--- a/rbc/energy/eia/downloader.py
+++ b/rbc/energy/eia/downloader.py
@@ -195,7 +195,7 @@ class EiaDownloader(EnergyDownloader):
 
         df_gen = pd.DataFrame(all_data)
         if df_gen.empty:
-            raise MissingDataError("No energy data available! Skipping...")
+            raise MissingDataError("No energy data available!")
 
         missing_cols = [c for c in EXPECTED_COLS if c not in df_gen.columns]
         if missing_cols:

--- a/rbc/energy/entsoe/downloader.py
+++ b/rbc/energy/entsoe/downloader.py
@@ -146,7 +146,7 @@ class EntsoeDownloader(EnergyDownloader):
             raise ConnectionError("API call did not return requested data!")
 
         if not result:
-            raise MissingDataError("No energy data available! Skipping...")
+            raise MissingDataError("No energy data available!")
 
         records = extract_records(result)  # turns into list of dicts
         records = add_timestamps(records)  # adds key 'timestamp' to each dict

--- a/rbc/energy/epias/downloader.py
+++ b/rbc/energy/epias/downloader.py
@@ -121,7 +121,7 @@ class EpiasDownloader(EnergyDownloader):
             "pp-list-for-date-range", start_date=start, end_date=end
         )
         if df_pp.empty:
-            raise MissingDataError("No power plant data available! Skipping...")
+            raise MissingDataError("No power plant data available!")
 
         # get generation data in batches
         num_batches = math.ceil(len(df_pp) / 1000)  # max allowed batch size = 1000
@@ -134,7 +134,7 @@ class EpiasDownloader(EnergyDownloader):
 
         df_gen = pd.concat(gen_data)
         if df_gen.empty:
-            raise MissingDataError("No energy data available! Skipping...")
+            raise MissingDataError("No energy data available!")
 
         missing_cols = [c for c in EXPECTED_COLS if c not in df_gen.columns]
         if missing_cols:

--- a/rbc/energy/epias/downloader.py
+++ b/rbc/energy/epias/downloader.py
@@ -145,6 +145,9 @@ class EpiasDownloader(EnergyDownloader):
 
         return df_gen
 
+    # --------------------------------------------
+    # Helper methods
+    # --------------------------------------------
     def _epias_call(self, *args, **kwargs) -> Any:
         """Wrap all eptr calls in order to transform any potential errors into HTTPError.
 

--- a/rbc/energy/epias/downloader.py
+++ b/rbc/energy/epias/downloader.py
@@ -4,22 +4,26 @@ Remote API access of EPIAS Platform using the eptr2 package.
 """
 
 import math
+import re
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
+from typing import Any
 
 import numpy as np
 import pandas as pd
+import requests
 from eptr2 import EPTR2
 from loguru import logger
 
 from rbc.energy.utils import (
-    WORKERS,
     DataStructureError,
     DownloadTask,
     EnergyDownloader,
     InvalidError,
     MissingDataError,
 )
+
+WORKERS = 2  # needs to be reduced to prevent repeated throttling errors
 
 MIN_YEAR = 2013
 EXPECTED_COLS = [
@@ -113,7 +117,9 @@ class EpiasDownloader(EnergyDownloader):
         start = task.date
         end = (task.dt + pd.Timedelta(days=1)).strftime("%Y-%m-%d")
 
-        df_pp = self.eptr.call("pp-list-for-date-range", start_date=start, end_date=end)
+        df_pp = self._epias_call(
+            "pp-list-for-date-range", start_date=start, end_date=end
+        )
         if df_pp.empty:
             raise MissingDataError("No power plant data available! Skipping...")
 
@@ -122,7 +128,7 @@ class EpiasDownloader(EnergyDownloader):
         batches = np.array_split(df_pp["id"].values, num_batches)
 
         gen_data = [
-            self.eptr.call("rt-gen-bulk", date=start, pp_ids=b.tolist())
+            self._epias_call("rt-gen-bulk", date=start, pp_ids=b.tolist())
             for b in batches
         ]
 
@@ -138,3 +144,59 @@ class EpiasDownloader(EnergyDownloader):
             )
 
         return df_gen
+
+    def _epias_call(self, *args, **kwargs) -> Any:
+        """Wrap all eptr calls in order to transform any potential errors into HTTPError.
+
+        Eptr (EPIAS API) errors are returned in strange formats that the parent class can't
+        identify correctly. The two common examples include:
+        - Request failed with status code: 429
+            [d0d17...],
+            [429],
+            [Because of reaching Throttling limits(80 req/min) for specified gateway,
+             message is BLOCKED!]
+        - Request failed with status code: 401
+            {
+              "status" : "401 UNAUTHORIZED",
+              "correlationId" : "7b46b...",
+              ...
+              "errors" : [ {
+                "errorCode" : "AUTH009",
+                "errorMessage" : "Güvenlik bilgisi(TGT) hatalı!"
+              } ],
+              "body" : { }
+            }
+
+        Args:
+            args: Required arguments for eptr call.
+            kwargs: Additional arguments for eptr call.
+
+        Returns:
+            Any: eptr.call output
+
+        Raises:
+            HTTPError: All identifyable errors that occur during eptr calls
+                or reraises the original error if the status code can't be extracted.
+        """
+        try:
+            return self.eptr.call(*args, **kwargs)
+
+        except Exception as e:
+            # find the code via matching ('status code: XXX' OR '[XXX]' OR '"status" : "XXX"')
+            msg = str(e)
+            match = re.search(
+                r'status code[:\s]+(\d{3})|\[(\d{3})\]|"status"\s*:\s*"(\d{3})', msg
+            )
+            code = int(next(g for g in match.groups() if g)) if match else None
+
+            if code is not None:
+                resp = requests.Response()
+                resp.status_code = code
+                resp.reason = msg[:200]
+
+                raise requests.exceptions.HTTPError(
+                    f"EPIAS API error {code}: {msg[:200]}", response=resp
+                ) from e
+
+            logger.error(f"Unrecognised EPIAS error: {msg[:300]}")
+            raise  # propagate unknown error to parent class

--- a/rbc/energy/ieso/downloader.py
+++ b/rbc/energy/ieso/downloader.py
@@ -106,9 +106,7 @@ class IesoDownloader(EnergyDownloader):
             df = self._get_from_new_source(task)
 
         if df.empty:
-            raise MissingDataError(
-                f"No energy data available for {task.year}-{task.month}. Skipping..."
-            )
+            raise MissingDataError("No energy data available!")
 
         missing_cols = [c for c in EXPECTED_COLS if c not in df.columns]
         if missing_cols:

--- a/rbc/energy/ons/downloader.py
+++ b/rbc/energy/ons/downloader.py
@@ -107,9 +107,7 @@ class OnsDownloader(EnergyDownloader):
             df = self._get_from_monthly_csv(task)
 
         if df.empty:
-            raise MissingDataError(
-                f"No energy data available for {task.year}-{task.month}. Skipping..."
-            )
+            raise MissingDataError("No energy data available (after month filter)!")
 
         missing_cols = [c for c in EXPECTED_COLS if c not in df.columns]
         if missing_cols:

--- a/rbc/energy/rei/downloader.py
+++ b/rbc/energy/rei/downloader.py
@@ -108,7 +108,7 @@ class ReiDownloader(EnergyDownloader):
 
         if json_year < MIN_YEAR:
             raise MissingDataError(
-                f"No energy data available (it's before {MIN_YEAR}-4). Skipping..."
+                f"No energy data available (it's before {MIN_YEAR}-4)!"
             )
 
         # load yearly JSON file
@@ -123,9 +123,7 @@ class ReiDownloader(EnergyDownloader):
         matching_indices = month_mask.nonzero()[0]
 
         if len(matching_indices) == 0:
-            raise MissingDataError(
-                f"No energy data found for month {task.year}-{task.month}. Skipping..."
-            )
+            raise MissingDataError("No energy data available (after month filter)!")
 
         start_idx = matching_indices[0]
         end_idx = matching_indices[-1] + 1  # +1 because Python slicing is exclusive

--- a/rbc/energy/rei/downloader.py
+++ b/rbc/energy/rei/downloader.py
@@ -128,12 +128,6 @@ class ReiDownloader(EnergyDownloader):
         start_idx = matching_indices[0]
         end_idx = matching_indices[-1] + 1  # +1 because Python slicing is exclusive
 
-        if len(matching_indices) != (end_idx - start_idx):
-            logger.warning(
-                f"REI timestamp continuity issue detected for {task.year}-{task.month}: "
-                f"{len(matching_indices)} timestamps in range of {end_idx - start_idx}!"
-            )
-
         # build monthly dict by slicing all arrays from the cached yearly data
         dict_month = {"epochs": dict_year["epochs"][start_idx:end_idx]}
 

--- a/rbc/energy/utils.py
+++ b/rbc/energy/utils.py
@@ -26,6 +26,7 @@ ASYNC_WORKERS = 10
 MAX_RETRIES = 3
 RETRY_DELAY = 5
 MAX_RATE_LIMIT_RETRIES = 6
+RATE_LIMIT_RETRY_DELAY = 15
 
 RETRY_ERRORS = (
     # requests / urllib3 (used by requests.get/head)
@@ -257,7 +258,10 @@ class EnergyDownloader(ABC):
         Returns:
             int: Status of the download (1 if successful, 0 if unsuccessful).
         """
-        for attempt in range(1, MAX_RETRIES + 1):
+        retry = 1
+        retry_ratelimit = 1
+
+        while True:
             try:
                 data = self._get_task_data(task=task)
                 self._save_task_data(task, data)
@@ -278,30 +282,58 @@ class EnergyDownloader(ABC):
             except self.RETRY_ERRORS as e:  # handle access failures
                 code = self._get_status_code(e)
 
-                if code:
-                    # 1. permanent missing data
-                    if code == 404:
-                        logger.warning(
-                            f"Data for '{task.identifier}' not found (404). Skipping."
-                        )
-                        return 1
-                    # 2. permanent client errors (400-499, except rate limits 429)
-                    if 400 <= code < 500 and code != 429:
-                        logger.error(
-                            f"Permanent error {code} for '{task.identifier}'. Skipping."
-                        )
-                        return 1
-
-                # 3. everything else (500s, Timeouts, 429s) -> Retry
-                if attempt < MAX_RETRIES:
-                    time.sleep(RETRY_DELAY)
-                else:
-                    logger.critical(
-                        f"Failed '{task.identifier}' after {MAX_RETRIES} attempts: {e}"
+                # 1. permanent missing data
+                if code == 404:
+                    logger.error(
+                        f"Error 404 for '{task.identifier}': Missing data. Skipping."
                     )
-                    return 0
+                    return 1
 
-        return 1  # pragma: no cover
+                # 2. auth-under-load / throttling errors -> patient retry, then leave as 0
+                if code in (401, 429):
+                    if retry_ratelimit <= MAX_RATE_LIMIT_RETRIES:
+                        wait = int(RATE_LIMIT_RETRY_DELAY * retry_ratelimit**1.5)
+                        logger.warning(
+                            f"Limit {code} for '{task.identifier}' (rate-limit attempt "
+                            f"{retry_ratelimit}/{MAX_RATE_LIMIT_RETRIES}). "
+                            f"Sleeping {wait}s."
+                        )
+                        retry_ratelimit += 1
+                        time.sleep(wait)
+                        continue
+
+                    logger.critical(
+                        f"Failed '{task.identifier}' after {MAX_RATE_LIMIT_RETRIES} "
+                        f"retry attempts: Rate/auth limit {code} persists. Retry in "
+                        f"next rerun...\n{e}"
+                    )
+                    return 0  # rerun next time!
+
+                # 3. permanent client errors (except 401 & rate limits 429)
+                if code is not None and 400 <= code < 500:
+                    logger.error(
+                        f"Client error {code} for '{task.identifier}'. Skipping."
+                    )
+                    return 1
+
+                # 4. everything else (500s/timeout/connection) -> classic retry, then leave 0
+                if retry <= MAX_RETRIES:
+                    logger.warning(
+                        f"Retry with {code} for '{task.identifier}' (attempt "
+                        f"{retry}/{MAX_RETRIES}). "
+                        f"Sleeping {RETRY_DELAY}s."
+                    )
+                    retry += 1
+                    time.sleep(RETRY_DELAY)
+                    continue
+
+                logger.critical(
+                    f"Failed '{task.identifier}' after {MAX_RETRIES} attempts: "
+                    f"500/Timeout error {code} persists. Retry in next rerun...\n{e}"
+                )
+                return 0  # rerun next time!
+
+        return 0  # pragma: no cover
 
     @abstractmethod
     def _get_task_data(self, task: DownloadTask) -> pd.DataFrame | dict:

--- a/rbc/energy/utils.py
+++ b/rbc/energy/utils.py
@@ -258,8 +258,8 @@ class EnergyDownloader(ABC):
         Returns:
             int: Status of the download (1 if successful, 0 if unsuccessful).
         """
-        retry = 1
-        retry_ratelimit = 1
+        reruns = 0  # num of task reruns (retries) due to error
+        reruns_ratelimit = 0  # num of task reruns (retries) due to rate limits
 
         while True:
             try:
@@ -291,14 +291,14 @@ class EnergyDownloader(ABC):
 
                 # 2. auth-under-load / throttling errors -> patient retry, then leave as 0
                 if code in (401, 429):
-                    if retry_ratelimit <= MAX_RATE_LIMIT_RETRIES:
-                        wait = int(RATE_LIMIT_RETRY_DELAY * retry_ratelimit**1.5)
+                    if reruns_ratelimit < MAX_RATE_LIMIT_RETRIES:
+                        reruns_ratelimit += 1
+                        wait = int(RATE_LIMIT_RETRY_DELAY * reruns_ratelimit**1.5)
                         logger.warning(
                             f"Limit {code} for '{task.identifier}' (rate-limit attempt "
-                            f"{retry_ratelimit}/{MAX_RATE_LIMIT_RETRIES}). "
+                            f"{reruns_ratelimit}/{MAX_RATE_LIMIT_RETRIES}). "
                             f"Sleeping {wait}s."
                         )
-                        retry_ratelimit += 1
                         time.sleep(wait)
                         continue
 
@@ -317,19 +317,18 @@ class EnergyDownloader(ABC):
                     return 1
 
                 # 4. everything else (500s/timeout/connection) -> classic retry, then leave 0
-                if retry <= MAX_RETRIES:
+                if reruns < MAX_RETRIES:
+                    reruns += 1
                     logger.warning(
-                        f"Retry with {code} for '{task.identifier}' (attempt "
-                        f"{retry}/{MAX_RETRIES}). "
-                        f"Sleeping {RETRY_DELAY}s."
+                        f"Retry due to error (code: {code}) for '{task.identifier}' "
+                        f"(attempt {reruns}/{MAX_RETRIES}). Sleeping {RETRY_DELAY}s."
                     )
-                    retry += 1
                     time.sleep(RETRY_DELAY)
                     continue
 
                 logger.critical(
                     f"Failed '{task.identifier}' after {MAX_RETRIES} attempts: "
-                    f"500/Timeout error {code} persists. Retry in next rerun...\n{e}"
+                    f"500/Timeout error (code {code}) persists. Retry in next rerun...\n{e}"
                 )
                 return 0  # rerun next time!
 

--- a/rbc/energy/utils.py
+++ b/rbc/energy/utils.py
@@ -276,10 +276,10 @@ class EnergyDownloader(ABC):
                 error_msg = f"MissingDataError for '{task_id}': {e}"
 
                 if task.dt.year == pd.Timestamp.now().year:
-                    logger.error(f"{error_msg}. Try task again in future...")
+                    logger.error(f"{error_msg} Retry again in the future...")
                     return 0  # current year task -> might become available later!
 
-                logger.error(f"{error_msg}. Skipping.")
+                logger.error(f"{error_msg} Skipping.")
                 return 1
 
             except self.RETRY_ERRORS as e:  # handle access failures

--- a/rbc/energy/utils.py
+++ b/rbc/energy/utils.py
@@ -260,6 +260,7 @@ class EnergyDownloader(ABC):
         """
         reruns = 0  # num of task reruns (retries) due to error
         reruns_ratelimit = 0  # num of task reruns (retries) due to rate limits
+        task_id = task.identifier
 
         while True:
             try:
@@ -272,12 +273,14 @@ class EnergyDownloader(ABC):
                 os._exit(1)
 
             except MissingDataError as e:  # handle missing data for task
-                logger.error(f"Missing data for '{task.identifier}': {e}")
+                error_msg = f"MissingDataError for '{task_id}': {e}"
 
                 if task.dt.year == pd.Timestamp.now().year:
+                    logger.error(f"{error_msg}. Try task again in future...")
                     return 0  # current year task -> might become available later!
 
-                return 1  # skip task
+                logger.error(f"{error_msg}. Skipping.")
+                return 1
 
             except self.RETRY_ERRORS as e:  # handle access failures
                 code = self._get_status_code(e)
@@ -285,8 +288,9 @@ class EnergyDownloader(ABC):
                 # 1. permanent missing data
                 if code == 404:
                     logger.error(
-                        f"Error 404 for '{task.identifier}': Missing data. Skipping."
+                        f"Error '404' for '{task_id}': Missing data. Skipping."
                     )
+                    logger.debug(f"Error details: {e}")
                     return 1
 
                 # 2. auth-under-load / throttling errors -> patient retry, then leave as 0
@@ -295,41 +299,42 @@ class EnergyDownloader(ABC):
                         reruns_ratelimit += 1
                         wait = int(RATE_LIMIT_RETRY_DELAY * reruns_ratelimit**1.5)
                         logger.warning(
-                            f"Limit {code} for '{task.identifier}' (rate-limit attempt "
-                            f"{reruns_ratelimit}/{MAX_RATE_LIMIT_RETRIES}). "
-                            f"Sleeping {wait}s."
+                            f"Rate limit '{code}' reached for '{task_id}' (attempt "
+                            f"{reruns_ratelimit}/{MAX_RATE_LIMIT_RETRIES}). Sleeping {wait}s."
                         )
                         time.sleep(wait)
                         continue
 
-                    logger.critical(
-                        f"Failed '{task.identifier}' after {MAX_RATE_LIMIT_RETRIES} "
-                        f"retry attempts: Rate/auth limit {code} persists. Retry in "
-                        f"next rerun...\n{e}"
+                    logger.error(
+                        f"Error '{code}' for '{task_id}': persisting rate limit issue after "
+                        f"{MAX_RATE_LIMIT_RETRIES} retries. Set to be retried next run..."
                     )
+                    logger.debug(f"Error details: {e}")
                     return 0  # rerun next time!
 
                 # 3. permanent client errors (except 401 & rate limits 429)
                 if code is not None and 400 <= code < 500:
                     logger.error(
-                        f"Client error {code} for '{task.identifier}'. Skipping."
+                        f"Error '{code}' for '{task_id}': permanent client issue. Skipping."
                     )
+                    logger.debug(f"Error details: {e}")
                     return 1
 
                 # 4. everything else (500s/timeout/connection) -> classic retry, then leave 0
                 if reruns < MAX_RETRIES:
                     reruns += 1
                     logger.warning(
-                        f"Retry due to error (code: {code}) for '{task.identifier}' "
+                        f"Retryable error '{code}' for '{task_id}' "
                         f"(attempt {reruns}/{MAX_RETRIES}). Sleeping {RETRY_DELAY}s."
                     )
                     time.sleep(RETRY_DELAY)
                     continue
 
-                logger.critical(
-                    f"Failed '{task.identifier}' after {MAX_RETRIES} attempts: "
-                    f"500/Timeout error (code {code}) persists. Retry in next rerun...\n{e}"
+                logger.error(
+                    f"Error '{code}' for '{task_id}': persisting 500s/Timeout/Connection "
+                    f"issue after {MAX_RETRIES} retries. Set to be retried next run..."
                 )
+                logger.debug(f"Error details: {e}")
                 return 0  # rerun next time!
 
         return 0  # pragma: no cover

--- a/tests/config/test_loader.py
+++ b/tests/config/test_loader.py
@@ -12,127 +12,167 @@ from rbc.config.schema import SCHEMA_REGISTRY
 # ----------------------------------
 # Tests
 # ----------------------------------
-@pytest.mark.parametrize("source", list(SCHEMA_REGISTRY.keys()))
-def test_load_config(tmp_configs_dir: Path, source: str) -> None:
-    """Happy path for "load_config" function.
+class TestLoadConfig:
+    """Tests for the "load_config" function."""
 
-    Check that "load_config" loads a YAML config for a source correctly.
+    @pytest.mark.parametrize("source", list(SCHEMA_REGISTRY.keys()))
+    def test_load_config(self, tmp_configs_dir: Path, source: str) -> None:
+        """Happy path for "load_config" function.
 
-    Args:
-        tmp_configs_dir (Path): Path to the temporary config directory.
-        source (str): Name of the data source (input to "load_config").
-    """
-    received_cfg_obj = loader.load_config(source=source, configs_dir=tmp_configs_dir)
-    assert received_cfg_obj.source == source
+        Check that "load_config" loads a YAML config for a source correctly.
 
-
-@pytest.mark.parametrize("source", list(SCHEMA_REGISTRY.keys()))
-def test_load_config_with_overrides(
-    tmp_configs_dir: Path, source_configs: dict, source: str
-) -> None:
-    """Happy path for "load_config" function.
-
-    Check that "load_config" loads a YAML config for a source correctly
-    with overrides.
-
-    Args:
-        tmp_configs_dir (Path): Path to the temporary config directory.
-        source_configs (dict): Dictionary of source configurations.
-        source (str): Name of the data source (input to "load_config").
-    """
-    assert source in source_configs, f"Missing test cfg for source '{source}'"
-    cfg_dict = source_configs[source]
-    overrides = {
-        k: ({sub_k: "override" for sub_k in v} if isinstance(v, dict) else "override")
-        for k, v in cfg_dict.items()
-    }
-
-    with patch("rbc.config.schema.Path.mkdir"):
+        Args:
+            tmp_configs_dir (Path): Path to the temporary config directory.
+            source (str): Name of the data source (input to "load_config").
+        """
         received_cfg_obj = loader.load_config(
-            source=source, configs_dir=tmp_configs_dir, overrides=overrides
+            source=source, configs_dir=tmp_configs_dir
         )
+        assert received_cfg_obj.source == source
 
-    received_cfg_dict = received_cfg_obj.model_dump(mode="json")
+    @pytest.mark.parametrize("source", list(SCHEMA_REGISTRY.keys()))
+    def test_load_config_with_overrides(
+        self, tmp_configs_dir: Path, source_configs: dict, source: str
+    ) -> None:
+        """Happy path for "load_config" function.
 
-    for k, expected_v in overrides.items():
-        if isinstance(expected_v, dict):
-            for sub_k, sub_v in expected_v.items():
-                assert received_cfg_dict[k][sub_k] == sub_v
-        else:
-            assert received_cfg_dict[k] == expected_v
+        Check that "load_config" loads a YAML config for a source correctly
+        with overrides.
 
+        Args:
+            tmp_configs_dir (Path): Path to the temporary config directory.
+            source_configs (dict): Dictionary of source configurations.
+            source (str): Name of the data source (input to "load_config").
+        """
+        assert source in source_configs, f"Missing test cfg for source '{source}'"
+        cfg_dict = source_configs[source]
+        overrides = {
+            k: (
+                {sub_k: "override" for sub_k in v}
+                if isinstance(v, dict)
+                else "override"
+            )
+            for k, v in cfg_dict.items()
+        }
 
-def test_load_config_missing_file(tmp_configs_dir: Path) -> None:
-    """Failure path for "load_config" function when YAML is missing.
+        with patch("rbc.config.schema.Path.mkdir"):
+            received_cfg_obj = loader.load_config(
+                source=source, configs_dir=tmp_configs_dir, overrides=overrides
+            )
 
-    Args:
-        tmp_configs_dir (Path): Path to the temporary config directory.
-    """
-    fake_cfg_path = Path(tmp_configs_dir, "fake.yaml")
-    fake_cfg_path.unlink(missing_ok=True)
+        received_cfg_dict = received_cfg_obj.model_dump(mode="json")
 
-    with pytest.raises(ValueError, match="missing"):
-        loader.load_config(source="fake", configs_dir=tmp_configs_dir)
+        for k, expected_v in overrides.items():
+            if isinstance(expected_v, dict):
+                for sub_k, sub_v in expected_v.items():
+                    assert received_cfg_dict[k][sub_k] == sub_v
+            else:
+                assert received_cfg_dict[k] == expected_v
 
+    def test_load_config_missing_file(self, tmp_configs_dir: Path) -> None:
+        """Failure path for "load_config" function when YAML is missing.
 
-def test_load_config_unknown_source(tmp_configs_dir: Path) -> None:
-    """Failure path for "load_config" function when data source is not in registry.
+        Args:
+            tmp_configs_dir (Path): Path to the temporary config directory.
+        """
+        fake_cfg_path = Path(tmp_configs_dir, "fake.yaml")
+        fake_cfg_path.unlink(missing_ok=True)
 
-    Args:
-        tmp_configs_dir (Path): Path to the temporary config directory.
-    """
-    unknown_cfg_path = Path(tmp_configs_dir, "unknown.yaml")
-    unknown_cfg_path.write_text("")
+        with pytest.raises(ValueError, match="missing"):
+            loader.load_config(source="fake", configs_dir=tmp_configs_dir)
 
-    with pytest.raises(ValueError, match="Unknown source"):
-        loader.load_config(source="unknown", configs_dir=tmp_configs_dir)
+    def test_load_config_unknown_source(self, tmp_configs_dir: Path) -> None:
+        """Failure path for "load_config" function when data source is not in registry.
+
+        Args:
+            tmp_configs_dir (Path): Path to the temporary config directory.
+        """
+        unknown_cfg_path = Path(tmp_configs_dir, "unknown.yaml")
+        unknown_cfg_path.write_text("")
+
+        with pytest.raises(ValueError, match="Unknown source"):
+            loader.load_config(source="unknown", configs_dir=tmp_configs_dir)
 
 
 # ----------------------------------
 # Tests - Helper functions
 # ----------------------------------
-@pytest.mark.parametrize(
-    "inputs, expected_outputs",
-    [
-        ([], {}),
-        (["a=1"], {"a": "1"}),
-        (["a.b=x"], {"a": {"b": "x"}}),
-        (["a.b=x", "c.d=y"], {"a": {"b": "x"}, "c": {"d": "y"}}),
-        (["a.b.c=deep"], {"a": {"b": {"c": "deep"}}}),
-    ],
-)
-def test_parse_key_value_pairs(inputs: list, expected_outputs: dict) -> None:
-    """Happy path for "parse_key_value_pairs" function.
+class TestUpdateConfig:
+    """Tests for the "update_config" helper function."""
 
-    Args:
-        inputs (list): List of pairs to parse.
-        expected_outputs (dict): Dictionary of expected outputs pairs.
-    """
-    returned_outputs = loader.parse_key_value_pairs(inputs)
-    assert type(returned_outputs) is dict
-    assert expected_outputs == returned_outputs
+    @pytest.mark.parametrize(
+        "input_cfg, updates, expected_cfg",
+        [
+            ({"a": 1}, {"a": 2}, {"a": 2}),
+            ({"a": 1}, {"a": "none"}, {"a": None}),
+            ({"a": {"b": 1}}, {"a": {"b": 2}}, {"a": {"b": 2}}),
+        ],
+        ids=["standard_update", "adapt_none", "nested_update"],
+    )
+    def test_update_config(
+        self, input_cfg: dict, updates: dict, expected_cfg: dict
+    ) -> None:
+        """Happy path for "update_config" function.
+
+        Args:
+            input_cfg (dict): Dictionary of exemplary input config.
+            updates (dict): Dictionary of updates.
+            expected_cfg (dict): Dictionary of expected updated config.
+        """
+        assert expected_cfg == loader.update_config(input_cfg, updates)
 
 
-@pytest.mark.parametrize(
-    "invalid_input, msg",
-    [
-        (["no_equals_sign"], "Invalid format"),
-        (
-            ["a=1", "a.b=2"],
-            "Conflict at 'a': cannot overwrite key",
-        ),  # Scalar turned dict
-        (["a.b=2", "a=1"], "Conflict at 'a': cannot overwrite a"),  # Dict turned scalar
-    ],
-)
-def test_parse_key_value_pairs_invalid_input(invalid_input: list, msg: str) -> None:
-    """Failure path for "parse_key_value_pairs" function when the input is invalid.
+class TestParseKeyValuePairs:
+    """Tests for the "parse_key_value_pairs" helper function."""
 
-    Inputs are invalid if either the format isn't correct (no "=") or there is a
-    conflict because key combinations were provided that can't overwrite one another.
+    @pytest.mark.parametrize(
+        "inputs, expected_outputs",
+        [
+            ([], {}),
+            (["a=1"], {"a": "1"}),
+            (["a.b=x"], {"a": {"b": "x"}}),
+            (["a.b=x", "c.d=y"], {"a": {"b": "x"}, "c": {"d": "y"}}),
+            (["a.b.c=deep"], {"a": {"b": {"c": "deep"}}}),
+        ],
+        ids=[
+            "none",
+            "a_pair",
+            "a_nested_pair",
+            "two_nested_pairs",
+            "a_deep_nested_pair",
+        ],
+    )
+    def test_parse_key_value_pairs(self, inputs: list, expected_outputs: dict) -> None:
+        """Happy path for "parse_key_value_pairs" function.
 
-    Args:
-        invalid_input (list): List of invalid pairs to parse.
-        msg (str): Message describing the error.
-    """
-    with pytest.raises(argparse.ArgumentTypeError, match=msg):
-        loader.parse_key_value_pairs(invalid_input)
+        Args:
+            inputs (list): List of pairs to parse.
+            expected_outputs (dict): Dictionary of expected outputs pairs.
+        """
+        returned_outputs = loader.parse_key_value_pairs(inputs)
+        assert isinstance(returned_outputs, dict)
+        assert expected_outputs == returned_outputs
+
+    @pytest.mark.parametrize(
+        "invalid_input, msg",
+        [
+            (["no_equals_sign"], "Invalid format"),
+            (["a=1", "a.b=2"], "Conflict at 'a': cannot overwrite key"),
+            (["a.b=2", "a=1"], "Conflict at 'a': cannot overwrite a"),
+        ],
+        ids=["no_equal", "variable_int_to_dict", "variable_dict_to_int"],
+    )
+    def test_parse_key_value_pairs_invalid_input(
+        self, invalid_input: list, msg: str
+    ) -> None:
+        """Failure path for "parse_key_value_pairs" function when the input is invalid.
+
+        Inputs are invalid if either the format isn't correct (no "=") or there is a
+        conflict because key combinations were provided that can't overwrite one another.
+
+        Args:
+            invalid_input (list): List of invalid pairs to parse.
+            msg (str): Message describing the error.
+        """
+        with pytest.raises(argparse.ArgumentTypeError, match=msg):
+            loader.parse_key_value_pairs(invalid_input)

--- a/tests/config/test_loader.py
+++ b/tests/config/test_loader.py
@@ -78,8 +78,8 @@ class TestLoadConfig:
         fake_cfg_path = Path(tmp_configs_dir, "fake.yaml")
         fake_cfg_path.unlink(missing_ok=True)
 
-        with pytest.raises(ValueError, match="missing"):
-            loader.load_config(source="fake", configs_dir=tmp_configs_dir)
+        with pytest.raises(ValueError, match="Source 'fake' is missing"):
+            loader.load_config(source="fake", configs_dir=fake_cfg_path)
 
     def test_load_config_unknown_source(self, tmp_configs_dir: Path) -> None:
         """Failure path for "load_config" function when data source is not in registry.

--- a/tests/config/test_schema.py
+++ b/tests/config/test_schema.py
@@ -1,12 +1,98 @@
 # tests/config/test_schema.py
 from pathlib import Path
+from typing import Any
+from unittest.mock import patch
 
 import pytest
 from pydantic import ValidationError
 
-from rbc.config.schema import SCHEMA_REGISTRY
+from rbc.config.schema import (
+    SCHEMA_REGISTRY,
+    AccessAPI,
+    AccessValidation,
+    Paths,
+    PathValidation,
+)
 
 
+# -------------------------------------------------
+# Tests - Validator schemas
+# -------------------------------------------------
+class TestPathValidation:
+    """Tests for the "PathValidation" validator class."""
+
+    def test_check_paths(self) -> None:
+        """Happy path for "PathValidation" class."""
+        with patch("rbc.config.schema.Path.mkdir") as mock_mkdir:
+            obj = Paths(dst_dir_raw="/tmp/str")
+            config = PathValidation.check_paths(obj)
+
+            assert config.dst_dir_raw == Path("/tmp/str")
+            assert mock_mkdir.call_count == 1
+
+    @pytest.mark.filterwarnings("ignore:Pydantic serializer warnings")
+    def test_check_paths_ignores_non_string(self) -> None:
+        """Happy path for "PathValidation" class, where non-str/path values are ignored."""
+        with patch("rbc.config.schema.Path.mkdir") as mock_mkdir:
+            obj = Paths.model_construct(dst_dir_raw=42)
+            PathValidation.check_paths(obj)
+
+            assert mock_mkdir.call_count == 0  # skips int, does not run mkdir
+
+    def test_check_paths_permission_error(self) -> None:
+        """Failure path for "PathValidation" class, where permission/OS issues cause error."""
+        with patch("rbc.config.schema.Path.mkdir") as mock_mkdir:
+            mock_mkdir.side_effect = PermissionError("Permission denied")
+            obj = Paths(dst_dir_raw="/root/secret")
+
+            with pytest.raises(ValueError, match="not writable or cannot be created"):
+                PathValidation.check_paths(obj)
+
+
+class TestAccessValidation:
+    """Tests for the "AccessValidation" validator class."""
+
+    @pytest.mark.parametrize("access_input", ["real_api_key", 42])
+    @pytest.mark.filterwarnings("ignore:Pydantic serializer warnings")
+    def test_check_access_values(self, access_input: Any) -> None:
+        """Happy path for "AccessValidation" class, with valid string or different type.
+
+        Args:
+            access_input (Any): Access input value to be validated.
+        """
+        obj = AccessAPI.model_construct(api_key=access_input)
+        config = AccessValidation.check_access_values(obj)
+
+        assert config is not None
+        assert config.api_key == access_input
+
+    def test_check_access_handles_none(self) -> None:
+        """Happy path for "AccessValidation" class, if access is None."""
+        assert AccessValidation.check_access_values(None) is None
+
+    @pytest.mark.parametrize(
+        "invalid_value, expected_error_msg",
+        [
+            ("   ", "is empty"),
+            ("", "is empty"),
+            ("YOUR-SECRET", "still contains the placeholder"),
+            ("DO-NOT-COMMIT", "still contains the placeholder"),
+        ],
+        ids=["whitespace", "empty", "placeholder_secret", "placeholder_commit"],
+    )
+    def test_check_access_values_value_error(
+        self, invalid_value: str, expected_error_msg: str
+    ) -> None:
+        """Failure path for "AccessValidation" when ValueError is raised."""
+        obj = AccessAPI(api_key=invalid_value)
+
+        with pytest.raises(ValueError, match=expected_error_msg):
+            AccessValidation.check_access_values(obj)
+
+
+# -------------------------------------------------
+# Tests - Schema usage
+# -------------------------------------------------
 @pytest.mark.parametrize("source", list(SCHEMA_REGISTRY.keys()))
 def test_config_validates(source: str, source_configs: dict) -> None:
     """Happy path for data source schemas.

--- a/tests/energy/aemo/test_downloader.py
+++ b/tests/energy/aemo/test_downloader.py
@@ -305,7 +305,7 @@ def test_get_task_data_no_generation_data(
 
     with patch("rbc.energy.aemo.downloader.asyncio.run") as mock_run:
         mock_run.return_value = mock_df_list
-        with pytest.raises(MissingDataError, match="No generation data"):
+        with pytest.raises(MissingDataError, match="No energy data available"):
             downloader._get_task_data(task)
         mock_run.call_args[0][0].close()
 

--- a/tests/energy/cen/test_downloader.py
+++ b/tests/energy/cen/test_downloader.py
@@ -12,12 +12,10 @@ from requests import exceptions
 from rbc.energy.cen import CenDownloader
 from rbc.energy.cen.downloader import EXPECTED_COLS
 from rbc.energy.utils import (
-    MAX_RATE_LIMIT_RETRIES,
     MAX_RETRIES,
     DataStructureError,
     DownloadTask,
     MissingDataError,
-    RateLimitError,
 )
 
 
@@ -332,6 +330,7 @@ def test_download_task_data_retry_exhaustion(
     """Failure path for "_get_task_data" method when the TOTAL network error limit is reached.
 
     Not just of the CenDownloader, but in "_download_task_data" of EnergyDownloader as well!
+    This tests its "4. everything else (500s/timeout/connection) -> classic retry" path.
 
     Args:
         downloader (CenDownloader): Instance of CenDownloader class.
@@ -341,12 +340,16 @@ def test_download_task_data_retry_exhaustion(
         patch("rbc.energy.cen.downloader.requests.get") as mock_get,
         patch("rbc.energy.cen.downloader.time.sleep") as mock_sleep,
     ):
-        mock_get.side_effect = [exceptions.HTTPError("Connection dropped")] * 20
+        mock_get.side_effect = [exceptions.HTTPError("Connection dropped")] * (
+            (1 + MAX_RETRIES) * (1 + MAX_RETRIES)
+        )
 
         status = downloader._download_task_data(task)
 
-        assert mock_get.call_count == 12  # child: 1+3 tries, parent: 3 tries => 12
-        assert mock_sleep.call_count == 11  # child: 3x per try = 9, parent: 2x => 11
+        # task (run through child) -> C: 4 attempts, P: (1st + 3 reruns) => 4 * 4 = 16
+        assert mock_get.call_count == 16
+        # sleep (in child & parent) -> C: 3 retries, P: (1st + 3 reruns) + 3 direct call => 15
+        assert mock_sleep.call_count == 15
         assert status == 0  # parent will have to give up and define as unfulfilled (0)
 
 
@@ -364,13 +367,13 @@ def test_get_task_data_rate_limit_fail(
         patch("rbc.energy.cen.downloader.time.sleep") as mock_sleep,
     ):
         resp_429 = MagicMock(status_code=429)
-        mock_get.side_effect = [resp_429] * (MAX_RATE_LIMIT_RETRIES + 1)
+        mock_get.side_effect = [resp_429] * (MAX_RETRIES + 1)
 
-        with pytest.raises(RateLimitError, match="rate limit has been exceeded"):
+        with pytest.raises(exceptions.HTTPError, match="CEN API rate limit"):
             downloader._get_task_data(task)
 
-        assert mock_get.call_count == MAX_RATE_LIMIT_RETRIES + 1
-        assert mock_sleep.call_count == MAX_RATE_LIMIT_RETRIES
+        assert mock_get.call_count == MAX_RETRIES + 1
+        assert mock_sleep.call_count == MAX_RETRIES
 
 
 def test_get_task_data_server_overload(

--- a/tests/energy/eia/test_downloader.py
+++ b/tests/energy/eia/test_downloader.py
@@ -11,11 +11,10 @@ from requests import exceptions
 
 from rbc.energy.eia import EiaDownloader
 from rbc.energy.utils import (
-    MAX_RATE_LIMIT_RETRIES,
+    MAX_RETRIES,
     DataStructureError,
     DownloadTask,
     MissingDataError,
-    RateLimitError,
 )
 
 
@@ -272,15 +271,13 @@ def test_get_task_data_rate_limit_fail(
         patch("rbc.energy.eia.downloader.requests.get") as mock_get,
         patch("rbc.energy.eia.downloader.time.sleep") as mock_sleep,
     ):
-        mock_get.side_effect = [MagicMock(status_code=429)] * (
-            MAX_RATE_LIMIT_RETRIES + 1
-        )
+        mock_get.side_effect = [MagicMock(status_code=429)] * (MAX_RETRIES + 1)
 
-        with pytest.raises(RateLimitError, match="limit has been exceeded"):
+        with pytest.raises(exceptions.HTTPError, match="EIA API rate limit"):
             downloader._get_task_data(task)
 
-        assert mock_get.call_count == MAX_RATE_LIMIT_RETRIES + 1
-        assert mock_sleep.call_count == MAX_RATE_LIMIT_RETRIES
+        assert mock_get.call_count == MAX_RETRIES + 1
+        assert mock_sleep.call_count == MAX_RETRIES
 
 
 @pytest.mark.parametrize("return_val", [{}, {"response": {}}])

--- a/tests/energy/eia/test_downloader.py
+++ b/tests/energy/eia/test_downloader.py
@@ -3,6 +3,7 @@
 
 import pickle
 from pathlib import Path
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pandas as pd
@@ -69,31 +70,35 @@ def task(init_args: dict) -> DownloadTask:
 
 
 def get_mock_eia_json(
-    date: str | None = None, data: list | None = None, total: int | None = None
+    date: str | None = None, data: list | int | None = None, total: int | None = None
 ) -> dict:
     """Helper to generate an argument-dependant EIA response body.
 
     Args:
-        date (str): The task date (YYYY-MM-DD)
-        data (list): Data list of EIA response body.
+        date (str, optional): The task date (YYYY-MM-DD). Defaults to None.
+        data (list | int, optional): List of data elements of EIA response body or int
+            number of elements in list of EIA response body. Defaults to None.
         total (int): Total number of data that should exist.
 
     Returns:
         dict: Dictionary with EIA response body.
     """
+    data_default = [
+        {
+            "period": f"{date}T00",
+            "respondent": "A",
+            "respondent-name": "Company A",
+            "fueltype": "NG",
+            "type-name": "Natural Gas",
+            "value": "10",
+            "value-units": "megawatthours",
+        }
+    ]
     if date is not None:
         if data is None:
-            data = [
-                {
-                    "period": f"{date}T00",
-                    "respondent": "A",
-                    "respondent-name": "Company A",
-                    "fueltype": "NG",
-                    "type-name": "Natural Gas",
-                    "value": "10",
-                    "value-units": "megawatthours",
-                }
-            ]
+            data = data_default
+        elif isinstance(data, int):
+            data = data_default * data
     else:
         data = []
 
@@ -216,6 +221,45 @@ def test_get_task_data(downloader: EiaDownloader, task: DownloadTask) -> None:
     assert df.iloc[0]["period"] == f"{task.date}T00"
     assert df.iloc[0]["value"] == "10"
     assert mock_get.call_count == 1
+
+
+def test_get_task_data_pagination(
+    downloader: EiaDownloader, task: DownloadTask
+) -> None:
+    """Happy path for "_get_task_data" method with multiple pages to parse.
+
+    Args:
+        downloader (EiaDownloader): Instance of EiaDownloader class.
+        task (DownloadTask): The metadata of a downloading task, here: date (YYYY-MM-DD)
+    """
+    # mock HTTP responses of two pages - p1: 5000 entries, p2: 1000 entries
+    mock_p1 = MagicMock(status_code=200)
+    mock_p1.json.return_value = get_mock_eia_json(task.date, data=5000, total=6000)
+    mock_p2 = MagicMock(status_code=200)
+    mock_p2.json.return_value = get_mock_eia_json(task.date, data=1000, total=6000)
+    mock_responses = [mock_p1, mock_p2]
+
+    # get parameters "params" passed to each requests call to later check "offset" increase
+    snapshot_params = []
+
+    def mock_get_side_effect(*args, **kwargs) -> Any:
+        """Side-effect function that get snapshots of the 'params' dict."""
+        snapshot_params.append(kwargs["params"].copy())
+        return mock_responses[len(snapshot_params) - 1]
+
+    with (
+        patch("rbc.energy.eia.downloader.requests.get") as mock_get,
+        patch("rbc.energy.eia.downloader.time.sleep") as mock_sleep,  # bypass delay
+    ):
+        mock_get.side_effect = mock_get_side_effect
+        df = downloader._get_task_data(task)
+
+    assert len(df) == 6000
+    assert mock_get.call_count == 2
+    assert mock_sleep.call_count == 1
+    mock_sleep.assert_called_with(0.1)
+    assert snapshot_params[0]["offset"] == 0  # check that "offset increases
+    assert snapshot_params[1]["offset"] == 5000
 
 
 def test_get_task_data_request_failed(

--- a/tests/energy/epias/test_downloader.py
+++ b/tests/energy/epias/test_downloader.py
@@ -7,6 +7,7 @@ from unittest.mock import patch
 
 import pandas as pd
 import pytest
+from requests.exceptions import HTTPError
 
 from rbc.energy.epias import EpiasDownloader
 from rbc.energy.epias.downloader import EXPECTED_COLS
@@ -265,3 +266,65 @@ def test_get_task_data_structure_changed(
 
     with pytest.raises(DataStructureError, match="Missing columns"):
         downloader._get_task_data(task)
+
+
+# --------------------------------------------
+# Tests - Helper methods
+# --------------------------------------------
+def test_epias_call(downloader: EpiasDownloader) -> None:
+    """Happy path for "_epias_call" wrapper method; error-free call results are returned.
+
+    Args:
+        downloader (EpiasDownloader): Instance of EpiasDownloader class.
+    """
+    expected_output = pd.DataFrame({"dummy_key": ["dummy_value"]})
+
+    with patch.object(downloader, "eptr") as mock_eptr:
+        mock_eptr.call.return_value = expected_output
+
+        output = downloader._epias_call("some-endpoint", dummy_param="dummy_def")
+
+    assert isinstance(output, pd.DataFrame)
+    mock_eptr.call.assert_called_once_with("some-endpoint", dummy_param="dummy_def")
+
+
+@pytest.mark.parametrize(
+    "msg, code",
+    [
+        ('failed with status code: 429\n[d0d17],\n[401],\n"status" : "500', 429),
+        ("[d0d17],\n[429],\n[Because", 429),
+        ('{\n"status" : "401 UNAUTHORIZED",\n"correlationId" : "7b46b"}', 401),
+    ],
+)
+def test_epias_call_api_error(downloader: EpiasDownloader, msg: str, code: int) -> None:
+    """Happy path for "_epias_call" wrapper method, extracting info from interpretable error.
+
+    Args:
+        downloader (EpiasDownloader): Instance of EpiasDownloader class.
+        msg (str): Error message.
+        code (int): Error code.
+    """
+    with pytest.raises(HTTPError, match=f"EPIAS API error {code}"):
+        with patch.object(downloader, "eptr") as mock_eptr:
+            mock_eptr.call.side_effect = Exception(msg)
+
+            downloader._epias_call("some-endpoint")
+
+
+def test_epias_call_unrecognised_error(downloader: EpiasDownloader) -> None:
+    """Failure path for "_epias_call" wrapper method when an unrecognisable error occurs.
+
+    Ensures these are reraised as is and not motified as the interpretable errors are.
+
+    Args:
+        downloader (EpiasDownloader): Instance of EpiasDownloader class.
+    """
+    error_msg = "Unknown error without a status code"
+
+    with pytest.raises(Exception, match=error_msg) as e_info:
+        with patch.object(downloader, "eptr") as mock_eptr:
+            mock_eptr.call.side_effect = Exception(error_msg)
+
+            downloader._epias_call("some-endpoint")
+
+        assert not isinstance(e_info.value, HTTPError)  # not converted to HTTP!

--- a/tests/energy/rei/test_downloader.py
+++ b/tests/energy/rei/test_downloader.py
@@ -286,7 +286,7 @@ def test_get_task_data_before_min_date(
         task_date (str): Date string for the task.
     """
     task = DownloadTask(date=task_date)
-    with pytest.raises(MissingDataError, match="No energy data available"):
+    with pytest.raises(MissingDataError, match="No energy data available \\(it's"):
         downloader._get_task_data(task)
 
 
@@ -304,7 +304,7 @@ def test_get_task_data_missing_month_data(downloader: ReiDownloader) -> None:
     with patch.object(
         downloader, "_load_yearly_json", return_value=(mock_dict, mock_ts)
     ):
-        with pytest.raises(MissingDataError, match="No energy data found for month"):
+        with pytest.raises(MissingDataError, match="No energy data available \\(after"):
             downloader._get_task_data(task_feb)
 
 

--- a/tests/energy/test_utils.py
+++ b/tests/energy/test_utils.py
@@ -13,6 +13,7 @@ import pytest
 from requests import exceptions
 
 from rbc.energy.utils import (
+    MAX_RATE_LIMIT_RETRIES,
     MAX_RETRIES,
     DataStructureError,
     DownloadTask,
@@ -168,11 +169,13 @@ class TestEnergyDownloaderThreading:
     @pytest.mark.parametrize(
         "code, expected_status, expected_sleep_calls",
         [
-            (None, 0, MAX_RETRIES - 1),
-            (300, 0, MAX_RETRIES - 1),
+            (None, 0, MAX_RETRIES),
+            (500, 0, MAX_RETRIES),
             (404, 1, 0),
+            (401, 0, MAX_RATE_LIMIT_RETRIES),
             (400, 1, 0),
         ],
+        ids=["no_code", "server_error", "missing_data", "rate_limit", "client_error"],
     )
     def test_threading_error_catching(
         self,
@@ -207,9 +210,7 @@ class TestEnergyDownloaderThreading:
                 with pytest.raises(SystemExit):
                     downloader._threading_wrapper(task)
 
-        mock_exit.assert_called_once_with(
-            1
-        )  # assert outside "with"-block for correct exec
+        mock_exit.assert_called_once_with(1)  # assert outside "with" for correct exec
 
         # 2. Test missing data (MissingDataError -> status 0 = current year, status 1 = prior)
         downloader.checkpoint = {}
@@ -220,8 +221,8 @@ class TestEnergyDownloaderThreading:
                 assert downloader.checkpoint[task.identifier] == expected_error_status
                 mock_save.assert_called_once()
 
-        # 3. Test HTTPError
-        # no code: (->0), retry: code=300 (->0), missing: code=404 (->1), client: code=400 (->1)
+        # 3. Test RETRY_ERRORS (HTTPError)
+        # no code OR server=500: ->0, missing=404: ->1, ratelimit=429: ->0, client=400 ->1
         downloader.checkpoint = {}
         with patch.object(
             downloader, "_get_task_data", side_effect=exceptions.HTTPError("")


### PR DESCRIPTION
# Fix rate limit error handling in energy downloaders

As documented in #58, running the API-based energy crawlers highlighted an issue with how the child classes (esp. EPIAS, CEN, AEMO) and the parent EnergyDownloader handle API rate limits errors (RLs) when they are raised in the form of expected 429 ("Too Many Requests"), but also the unconventional 401 ("Unauthorized") errors.

This PR fixes the issue by adapting:
- the `EnergyDownloader` parent class:
   - amended the `_download_task_data` method with logic to handle `429` **and** `401` errors with a patient retry logic. This includes 6 retries with increasing wait times and - if that doesn't suffice - the task being saved as `0` to be retried during the next run.
- the `EpiasDownloader` child class:
   - defined `WORKERS=2` to prevent overloading the restrictive API
   - included a new wrapper method `_epias_call` to reformat the weird `eptr2` error outputs into actionable `HTTPError`s
- the `CenDownloader` and `EiaDownlaoder` child classes:
   - in light of the new parent's patient retry: reduced the local retry limits in `_get_task_data`. 
   The logic isn't abolished entirely in the child classes, as it allows for retries of specific pages/segments of a task's data, rather than the retrying the whole thing again (as the parent enforces).
   - replaced using the fatal `RateLimitError` with raising a `HTTPError`, therefore ensuring the parent class' graceful retry logic is leveraged.

The associated test suites are enhanced to account for these changes.
Logging messages are also consolidated and reformatted for more concise print-outs.

## Related issues

Fixes #58 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

<!-- If you are unable to check all the boxes, your pull request may not be eligible for review. -->

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules